### PR TITLE
GUM-324: Return real asset ID for duplicate uploads

### DIFF
--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -294,9 +294,18 @@ def _handle_upload_error(e: Exception) -> AssetMediaResponseDto | JSONResponse:
     """Map upload exceptions to Immich-compatible HTTP responses."""
     error_msg = str(e).lower()
     if "duplicate" in error_msg or "already exists" in error_msg:
+        # Try to extract the real asset ID from the exception body (SDK errors
+        # preserve the API response). Fall back to a placeholder UUID.
+        dup_id = "00000000-0000-0000-0000-000000000000"
+        body = getattr(e, "body", None)
+        if isinstance(body, dict) and body.get("id"):
+            try:
+                dup_id = str(safe_uuid_from_asset_id(body["id"]))
+            except Exception:
+                pass
         return JSONResponse(
             content={
-                "id": "00000000-0000-0000-0000-000000000000",
+                "id": dup_id,
                 "status": AssetMediaStatus.duplicate.value,
             },
             status_code=status.HTTP_200_OK,
@@ -471,7 +480,7 @@ async def _upload_buffered(
                 span.set_data("upload.filename", asset_data.filename)
                 span.set_data("upload.content_type", asset_data.content_type)
                 span.set_data("upload.strategy", "buffered")
-                gumnut_asset = await client.assets.create(
+                raw_response = await client.assets.with_raw_response.create(
                     asset_data=(
                         asset_data.filename,
                         asset_data.file,
@@ -483,7 +492,18 @@ async def _upload_buffered(
                     file_modified_at=file_modified_at,
                 )
 
+            gumnut_asset = await raw_response.parse()
             asset_uuid = safe_uuid_from_asset_id(gumnut_asset.id)
+
+            if raw_response.status_code == 200:
+                return JSONResponse(
+                    content={
+                        "id": str(asset_uuid),
+                        "status": AssetMediaStatus.duplicate.value,
+                    },
+                    status_code=status.HTTP_200_OK,
+                )
+
             await _emit_upload_events(gumnut_asset, current_user)
 
             return AssetMediaResponseDto(
@@ -532,9 +552,9 @@ async def _upload_streaming(
         result = await pipeline.execute(_extract_upload_fields)
 
         asset_id = result.get("id", "")
-        asset_status = result.get("status", "created")
+        http_status = result.pop("_http_status", 201)
 
-        if asset_status == AssetMediaStatus.duplicate.value:
+        if http_status == 200:
             dup_uuid = safe_uuid_from_asset_id(asset_id) if asset_id else UUID(int=0)
             return JSONResponse(
                 content={

--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -291,26 +291,13 @@ def _extract_upload_fields(fields: dict[str, str]) -> UploadFields:
 
 
 def _handle_upload_error(e: Exception) -> AssetMediaResponseDto | JSONResponse:
-    """Map upload exceptions to Immich-compatible HTTP responses."""
+    """Map upload exceptions to Immich-compatible HTTP responses.
+
+    Note: Duplicate detection is handled upstream via HTTP status codes
+    (photos-api returns 200 for duplicates, 201 for new assets), not here.
+    """
     error_msg = str(e).lower()
-    if "duplicate" in error_msg or "already exists" in error_msg:
-        # Try to extract the real asset ID from the exception body (SDK errors
-        # preserve the API response). Fall back to a placeholder UUID.
-        dup_id = "00000000-0000-0000-0000-000000000000"
-        body = getattr(e, "body", None)
-        if isinstance(body, dict) and body.get("id"):
-            try:
-                dup_id = str(safe_uuid_from_asset_id(body["id"]))
-            except Exception:
-                pass
-        return JSONResponse(
-            content={
-                "id": dup_id,
-                "status": AssetMediaStatus.duplicate.value,
-            },
-            status_code=status.HTTP_200_OK,
-        )
-    elif check_for_error_by_code(e, 413) or "too large" in error_msg:
+    if check_for_error_by_code(e, 413) or "too large" in error_msg:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
             detail="Asset file too large",

--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -495,7 +495,7 @@ async def _upload_buffered(
             gumnut_asset = await raw_response.parse()
             asset_uuid = safe_uuid_from_asset_id(gumnut_asset.id)
 
-            if raw_response.status_code == 200:
+            if raw_response.status_code == status.HTTP_200_OK:
                 return JSONResponse(
                     content={
                         "id": str(asset_uuid),
@@ -552,9 +552,9 @@ async def _upload_streaming(
         result = await pipeline.execute(_extract_upload_fields)
 
         asset_id = result.get("id", "")
-        http_status = result.pop("_http_status", 201)
+        http_status = result.pop("_http_status", status.HTTP_201_CREATED)
 
-        if http_status == 200:
+        if http_status == status.HTTP_200_OK:
             dup_uuid = safe_uuid_from_asset_id(asset_id) if asset_id else UUID(int=0)
             return JSONResponse(
                 content={

--- a/services/streaming_upload.py
+++ b/services/streaming_upload.py
@@ -289,7 +289,10 @@ class StreamingUploadPipeline:
             self.refreshed_token = new_token
 
         result = response.json()
-        result["_http_status"] = response.status_code
+        if isinstance(result, dict):
+            result["_http_status"] = response.status_code
+        else:
+            result = {"_http_status": response.status_code, "data": result}
         return result
 
     # --- Main orchestration ---

--- a/services/streaming_upload.py
+++ b/services/streaming_upload.py
@@ -288,7 +288,9 @@ class StreamingUploadPipeline:
         if new_token:
             self.refreshed_token = new_token
 
-        return response.json()
+        result = response.json()
+        result["_http_status"] = response.status_code
+        return result
 
     # --- Main orchestration ---
 

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -466,58 +466,6 @@ class TestUploadAsset:
         assert result.body == f'{{"id":"{sample_uuid}","status":"duplicate"}}'.encode()
 
     @pytest.mark.anyio
-    async def test_upload_asset_duplicate_error_fallback(self, mock_current_user):
-        """Test that unexpected duplicate errors fall back to placeholder UUID."""
-        mock_client = Mock()
-        mock_client.assets.with_raw_response.create = AsyncMock(
-            side_effect=Exception("Asset already exists")
-        )
-
-        request = _make_mock_request()
-        settings = _make_mock_settings()
-
-        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
-            result = await upload_asset(
-                request=request,
-                client=mock_client,
-                current_user=mock_current_user,
-                settings=settings,
-            )
-
-        assert isinstance(result, JSONResponse)
-        assert result.status_code == 200
-        assert (
-            result.body
-            == b'{"id":"00000000-0000-0000-0000-000000000000","status":"duplicate"}'
-        )
-
-    @pytest.mark.anyio
-    async def test_upload_asset_duplicate_error_extracts_id_from_body(
-        self, sample_uuid, mock_current_user
-    ):
-        """Test that error handler extracts real ID from SDK exception body."""
-        error = Exception("Asset already exists")
-        error.body = {"id": uuid_to_gumnut_asset_id(sample_uuid)}  # type: ignore[attr-defined]
-
-        mock_client = Mock()
-        mock_client.assets.with_raw_response.create = AsyncMock(side_effect=error)
-
-        request = _make_mock_request()
-        settings = _make_mock_settings()
-
-        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
-            result = await upload_asset(
-                request=request,
-                client=mock_client,
-                current_user=mock_current_user,
-                settings=settings,
-            )
-
-        assert isinstance(result, JSONResponse)
-        assert result.status_code == 200
-        assert result.body == f'{{"id":"{sample_uuid}","status":"duplicate"}}'.encode()
-
-    @pytest.mark.anyio
     async def test_upload_asset_api_error(self, mock_current_user):
         """Test upload asset with API error."""
         mock_client = Mock()
@@ -745,20 +693,21 @@ class TestUploadAsset:
         """Test that small content-length selects buffered strategy."""
         mock_client = Mock()
         mock_client.assets.with_raw_response.create = AsyncMock(
-            side_effect=Exception("Asset already exists")
+            side_effect=Exception("test error")
         )
 
         # Content-Length 1024 < threshold 100MB → buffered
         request = _make_mock_request(content_length=1024)
         settings = _make_mock_settings(threshold=100 * 1024 * 1024)
 
-        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
-            await upload_asset(
-                request=request,
-                client=mock_client,
-                current_user=mock_current_user,
-                settings=settings,
-            )
+        with pytest.raises(HTTPException):
+            with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+                await upload_asset(
+                    request=request,
+                    client=mock_client,
+                    current_user=mock_current_user,
+                    settings=settings,
+                )
 
         # Buffered path was used (form() was called)
         request.form.assert_called_once()
@@ -803,19 +752,20 @@ class TestUploadAsset:
         threshold = 100 * 1024 * 1024
         mock_client = Mock()
         mock_client.assets.with_raw_response.create = AsyncMock(
-            side_effect=Exception("Asset already exists")
+            side_effect=Exception("test error")
         )
 
         request = _make_mock_request(content_length=threshold)
         settings = _make_mock_settings(threshold=threshold)
 
-        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
-            await upload_asset(
-                request=request,
-                client=mock_client,
-                current_user=mock_current_user,
-                settings=settings,
-            )
+        with pytest.raises(HTTPException):
+            with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+                await upload_asset(
+                    request=request,
+                    client=mock_client,
+                    current_user=mock_current_user,
+                    settings=settings,
+                )
 
         # At boundary → buffered path (form() called)
         request.form.assert_called_once()
@@ -827,7 +777,7 @@ class TestUploadAsset:
         """Missing Content-Length header falls through to buffered path."""
         mock_client = Mock()
         mock_client.assets.with_raw_response.create = AsyncMock(
-            side_effect=Exception("Asset already exists")
+            side_effect=Exception("test error")
         )
 
         request = _make_mock_request(content_length=1024)
@@ -835,13 +785,14 @@ class TestUploadAsset:
         del request.headers["content-length"]
         settings = _make_mock_settings(threshold=100 * 1024 * 1024)
 
-        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
-            await upload_asset(
-                request=request,
-                client=mock_client,
-                current_user=mock_current_user,
-                settings=settings,
-            )
+        with pytest.raises(HTTPException):
+            with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+                await upload_asset(
+                    request=request,
+                    client=mock_client,
+                    current_user=mock_current_user,
+                    settings=settings,
+                )
 
         request.form.assert_called_once()
 
@@ -852,20 +803,21 @@ class TestUploadAsset:
         """Non-numeric Content-Length falls through to buffered path."""
         mock_client = Mock()
         mock_client.assets.with_raw_response.create = AsyncMock(
-            side_effect=Exception("Asset already exists")
+            side_effect=Exception("test error")
         )
 
         request = _make_mock_request(content_length=1024)
         request.headers["content-length"] = "not-a-number"
         settings = _make_mock_settings(threshold=100 * 1024 * 1024)
 
-        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
-            await upload_asset(
-                request=request,
-                client=mock_client,
-                current_user=mock_current_user,
-                settings=settings,
-            )
+        with pytest.raises(HTTPException):
+            with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+                await upload_asset(
+                    request=request,
+                    client=mock_client,
+                    current_user=mock_current_user,
+                    settings=settings,
+                )
 
         request.form.assert_called_once()
 

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -387,8 +387,6 @@ class TestUploadAsset:
     @pytest.mark.anyio
     async def test_upload_asset_success(self, sample_uuid, mock_current_user):
         """Test successful asset upload via buffered path."""
-        mock_client = Mock()
-
         mock_gumnut_asset = Mock()
         mock_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
         mock_gumnut_asset.checksum = "abc123"
@@ -401,7 +399,15 @@ class TestUploadAsset:
         mock_gumnut_asset.file_size_bytes = 1024
         mock_gumnut_asset.exif = None
         mock_gumnut_asset.people = []
-        mock_client.assets.create = AsyncMock(return_value=mock_gumnut_asset)
+
+        mock_raw_response = Mock()
+        mock_raw_response.status_code = 201
+        mock_raw_response.parse = AsyncMock(return_value=mock_gumnut_asset)
+
+        mock_client = Mock()
+        mock_client.assets.with_raw_response.create = AsyncMock(
+            return_value=mock_raw_response
+        )
 
         mock_file = Mock()
         mock_file.filename = "test.jpg"
@@ -423,15 +429,47 @@ class TestUploadAsset:
         assert isinstance(result, AssetMediaResponseDto)
         assert result.id == str(sample_uuid)
         assert result.status == AssetMediaStatus.created
-        mock_client.assets.create.assert_called_once()
-        call_kwargs = mock_client.assets.create.call_args
+        mock_client.assets.with_raw_response.create.assert_called_once()
+        call_kwargs = mock_client.assets.with_raw_response.create.call_args
         assert call_kwargs.kwargs["asset_data"][1] is mock_file.file
 
     @pytest.mark.anyio
-    async def test_upload_asset_duplicate(self, sample_uuid, mock_current_user):
-        """Test upload asset with duplicate error returns 200 with duplicate status."""
+    async def test_upload_asset_duplicate_returns_real_id(
+        self, sample_uuid, mock_current_user
+    ):
+        """Test that duplicate upload (HTTP 200 from photos-api) returns the real asset ID."""
+        mock_gumnut_asset = Mock()
+        mock_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
+
+        mock_raw_response = Mock()
+        mock_raw_response.status_code = 200
+        mock_raw_response.parse = AsyncMock(return_value=mock_gumnut_asset)
+
         mock_client = Mock()
-        mock_client.assets.create = AsyncMock(
+        mock_client.assets.with_raw_response.create = AsyncMock(
+            return_value=mock_raw_response
+        )
+
+        request = _make_mock_request()
+        settings = _make_mock_settings()
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            result = await upload_asset(
+                request=request,
+                client=mock_client,
+                current_user=mock_current_user,
+                settings=settings,
+            )
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 200
+        assert result.body == f'{{"id":"{sample_uuid}","status":"duplicate"}}'.encode()
+
+    @pytest.mark.anyio
+    async def test_upload_asset_duplicate_error_fallback(self, mock_current_user):
+        """Test that unexpected duplicate errors fall back to placeholder UUID."""
+        mock_client = Mock()
+        mock_client.assets.with_raw_response.create = AsyncMock(
             side_effect=Exception("Asset already exists")
         )
 
@@ -454,10 +492,36 @@ class TestUploadAsset:
         )
 
     @pytest.mark.anyio
+    async def test_upload_asset_duplicate_error_extracts_id_from_body(
+        self, sample_uuid, mock_current_user
+    ):
+        """Test that error handler extracts real ID from SDK exception body."""
+        error = Exception("Asset already exists")
+        error.body = {"id": uuid_to_gumnut_asset_id(sample_uuid)}  # type: ignore[attr-defined]
+
+        mock_client = Mock()
+        mock_client.assets.with_raw_response.create = AsyncMock(side_effect=error)
+
+        request = _make_mock_request()
+        settings = _make_mock_settings()
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            result = await upload_asset(
+                request=request,
+                client=mock_client,
+                current_user=mock_current_user,
+                settings=settings,
+            )
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 200
+        assert result.body == f'{{"id":"{sample_uuid}","status":"duplicate"}}'.encode()
+
+    @pytest.mark.anyio
     async def test_upload_asset_api_error(self, mock_current_user):
         """Test upload asset with API error."""
         mock_client = Mock()
-        mock_client.assets.create = AsyncMock(
+        mock_client.assets.with_raw_response.create = AsyncMock(
             side_effect=Exception("401 Invalid API key")
         )
 
@@ -480,8 +544,6 @@ class TestUploadAsset:
         self, sample_uuid, mock_current_user
     ):
         """Test that upload_asset emits on_upload_success and AssetUploadReadyV1 events."""
-        mock_client = Mock()
-
         mock_gumnut_asset = Mock()
         mock_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
         mock_gumnut_asset.checksum = "abc123"
@@ -494,7 +556,15 @@ class TestUploadAsset:
         mock_gumnut_asset.file_size_bytes = 1024
         mock_gumnut_asset.exif = None
         mock_gumnut_asset.people = []
-        mock_client.assets.create = AsyncMock(return_value=mock_gumnut_asset)
+
+        mock_raw_response = Mock()
+        mock_raw_response.status_code = 201
+        mock_raw_response.parse = AsyncMock(return_value=mock_gumnut_asset)
+
+        mock_client = Mock()
+        mock_client.assets.with_raw_response.create = AsyncMock(
+            return_value=mock_raw_response
+        )
 
         request = _make_mock_request()
         settings = _make_mock_settings()
@@ -543,7 +613,7 @@ class TestUploadAsset:
         assert isinstance(result, AssetMediaResponseDto)
         assert UUID(result.id)
         assert result.status == AssetMediaStatus.created
-        mock_client.assets.create.assert_not_called()
+        mock_client.assets.with_raw_response.create.assert_not_called()
 
     @pytest.mark.anyio
     async def test_upload_live_photo_mov_with_video_content_type_is_dropped(
@@ -572,13 +642,11 @@ class TestUploadAsset:
         assert isinstance(result, AssetMediaResponseDto)
         assert UUID(result.id)
         assert result.status == AssetMediaStatus.created
-        mock_client.assets.create.assert_not_called()
+        mock_client.assets.with_raw_response.create.assert_not_called()
 
     @pytest.mark.anyio
     async def test_upload_regular_video_proceeds(self, sample_uuid, mock_current_user):
         """Test that regular video uploads are not dropped."""
-        mock_client = Mock()
-
         mock_gumnut_asset = Mock()
         mock_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
         mock_gumnut_asset.checksum = "abc123"
@@ -591,7 +659,15 @@ class TestUploadAsset:
         mock_gumnut_asset.file_size_bytes = 10240
         mock_gumnut_asset.exif = None
         mock_gumnut_asset.people = []
-        mock_client.assets.create = AsyncMock(return_value=mock_gumnut_asset)
+
+        mock_raw_response = Mock()
+        mock_raw_response.status_code = 201
+        mock_raw_response.parse = AsyncMock(return_value=mock_gumnut_asset)
+
+        mock_client = Mock()
+        mock_client.assets.with_raw_response.create = AsyncMock(
+            return_value=mock_raw_response
+        )
 
         mock_file = Mock()
         mock_file.filename = "video.mp4"
@@ -616,15 +692,13 @@ class TestUploadAsset:
         assert isinstance(result, AssetMediaResponseDto)
         assert result.id == str(sample_uuid)
         assert result.status == AssetMediaStatus.created
-        mock_client.assets.create.assert_called_once()
+        mock_client.assets.with_raw_response.create.assert_called_once()
 
     @pytest.mark.anyio
     async def test_upload_asset_websocket_error_does_not_fail_upload(
         self, sample_uuid, mock_current_user
     ):
         """Test that WebSocket emission errors don't fail the upload."""
-        mock_client = Mock()
-
         mock_gumnut_asset = Mock()
         mock_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
         mock_gumnut_asset.checksum = "abc123"
@@ -637,7 +711,15 @@ class TestUploadAsset:
         mock_gumnut_asset.file_size_bytes = 1024
         mock_gumnut_asset.exif = None
         mock_gumnut_asset.people = []
-        mock_client.assets.create = AsyncMock(return_value=mock_gumnut_asset)
+
+        mock_raw_response = Mock()
+        mock_raw_response.status_code = 201
+        mock_raw_response.parse = AsyncMock(return_value=mock_gumnut_asset)
+
+        mock_client = Mock()
+        mock_client.assets.with_raw_response.create = AsyncMock(
+            return_value=mock_raw_response
+        )
 
         request = _make_mock_request()
         settings = _make_mock_settings()
@@ -662,7 +744,7 @@ class TestUploadAsset:
     async def test_upload_strategy_selection_buffered(self, mock_current_user):
         """Test that small content-length selects buffered strategy."""
         mock_client = Mock()
-        mock_client.assets.create = AsyncMock(
+        mock_client.assets.with_raw_response.create = AsyncMock(
             side_effect=Exception("Asset already exists")
         )
 
@@ -720,7 +802,7 @@ class TestUploadAsset:
         """Content-Length exactly at threshold uses buffered (strict > comparison)."""
         threshold = 100 * 1024 * 1024
         mock_client = Mock()
-        mock_client.assets.create = AsyncMock(
+        mock_client.assets.with_raw_response.create = AsyncMock(
             side_effect=Exception("Asset already exists")
         )
 
@@ -744,7 +826,7 @@ class TestUploadAsset:
     ):
         """Missing Content-Length header falls through to buffered path."""
         mock_client = Mock()
-        mock_client.assets.create = AsyncMock(
+        mock_client.assets.with_raw_response.create = AsyncMock(
             side_effect=Exception("Asset already exists")
         )
 
@@ -769,7 +851,7 @@ class TestUploadAsset:
     ):
         """Non-numeric Content-Length falls through to buffered path."""
         mock_client = Mock()
-        mock_client.assets.create = AsyncMock(
+        mock_client.assets.with_raw_response.create = AsyncMock(
             side_effect=Exception("Asset already exists")
         )
 

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -901,6 +901,46 @@ class TestUploadAsset:
 
         mock_streaming.assert_called_once()
 
+    @pytest.mark.anyio
+    async def test_streaming_upload_duplicate_returns_real_id(
+        self, sample_uuid, mock_current_user
+    ):
+        """Test that streaming path returns real asset ID for duplicates (HTTP 200)."""
+        gumnut_id = uuid_to_gumnut_asset_id(sample_uuid)
+
+        request = Mock()
+        request.headers = {
+            "content-length": str(300 * 1024 * 1024),
+            "content-type": "multipart/form-data; boundary=---abc123",
+        }
+
+        class _State:
+            jwt_token = "test-jwt-token"
+
+        request.state = _State()
+
+        settings = _make_mock_settings(threshold=100 * 1024 * 1024)
+
+        mock_pipeline_instance = Mock()
+        mock_pipeline_instance.execute = AsyncMock(
+            return_value={"id": gumnut_id, "_http_status": 200}
+        )
+
+        with patch(
+            "routers.api.assets.StreamingUploadPipeline",
+            return_value=mock_pipeline_instance,
+        ):
+            result = await upload_asset(
+                request=request,
+                client=Mock(),
+                current_user=mock_current_user,
+                settings=settings,
+            )
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 200
+        assert result.body == f'{{"id":"{sample_uuid}","status":"duplicate"}}'.encode()
+
 
 class TestUpdateAssets:
     """Test the update_assets endpoint."""

--- a/tests/unit/services/test_streaming_upload.py
+++ b/tests/unit/services/test_streaming_upload.py
@@ -121,6 +121,7 @@ class TestStreamingUploadPipeline:
 
         assert result["id"] == "asset_abc123"
         assert result["status"] == "created"
+        assert result["_http_status"] == 201
         mock_client.post.assert_called_once()
 
     @pytest.mark.anyio
@@ -214,6 +215,7 @@ class TestStreamingUploadPipeline:
             result = await pipeline.execute(_extract_fields)
 
         assert result["status"] == "duplicate"
+        assert result["_http_status"] == 200
 
     @pytest.mark.anyio
     async def test_4xx_forwarded_as_is(self):


### PR DESCRIPTION
## Summary
- Fix `POST /assets` to return the real asset ID (not a placeholder UUID) when a duplicate is detected
- Buffered path: use `with_raw_response.create()` to detect HTTP 200 (duplicate) vs 201 (new) from photos-api
- Streaming path: propagate HTTP status code from the pipeline so the adapter can detect duplicates
- Remove dead "duplicate"/"already exists" string-matching branch from `_handle_upload_error` — photos-api returns HTTP 200 for duplicates (not errors), so this code path was unreachable

## Linear
https://linear.app/gumnut-ai/issue/GUM-324/post-assets-duplicate-response-returns-placeholder-uuid-instead-of

## Test plan
- [x] Buffered path: new asset returns 201 + "created" status
- [x] Buffered path: duplicate returns 200 + "duplicate" status with real asset ID
- [x] Streaming path: duplicate returns 200 + "duplicate" status with real asset ID
- [x] All 647 tests pass
- [x] Pyright type check clean, ruff lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)