### PR TITLE
GUM-140: now supporting the assetId parameter in GET /albums

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,12 +180,24 @@ This is useful for:
 
 ### Immich API Integration
 
+Defining endpoint parameters:
+
+- Use `Annotated` to specify attributes, such as `Query()`, `Path()`, `Body()` functions, or numeric or string validations, but do not use `Default` - the default value should be specified as part of the Python declaration.
+- If a parameter is not required, use `| SkipJsonSchema[None]` after defining the type to allow Pydantic to accept the `None` type, but prevent `None` from being exposed in the OpenAPI schema. 
+- If the exposed parameter name needs to be camelCase, use `alias="camelCase"` within the function and then use an appropriate snake_case name for the parameter in the function signature.
+
+Example:
+```python
+asset_id: Annotated[UUID | SkipJsonSchema[None], Query(alias="assetId")] = None,
+```
+
 When implementing new endpoints:
 
 1. **Generate models**: Use `generate_immich_models.py` to create up-to-date Pydantic models
 2. **Import models**: Use generated models from `routers.immich_models` for type safety
-3. **Validate compatibility**: Run `validate_api_compatibility.py` to ensure correct implementation
-4. **Test endpoints**: Verify responses match Immich API expectations
+3. **Defining parameters**: When declaring parameters, use `Annotated` to specify attributes, such as `Query` or numeric validations, but do not use `Default` within Annotated. If a type `asset_id: Annotated[UUID | SkipJsonSchema[None], Query(alias="assetId")] = None,`
+4. **Validate compatibility**: Run `validate_api_compatibility.py` to ensure correct implementation
+5. **Test endpoints**: Verify responses match Immich API expectations
 
 ### Testing Guidelines
 

--- a/routers/api/albums.py
+++ b/routers/api/albums.py
@@ -38,7 +38,7 @@ router = APIRouter(
 
 @router.get("")
 async def get_all_albums(
-    assetId: UUID = Query(default=None, alias="assetId"),
+    asset_id: UUID = Query(default=None, alias="assetId"),
     shared: bool = Query(default=None, alias="shared"),
 ) -> List[AlbumResponseDto]:
     """
@@ -51,12 +51,12 @@ async def get_all_albums(
         # Shared albums not supported in this adapter
         return []
 
-    if assetId:
-        # Can't constrain by assetId in Gumnut, return empty list
-        return []
-
     try:
-        gumnut_albums = client.albums.list()
+        kwargs = {}
+        if asset_id:
+            kwargs["asset_id"] = uuid_to_gumnut_asset_id(asset_id)
+
+        gumnut_albums = client.albums.list(**kwargs)
 
         # Convert Gumnut albums to AlbumResponseDto format
         immich_albums = [

--- a/routers/api/albums.py
+++ b/routers/api/albums.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Annotated, List
 from uuid import UUID
 import logging
 
@@ -26,6 +26,7 @@ from routers.utils.gumnut_id_conversion import (
 )
 from routers.utils.asset_conversion import convert_gumnut_asset_to_immich
 from routers.utils.album_conversion import convert_gumnut_album_to_immich
+from pydantic.json_schema import SkipJsonSchema
 
 logger = logging.getLogger(__name__)
 
@@ -38,8 +39,8 @@ router = APIRouter(
 
 @router.get("")
 async def get_all_albums(
-    asset_id: UUID = Query(default=None, alias="assetId"),
-    shared: bool = Query(default=None, alias="shared"),
+    asset_id: Annotated[UUID | SkipJsonSchema[None], Query(alias="assetId")] = None,
+    shared: Annotated[bool | SkipJsonSchema[None], Query(alias="shared")] = None,
 ) -> List[AlbumResponseDto]:
     """
     Fetch albums from Gumnut and convert to AlbumResponseDto format.

--- a/tests/test_albums.py
+++ b/tests/test_albums.py
@@ -43,7 +43,7 @@ class TestGetAllAlbums:
             )
 
             # Execute
-            result = await get_all_albums(asset_id=None, shared=None)  # type: ignore
+            result = await get_all_albums(asset_id=None, shared=None)
 
             # Assert
             assert isinstance(result, list)
@@ -75,7 +75,7 @@ class TestGetAllAlbums:
             )
 
             # Execute
-            result = await get_all_albums(asset_id=None, shared=None)  # type: ignore
+            result = await get_all_albums(asset_id=None, shared=None)
 
             # Assert - verify asset counts are preserved from Gumnut albums
             assert len(result) == 3
@@ -100,7 +100,7 @@ class TestGetAllAlbums:
 
             # Execute with asset_id
             test_asset_uuid = uuid4()
-            result = await get_all_albums(asset_id=test_asset_uuid, shared=None)  # type: ignore
+            result = await get_all_albums(asset_id=test_asset_uuid, shared=None)
 
             # Assert
             assert isinstance(result, list)
@@ -123,7 +123,7 @@ class TestGetAllAlbums:
 
             # Execute with asset_id
             test_asset_uuid = uuid4()
-            result = await get_all_albums(asset_id=test_asset_uuid, shared=None)  # type: ignore
+            result = await get_all_albums(asset_id=test_asset_uuid, shared=None)
 
             # Assert
             assert isinstance(result, list)
@@ -153,7 +153,7 @@ class TestGetAllAlbums:
 
             # Execute & Assert
             with pytest.raises(HTTPException) as exc_info:
-                await get_all_albums(asset_id=None, shared=None)  # type: ignore
+                await get_all_albums(asset_id=None, shared=None)
 
             assert exc_info.value.status_code == 500
             assert "Failed to fetch albums" in str(exc_info.value.detail)

--- a/uv.lock
+++ b/uv.lock
@@ -159,7 +159,7 @@ wheels = [
 
 [[package]]
 name = "gumnut-sdk"
-version = "0.20.0"
+version = "0.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -169,9 +169,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/ef/c1ffef7627d625861c845f78769ab1e40da84a967f83073895087e6c1b89/gumnut_sdk-0.20.0.tar.gz", hash = "sha256:d5f65be4dd5bff071d9fbabe422c239c8dc2283066ea54747fe1907c6b89f1b6", size = 123806, upload-time = "2025-10-14T00:14:29.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/f5/5ba6b4de4aa42d382a59272c17324168de9126e9bf5027e6881bdb831d2e/gumnut_sdk-0.21.0.tar.gz", hash = "sha256:b7e0e0b47eddc4a513fbae3bd344ead2915fc68384b742a66071dac4b504f1bc", size = 123861, upload-time = "2025-10-14T21:14:44.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/8a/e6e49ce4b34a3b5c2e3ffb2f8ec58a32a4ffaf22e9d0cd8ac8b2272225c7/gumnut_sdk-0.20.0-py3-none-any.whl", hash = "sha256:ef392f4ebc32298f302c4533996d624ba99cd3c62f7b75069f4a76958762031a", size = 109976, upload-time = "2025-10-14T00:14:28.359Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d9/5bd94c5641b3bf1a68619ad6d58286e428f85411ff474e4e034edb82d646/gumnut_sdk-0.21.0-py3-none-any.whl", hash = "sha256:14d2491a759e6e5dcc97c2e1e6e2293b2350a0bb158b65e9d5d93e03d2ceea07", size = 110004, upload-time = "2025-10-14T21:14:43.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
OK, final PR - I swear!

The assetId parameter in GET /albums is used by Immich on the asset detail page to display the albums that contain the asset.