### PR TITLE
Mild fixes to conversion code

### DIFF
--- a/routers/utils/album_conversion.py
+++ b/routers/utils/album_conversion.py
@@ -5,7 +5,6 @@ This module provides shared functionality for converting album data from the Gum
 to the Immich API format, including handling of datetime fields and album metadata.
 """
 
-from datetime import datetime
 from uuid import UUID
 
 from gumnut.types.album_response import AlbumResponse
@@ -34,38 +33,10 @@ def convert_gumnut_album_to_immich(
         AlbumResponseDto object with processed data
     """
     album_id = gumnut_album.id
-    album_name = gumnut_album.name or "Untitled Album"
+    album_name = gumnut_album.name
     album_description = gumnut_album.description
     created_at = gumnut_album.created_at
     updated_at = gumnut_album.updated_at
-
-    # Ensure created_at and updated_at are datetime objects
-    # AlbumResponse should already have datetime objects, but handle edge cases
-    if created_at is None:
-        created_at = datetime.now()
-    elif not isinstance(created_at, datetime):
-        # If it's not already a datetime (e.g., it's a string), parse it
-        try:
-            if isinstance(created_at, str):
-                iso_string: str = created_at.replace("Z", "+00:00")
-                created_at = datetime.fromisoformat(iso_string)
-            else:
-                created_at = datetime.now()
-        except (ValueError, AttributeError):
-            created_at = datetime.now()
-
-    if updated_at is None:
-        updated_at = datetime.now()
-    elif not isinstance(updated_at, datetime):
-        # If it's not already a datetime (e.g., it's a string), parse it
-        try:
-            if isinstance(updated_at, str):
-                iso_string: str = updated_at.replace("Z", "+00:00")
-                updated_at = datetime.fromisoformat(iso_string)
-            else:
-                updated_at = datetime.now()
-        except (ValueError, AttributeError):
-            updated_at = datetime.now()
 
     # Determine asset count
     if asset_count is not None:

--- a/routers/utils/asset_conversion.py
+++ b/routers/utils/asset_conversion.py
@@ -72,18 +72,7 @@ def extract_exif_info(exif: Exif | None) -> ExifResponseDto:
     file_size = None
     time_zone = None
 
-    # Parse datetime fields if they're strings
-    def parse_datetime(dt_value):
-        if isinstance(dt_value, str):
-            try:
-                return datetime.fromisoformat(dt_value.replace("Z", "+00:00"))
-            except (ValueError, AttributeError):
-                return None
-        return dt_value
-
-    date_time_original = parse_datetime(date_time_original)
-    modify_date = parse_datetime(modify_date)
-
+    # Pydantic will throw an error if date_time_original does not have a timezone
     if date_time_original is not None:
         time_zone = date_time_original.tzname()
         if not time_zone:

--- a/routers/utils/gumnut_id_conversion.py
+++ b/routers/utils/gumnut_id_conversion.py
@@ -22,6 +22,9 @@ def safe_uuid_from_gumnut_id(gumnut_id: str, prefix: str) -> UUID:
 
     Returns:
         UUID object
