### PR TITLE
Add exclude-newer cooldown to immich-adapter (GUM-471)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,8 @@ FROM ghcr.io/immich-app/immich-server:${IMMICH_VERSION} AS immich-source
 # ============================================================================
 FROM python:3.14-slim AS builder
 
-# Copy uv from official image - pinned to specific version for reproducibility
-# Version 0.9.8 released 2025-11-07
-COPY --from=ghcr.io/astral-sh/uv:0.9.8 /uv /usr/local/bin/uv
+# Copy uv from official image
+COPY --from=ghcr.io/astral-sh/uv:0.11.3 /uv /usr/local/bin/uv
 
 # Set working directory
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ FROM ghcr.io/immich-app/immich-server:${IMMICH_VERSION} AS immich-source
 # ============================================================================
 FROM python:3.14-slim AS builder
 
-# Copy uv from official image
-COPY --from=ghcr.io/astral-sh/uv:0.11.3 /uv /usr/local/bin/uv
+# Copy uv from official image (pinned by digest for reproducible builds)
+COPY --from=ghcr.io/astral-sh/uv:0.11.3@sha256:90bbb3c16635e9627f49eec6539f956d70746c409209041800a0280b93152823 /uv /usr/local/bin/uv
 
 # Set working directory
 WORKDIR /app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,11 @@ dependencies = [
     "user-agents>=2.2.0",
 ]
 
+[tool.uv]
+exclude-newer = "14 days"
+# First-party SDK publishes frequently; exempt from the cooldown window.
+exclude-newer-package = { gumnut-sdk = false }
+
 [dependency-groups]
 dev = [
     "pyright>=1.1.403",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
 ]
 
 [tool.uv]
+# Supply chain guard: only resolve packages published ≥ 14 days ago.
+# Most compromised packages are detected and yanked within 1–2 weeks,
+# so this window lets the ecosystem catch problems before we pull them in.
 exclude-newer = "14 days"
 # First-party SDK publishes frequently; exempt from the cooldown window.
 exclude-newer-package = { gumnut-sdk = false }

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,13 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
+[options]
+exclude-newer = "2026-03-23T17:39:34.25737Z"
+exclude-newer-span = "P14D"
+
+[options.exclude-newer-package]
+gumnut-sdk = false
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"


### PR DESCRIPTION
## Summary
- Add `exclude-newer = "14 days"` to immich-adapter `pyproject.toml` to mitigate supply chain risk by filtering out recently-published packages during dependency resolution
- Opt out `gumnut-sdk` from the cooldown (first-party SDK, publishes frequently)
- Bump uv from 0.9.8 to 0.11.3 in Dockerfile (required for duration syntax), pinned by digest

## Linear
https://linear.app/gumnut-ai/issue/GUM-471/set-uv-exclude-newer-for-python-projects

## Cross-repo
- Companion PR in photos (same branch name)
- No deploy ordering required — changes are independent

## Test plan
- [x] `uv lock` resolves successfully with the new setting
- [x] `uv sync --locked` validates the lock file
- [x] All 646 tests pass
- [x] Lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)