### PR TITLE
GUM-158: Enabling mobile OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,13 +3,6 @@ ENVIRONMENT=development
 # Gumnut API Configuration
 GUMNUT_API_BASE_URL=http://localhost:8000
 
-# Adapter External URL Configuration
-# The public URL where this adapter is accessible
-# Used for OAuth redirects, webhooks, and other external integrations
-# Set to your custom domain in production (e.g., https://immich.yourdomain.com)
-# For local testing, you might use localhost for http or your machine's IP for https
-ADAPTER_EXTERNAL_URL=https://127.0.0.1:8001
-
 # OAuth Mobile Redirect URI Configuration
 # Custom URL scheme for mobile app deep linking during OAuth flow
 # Default is for official Immich mobile app

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,16 @@
 ENVIRONMENT=development
+
+# Gumnut API Configuration
+GUMNUT_API_BASE_URL=http://localhost:8000
+
+# Adapter External URL Configuration
+# The public URL where this adapter is accessible
+# Used for OAuth redirects, webhooks, and other external integrations
+# Set to your custom domain in production (e.g., https://immich.yourdomain.com)
+# For local testing, you might use localhost for http or your machine's IP for https
+ADAPTER_EXTERNAL_URL=https://127.0.0.1:8001
+
+# OAuth Mobile Redirect URI Configuration
+# Custom URL scheme for mobile app deep linking during OAuth flow
+# Default is for official Immich mobile app
+OAUTH_MOBILE_REDIRECT_URI=app.immich:///oauth-callback

--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,6 @@ __marimo__/
 static/*
 # But keep the directory itself
 !static/.gitkeep
+
+# PEM files should be ignored for security reasons
+*.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,4 +103,8 @@ ENV LOG_LEVEL=info
 # Run the application with optimized uvicorn settings
 # Render sets PORT environment variable automatically (typically 10000)
 # Using exec form with shell for proper signal handling and variable substitution
-CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8080} --log-level ${LOG_LEVEL} --timeout-graceful-shutdown 60 --timeout-keep-alive 75 --limit-concurrency 1000 --backlog 2048"]
+CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8080} --log-level ${LOG_LEVEL} \
+  --timeout-graceful-shutdown 60 \
+  --timeout-keep-alive ${TIMEOUT_KEEP_ALIVE:-75} \
+  --limit-concurrency ${LIMIT_CONCURRENCY:-1000} \
+  --backlog ${BACKLOG:-2048}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,4 +103,4 @@ ENV LOG_LEVEL=info
 # Run the application with optimized uvicorn settings
 # Render sets PORT environment variable automatically (typically 10000)
 # Using exec form with shell for proper signal handling and variable substitution
-CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8080} --log-level ${LOG_LEVEL} --timeout-graceful-shutdown 60"]
+CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8080} --log-level ${LOG_LEVEL} --timeout-graceful-shutdown 60 --timeout-keep-alive 75 --limit-concurrency 1000 --backlog 2048"]

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ docker run --rm -p 8080:8080 \
 **Environment Variables:**
 - `PORT`: Port to bind to (default: 8080)
 - `GUMNUT_API_BASE_URL`: URL of the Gumnut API backend
-- `ADAPTER_EXTERNAL_URL`: The public URL where this adapter is accessible
 - `OAUTH_MOBILE_REDIRECT_URI`: Custom URL scheme for mobile app deep linking during OAuth flow (default: app.immich:///oauth-callback)
 - `ENVIRONMENT`: Set to `development` or `production`
 - `LOG_LEVEL`: Log level (default: `info`, options: `debug`, `info`, `warning`, `error`)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ docker run --rm -p 8080:8080 \
 **Environment Variables:**
 - `PORT`: Port to bind to (default: 8080)
 - `GUMNUT_API_BASE_URL`: URL of the Gumnut API backend
+- `ADAPTER_EXTERNAL_URL`: The public URL where this adapter is accessible
+- `OAUTH_MOBILE_REDIRECT_URI`: Custom URL scheme for mobile app deep linking during OAuth flow (default: app.immich:///oauth-callback)
 - `ENVIRONMENT`: Set to `development` or `production`
 - `LOG_LEVEL`: Log level (default: `info`, options: `debug`, `info`, `warning`, `error`)
 
@@ -69,6 +71,29 @@ docker run --rm -p 8080:8080 \
 ```bash
 docker build --build-arg IMMICH_VERSION=v2.2.3 -t immich-adapter .
 ```
+
+### Production Mode
+
+For production deployments or when testing with mobile clients (iOS/Android), use these optimized settings:
+
+```bash
+uv run fastapi run --port 3001 \
+  --timeout-keep-alive 75 \
+  --limit-concurrency 1000 \
+  --backlog 2048
+```
+
+**Configuration Explanation:**
+
+- `--timeout-keep-alive 75`: Sets keep-alive timeout to 75 seconds (iOS-friendly, matches typical mobile client expectations)
+- `--limit-concurrency 1000`: Limits concurrent connections to prevent resource exhaustion
+- `--backlog 2048`: Sets the socket backlog queue size for pending connections (helps with bursts of rapid requests)
+
+**Why these settings matter for mobile clients:**
+
+Mobile clients (especially iOS/Flutter) often make rapid successive requests and use longer keep alive settings. The production configuration:
+- Keeps connections alive longer to enable HTTP connection reuse and prevent "Connection closed before full header was received" errors
+- Handles bursts of concurrent requests without connection queueing
 
 ## Access the application
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -15,9 +15,6 @@ class Settings(BaseSettings):
     gumnut_api_base_url: str = "http://localhost:8000"
     sentry_dsn: str | None = None
 
-    # External URL for this adapter (set to public URL in production)
-    adapter_external_url: str = "https://127.0.0.1:8001"
-
     # Mobile app OAuth redirect URL (custom URL scheme for mobile deep linking)
     oauth_mobile_redirect_uri: str = "app.immich:///oauth-callback"
 
@@ -28,6 +25,11 @@ class Settings(BaseSettings):
                 "ENVIRONMENT must be 'development', 'test', or 'production'"
             )
         return v
+
+    @field_validator("gumnut_api_base_url")
+    def strip_trailing_slash(cls, v: str) -> str:
+        """Strip trailing slashes from URLs to prevent double-slash bugs when building URLs."""
+        return v.rstrip("/")
 
 
 class TestSettings(Settings):

--- a/config/settings.py
+++ b/config/settings.py
@@ -15,6 +15,12 @@ class Settings(BaseSettings):
     gumnut_api_base_url: str = "http://localhost:8000"
     sentry_dsn: str | None = None
 
+    # External URL for this adapter (set to public URL in production)
+    adapter_external_url: str = "https://127.0.0.1:8001"
+
+    # Mobile app OAuth redirect URL (custom URL scheme for mobile deep linking)
+    oauth_mobile_redirect_uri: str = "app.immich:///oauth-callback"
+
     @field_validator("environment")
     def validate_environment(cls, v: str | None) -> str:
         if v is None or v not in ["development", "test", "production"]:


### PR DESCRIPTION
Fixes to allow mobile OAuth:
- Implemented mobile redirect endpoint (`api/oauth/mobile-redirect`) to support OAuth providers that do not support Immich's custom app scheme of `app.immich:///oauth-callback` in the redirect URI.
- Added uvicorn settings `--timeout-keep-alive`, `--limit-concurrency`, and `--backlog` to better support mobile clients. `--timeout-keep-alive` is particularly important as it prevents "Connection closed before full header was received" errors.