+
+    Throws:
+        ValueError if the gumnut_id is not in the expected format or cannot be decoded
     """
     expected_prefix = f"{prefix}_"
     if gumnut_id.startswith(expected_prefix):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,12 @@ from datetime import datetime, timezone
 from uuid import uuid4
 from typing import List, Any
 
+from routers.utils.gumnut_id_conversion import (
+    uuid_to_gumnut_album_id,
+    uuid_to_gumnut_asset_id,
+    uuid_to_gumnut_person_id,
+)
+
 # Configure anyio to use only asyncio backend
 pytest_plugins = ("anyio",)
 
@@ -35,7 +41,7 @@ def sample_uuid():
 def sample_gumnut_album():
     """Create a sample Gumnut album object with proper date fields."""
     album = Mock()
-    album.id = "gumnut-album-123"
+    album.id = uuid_to_gumnut_album_id(uuid4())
     album.name = "Test Album"
     album.description = "Test Description"
     album.created_at = datetime.now(timezone.utc)
@@ -48,7 +54,7 @@ def sample_gumnut_album():
 def sample_gumnut_asset():
     """Create a sample Gumnut asset object with proper date fields."""
     asset = Mock()
-    asset.id = "gumnut-asset-456"
+    asset.id = uuid_to_gumnut_asset_id(uuid4())
     asset.device_asset_id = "device-123"
     asset.device_id = "device-456"
     asset.file_created_at = datetime.now(timezone.utc)
@@ -72,7 +78,7 @@ def multiple_gumnut_albums():
     albums = []
     for i in range(3):
         album = Mock()
-        album.id = f"gumnut-album-{i}"
+        album.id = uuid_to_gumnut_album_id(uuid4())
         album.name = f"Test Album {i}"
         album.description = f"Test Description {i}"
         album.created_at = datetime.now(timezone.utc)
@@ -88,7 +94,7 @@ def multiple_gumnut_assets():
     assets = []
     for i in range(3):
         asset = Mock()
-        asset.id = f"gumnut-asset-{i}"
+        asset.id = uuid_to_gumnut_asset_id(uuid4())
         asset.device_asset_id = f"device-{i}"
         asset.device_id = f"device-{i}"
         asset.file_created_at = datetime.now(timezone.utc)
@@ -128,7 +134,7 @@ def mock_sync_cursor_page():
 def sample_gumnut_person():
     """Create a sample Gumnut person object with proper fields."""
     person = Mock()
-    person.id = "gumnut-person-123"
+    person.id = uuid_to_gumnut_person_id(uuid4())
     person.name = "Test Person"
     person.birth_date = datetime(1990, 1, 1).date()
     person.is_favorite = False
@@ -146,7 +152,7 @@ def multiple_gumnut_people():
     people = []
     for i in range(3):
         person = Mock()
-        person.id = f"gumnut-person-{i}"
+        person.id = uuid_to_gumnut_person_id(uuid4())
         person.name = f"Test Person {i}"
         person.birth_date = datetime(1990 + i, 1, 1).date()
         person.is_favorite = i % 2 == 0  # Alternate favorites

--- a/tests/test_albums.py
+++ b/tests/test_albums.py
@@ -234,32 +234,6 @@ class TestCreateAlbum:
             )
 
     @pytest.mark.anyio
-    async def test_create_album_no_name(self, sample_gumnut_album):
-        """Test album creation with empty name."""
-        # Setup - mock only the Gumnut client, let conversion functions run naturally
-        with patch("routers.api.albums.get_gumnut_client") as mock_get_client:
-            mock_client = Mock()
-            mock_get_client.return_value = mock_client
-            # Update the sample to have empty name we want to test
-            sample_gumnut_album.name = ""
-            sample_gumnut_album.description = "Description"
-            mock_client.albums.create.return_value = sample_gumnut_album
-
-            # Use empty string instead of None since albumName is required
-            request = CreateAlbumDto(albumName="", description="Description")
-
-            # Execute
-            result = await create_album(request)
-
-            # Assert
-            assert hasattr(result, "albumName")
-            # The conversion function converts empty names to "Untitled Album"
-            assert result.albumName == "Untitled Album"
-            mock_client.albums.create.assert_called_once_with(
-                name="", description="Description"
-            )
-
-    @pytest.mark.anyio
     async def test_create_album_gumnut_error(self):
         """Test handling of Gumnut API errors during creation."""
         # Setup - mock directly in the test

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -377,9 +377,6 @@ class TestUpdateAsset:
             # Should return a converted AssetResponseDto from get_asset_info
             assert hasattr(result, "id")
             assert hasattr(result, "deviceAssetId")
-            assert (
-                result.deviceAssetId == "gumnut-asset-456"
-            )  # From sample_gumnut_asset.id
             mock_client.assets.retrieve.assert_called_once()
 
 
@@ -402,9 +399,6 @@ class TestGetAssetInfo:
             # Result should be a real AssetResponseDto from conversion
             assert hasattr(result, "id")
             assert hasattr(result, "deviceAssetId")
-            assert (
-                result.deviceAssetId == "gumnut-asset-456"
-            )  # From sample_gumnut_asset.id
             mock_client.assets.retrieve.assert_called_once()
 
     @pytest.mark.anyio

--- a/tests/test_gumnut_id_conversion.py
+++ b/tests/test_gumnut_id_conversion.py
@@ -1,0 +1,253 @@
+"""
+Tests for gumnut_id_conversion utilities.
+"""
+
+import pytest
+from uuid import UUID, uuid4
+import shortuuid
+
+from routers.utils.gumnut_id_conversion import (
+    safe_uuid_from_gumnut_id,
+    uuid_to_gumnut_id,
+    safe_uuid_from_album_id,
+    uuid_to_gumnut_album_id,
+    safe_uuid_from_asset_id,
+    uuid_to_gumnut_asset_id,
+    safe_uuid_from_person_id,
+    uuid_to_gumnut_person_id,
+)
+
+
+class TestSafeUuidFromGumnutId:
+    """Test the safe_uuid_from_gumnut_id function."""
+
+    def test_valid_album_id_conversion(self):
+        """Test converting valid album ID to UUID."""
+        # Create a test UUID and encode it
+        test_uuid = uuid4()
+        short_uuid = shortuuid.encode(test_uuid)
+        gumnut_id = f"album_{short_uuid}"
+
+        result = safe_uuid_from_gumnut_id(gumnut_id, "album")
+
+        assert result == test_uuid
+        assert isinstance(result, UUID)
+
+    def test_valid_asset_id_conversion(self):
+        """Test converting valid asset ID to UUID."""
+        test_uuid = uuid4()
+        short_uuid = shortuuid.encode(test_uuid)
+        gumnut_id = f"asset_{short_uuid}"
+
+        result = safe_uuid_from_gumnut_id(gumnut_id, "asset")
+
+        assert result == test_uuid
+        assert isinstance(result, UUID)
+
+    def test_valid_person_id_conversion(self):
+        """Test converting valid person ID to UUID."""
+        test_uuid = uuid4()
+        short_uuid = shortuuid.encode(test_uuid)
+        gumnut_id = f"person_{short_uuid}"
+
+        result = safe_uuid_from_gumnut_id(gumnut_id, "person")
+
+        assert result == test_uuid
+        assert isinstance(result, UUID)
+
+    def test_invalid_prefix_fallback(self):
+        """Test handling of invalid prefix - should fall back to UUID parsing."""
+        test_uuid = uuid4()
+        gumnut_id = str(test_uuid)  # No prefix, just raw UUID
+
+        # Since gumnut_id does not have a prefix, a ValueError should be raised
+        with pytest.raises(ValueError):
+            safe_uuid_from_gumnut_id(gumnut_id, "album")
+
+    def test_wrong_prefix_fallback(self):
+        """Test handling of wrong prefix - should fall back to UUID parsing."""
+        test_uuid = uuid4()
+        short_uuid = shortuuid.encode(test_uuid)
+        gumnut_id = f"wrong_{short_uuid}"
+
+        # Since gumnut_id has a different prefix than what we call safe_uuid_from_gumnut_id() with, a ValueError should be raised
+        with pytest.raises(ValueError):
+            safe_uuid_from_gumnut_id(gumnut_id, "album")
+
+    def test_empty_string_handling(self):
+        """Test handling of empty string."""
+        with pytest.raises(ValueError):
+            safe_uuid_from_gumnut_id("", "album")
+
+    def test_known_uuid_roundtrip(self):
+        """Test with a known UUID to ensure consistent behavior."""
+        known_uuid = UUID("550e8400-e29b-41d4-a716-446655440000")
+        short_uuid = shortuuid.encode(known_uuid)
+        gumnut_id = f"album_{short_uuid}"
+
+        result = safe_uuid_from_gumnut_id(gumnut_id, "album")
+
+        assert result == known_uuid
+
+
+class TestUuidToGumnutId:
+    """Test the uuid_to_gumnut_id function."""
+
+    def test_album_id_generation(self):
+        """Test generating album ID from UUID."""
+        test_uuid = uuid4()
+
+        result = uuid_to_gumnut_id(test_uuid, "album")
+
+        assert result.startswith("album_")
+        assert isinstance(result, str)
+
+        # Should be reversible
+        decoded = safe_uuid_from_gumnut_id(result, "album")
+        assert decoded == test_uuid
+
+    def test_asset_id_generation(self):
+        """Test generating asset ID from UUID."""
+        test_uuid = uuid4()
+
+        result = uuid_to_gumnut_id(test_uuid, "asset")
+
+        assert result.startswith("asset_")
+        assert isinstance(result, str)
+
+        # Should be reversible
+        decoded = safe_uuid_from_gumnut_id(result, "asset")
+        assert decoded == test_uuid
+
+    def test_person_id_generation(self):
+        """Test generating person ID from UUID."""
+        test_uuid = uuid4()
+
+        result = uuid_to_gumnut_id(test_uuid, "person")
+
+        assert result.startswith("person_")
+        assert isinstance(result, str)
+
+        # Should be reversible
+        decoded = safe_uuid_from_gumnut_id(result, "person")
+        assert decoded == test_uuid
+
+    def test_known_uuid_conversion(self):
+        """Test with a known UUID for consistent results."""
+        known_uuid = UUID("550e8400-e29b-41d4-a716-446655440000")
+
+        result = uuid_to_gumnut_id(known_uuid, "test")
+
+        assert result.startswith("test_")
+        # The shortuuid encoding should be deterministic for the same UUID
+        expected_short = shortuuid.encode(known_uuid)
+        assert result == f"test_{expected_short}"
+
+
+class TestConvenienceFunctions:
+    """Test the convenience functions for specific types."""
+
+    def test_album_convenience_functions(self):
+        """Test album-specific convenience functions."""
+        test_uuid = uuid4()
+
+        # UUID to album ID
+        album_id = uuid_to_gumnut_album_id(test_uuid)
+        assert album_id.startswith("album_")
+
+        # Album ID back to UUID
+        recovered_uuid = safe_uuid_from_album_id(album_id)
+        assert recovered_uuid == test_uuid
+
+    def test_asset_convenience_functions(self):
+        """Test asset-specific convenience functions."""
+        test_uuid = uuid4()
+
+        # UUID to asset ID
+        asset_id = uuid_to_gumnut_asset_id(test_uuid)
+        assert asset_id.startswith("asset_")
+
+        # Asset ID back to UUID
+        recovered_uuid = safe_uuid_from_asset_id(asset_id)
+        assert recovered_uuid == test_uuid
+
+    def test_person_convenience_functions(self):
+        """Test person-specific convenience functions."""
+        test_uuid = uuid4()
+
+        # UUID to person ID
+        person_id = uuid_to_gumnut_person_id(test_uuid)
+        assert person_id.startswith("person_")
+
+        # Person ID back to UUID
+        recovered_uuid = safe_uuid_from_person_id(person_id)
+        assert recovered_uuid == test_uuid
+
+    def test_convenience_functions_equivalence(self):
+        """Test that convenience functions are equivalent to generic functions."""
+        test_uuid = uuid4()
+
+        # Album functions
+        assert uuid_to_gumnut_album_id(test_uuid) == uuid_to_gumnut_id(
+            test_uuid, "album"
+        )
+
+        album_id = f"album_{shortuuid.encode(test_uuid)}"
+        assert safe_uuid_from_album_id(album_id) == safe_uuid_from_gumnut_id(
+            album_id, "album"
+        )
+
+        # Asset functions
+        assert uuid_to_gumnut_asset_id(test_uuid) == uuid_to_gumnut_id(
+            test_uuid, "asset"
+        )
+
+        asset_id = f"asset_{shortuuid.encode(test_uuid)}"
+        assert safe_uuid_from_asset_id(asset_id) == safe_uuid_from_gumnut_id(
+            asset_id, "asset"
+        )
+
+        # Person functions
+        assert uuid_to_gumnut_person_id(test_uuid) == uuid_to_gumnut_id(
+            test_uuid, "person"
+        )
+
+        person_id = f"person_{shortuuid.encode(test_uuid)}"
+        assert safe_uuid_from_person_id(person_id) == safe_uuid_from_gumnut_id(
+            person_id, "person"
+        )
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions."""
+
+    def test_nil_uuid_handling(self):
+        """Test handling of nil UUID (all zeros)."""
+        nil_uuid = UUID("00000000-0000-0000-0000-000000000000")
+
+        # Should work with nil UUID
+        gumnut_id = uuid_to_gumnut_id(nil_uuid, "test")
+        recovered = safe_uuid_from_gumnut_id(gumnut_id, "test")
+
+        assert recovered == nil_uuid
+
+    def test_max_uuid_handling(self):
+        """Test handling of max UUID (all f's)."""
+        max_uuid = UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")
+
+        # Should work with max UUID
+        gumnut_id = uuid_to_gumnut_id(max_uuid, "test")
+        recovered = safe_uuid_from_gumnut_id(gumnut_id, "test")
+
+        assert recovered == max_uuid
+
+    def test_prefix_variations(self):
+        """Test different prefix variations."""
+        test_uuid = uuid4()
+
+        prefixes = ["", "a", "long_prefix_name", "123", "prefix-with-dash"]
+
+        for prefix in prefixes:
+            gumnut_id = uuid_to_gumnut_id(test_uuid, prefix)
+            recovered = safe_uuid_from_gumnut_id(gumnut_id, prefix)
+            assert recovered == test_uuid, f"Failed with prefix: {prefix}"

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -14,6 +14,7 @@ from routers.immich_models import (
     AssetOrder,
     AssetVisibility,
 )
+from routers.utils.gumnut_id_conversion import uuid_to_gumnut_asset_id
 
 
 def call_get_time_buckets(**kwargs):
@@ -292,7 +293,7 @@ class TestGetTimeBucket:
             # Setup test assets - some in January 2024, some in February
             assets = multiple_gumnut_assets
             # Asset 0: January 2024 (should be included)
-            assets[0].id = "asset-jan-1"
+            assets[0].id = uuid_to_gumnut_asset_id(uuid4())
             assets[0].local_datetime = datetime(
                 2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc
             )
@@ -302,7 +303,7 @@ class TestGetTimeBucket:
             assets[0].local_datetime_offset = -5
 
             # Asset 1: February 2024 (should NOT be included)
-            assets[1].id = "asset-feb-1"
+            assets[1].id = uuid_to_gumnut_asset_id(uuid4())
             assets[1].local_datetime = datetime(
                 2024, 2, 20, 14, 0, 0, tzinfo=timezone.utc
             )
@@ -312,7 +313,7 @@ class TestGetTimeBucket:
             assets[1].local_datetime_offset = 0
 
             # Asset 2: January 2024 (should be included)
-            assets[2].id = "asset-jan-2"
+            assets[2].id = uuid_to_gumnut_asset_id(uuid4())
             assets[2].local_datetime = datetime(
                 2024, 1, 25, 16, 0, 0, tzinfo=timezone.utc
             )
@@ -370,7 +371,7 @@ class TestGetTimeBucket:
 
             # Setup test assets
             assets = multiple_gumnut_assets
-            assets[0].id = "asset-1"
+            assets[0].id = uuid_to_gumnut_asset_id(uuid4())
             assets[0].local_datetime = datetime(
                 2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc
             )
@@ -408,7 +409,7 @@ class TestGetTimeBucket:
 
             # Setup test assets
             assets = multiple_gumnut_assets
-            assets[0].id = "asset-1"
+            assets[0].id = uuid_to_gumnut_asset_id(uuid4())
             assets[0].local_datetime = datetime(
                 2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc
             )
@@ -443,7 +444,7 @@ class TestGetTimeBucket:
 
             # Create mock asset with string datetime
             mock_asset = Mock()
-            mock_asset.id = "asset-1"
+            mock_asset.id = uuid_to_gumnut_asset_id(uuid4())
             mock_asset.local_datetime = "2024-01-15T10:00:00Z"
             mock_asset.created_at = "2024-01-15T10:00:00Z"
             mock_asset.mime_type = "image/jpeg"
@@ -505,7 +506,7 @@ class TestGetTimeBucket:
 
             # Create dict-format asset
             dict_asset = {
-                "id": "dict-asset-1",
+                "id": uuid_to_gumnut_asset_id(uuid4()),
                 "local_datetime": "2024-01-15T10:00:00Z",
                 "created_at": "2024-01-15T10:00:00Z",
                 "mime_type": "image/jpeg",
@@ -538,7 +539,7 @@ class TestGetTimeBucket:
 
             # Create mock asset with minimal attributes
             mock_asset = Mock()
-            mock_asset.id = "minimal-asset"
+            mock_asset.id = uuid_to_gumnut_asset_id(uuid4())
             mock_asset.local_datetime = datetime(
                 2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc
             )


### PR DESCRIPTION
Remove unneeded code that handles datetimes in strings - the Gumnut objects will never use strings for datetimes.

Remove code from safe_uuid_from_gumnut_id() that would accommodate bad prefixes or other errors - now we just throw an exception as this is not a valid case.

Fix all tests that used invalid gumnut ids.

Removed album testcase checking for an album with no name - that is not a valid condition.

Added test cases for gumnut <> uuid conversion.