### PR TITLE
Fix reversed source/target semantics in people reassign endpoint

### DIFF
--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -79,8 +79,9 @@ asset_id: Annotated[UUID | SkipJsonSchema[None], Query(alias="assetId")] = None,
 1. **Generate models**: Use `generate_immich_models.py` to create up-to-date Pydantic models (see [development tools](development-tools.md))
 2. **Import models**: Use generated models from `routers.immich_models` for type safety
 3. **Define parameters**: Follow the parameter conventions above
-4. **Validate compatibility**: Run `validate_api_compatibility.py` to ensure correct implementation
-5. **Test endpoints**: Verify responses match Immich API expectations
+4. **Verify parameter semantics**: Check the Immich OpenAPI spec (`https://api.immich.app/endpoints/`) or source code to confirm what each URL path and body parameter represents. URL `{id}` parameters don't always refer to the entity being queried — e.g., in `PUT /people/{id}/reassign`, `{id}` is the target person (reassign TO), not the source.
+5. **Validate compatibility**: Run `validate_api_compatibility.py` to ensure correct implementation
+6. **Test endpoints**: Verify responses match Immich API expectations
 
 ### Exception Handling
 

--- a/routers/api/people.py
+++ b/routers/api/people.py
@@ -425,13 +425,16 @@ async def reassign_faces(
     The URL {id} is the target person (who to reassign faces TO).
     For each item in the request, finds the face belonging to the source person
     (body personId) on the given asset and reassigns it to the target person
-    (URL {id}). Returns the target person for each item that had faces reassigned.
+    (URL {id}). Returns the target person if any faces were reassigned.
     """
     try:
         gumnut_target_person_id = uuid_to_gumnut_person_id(id)
-        target_person: PersonResponseDto | None = None
-        results: List[PersonResponseDto] = []
 
+        # Validate and cache the target person before modifying any faces
+        gumnut_person = await client.people.retrieve(gumnut_target_person_id)
+        target_person = convert_gumnut_person_to_immich(gumnut_person)
+
+        any_reassigned = False
         for item in request.data:
             gumnut_asset_id = uuid_to_gumnut_asset_id(item.assetId)
             gumnut_source_person_id = uuid_to_gumnut_person_id(item.personId)
@@ -457,14 +460,9 @@ async def reassign_faces(
 
             for face in faces:
                 await client.faces.update(face.id, person_id=gumnut_target_person_id)
+            any_reassigned = True
 
-            # Fetch target person once, return for each successful item
-            if target_person is None:
-                gumnut_person = await client.people.retrieve(gumnut_target_person_id)
-                target_person = convert_gumnut_person_to_immich(gumnut_person)
-            results.append(target_person)
-
-        return results
+        return [target_person] if any_reassigned else []
 
     except HTTPException:
         raise

--- a/routers/api/people.py
+++ b/routers/api/people.py
@@ -420,19 +420,21 @@ async def reassign_faces(
     request: AssetFaceUpdateDto,
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
 ) -> List[PersonResponseDto]:
-    """Reassign faces from one person to other people.
+    """Reassign faces to a person.
 
+    The URL {id} is the target person (who to reassign faces TO).
     For each item in the request, finds the face belonging to the source person
-    (URL {id}) on the given asset and reassigns it to the target person (body
-    personId). Returns the list of target people that received faces.
+    (body personId) on the given asset and reassigns it to the target person
+    (URL {id}). Returns the target person for each item that had faces reassigned.
     """
     try:
-        gumnut_source_person_id = uuid_to_gumnut_person_id(id)
-        seen_targets: dict[str, None] = {}
+        gumnut_target_person_id = uuid_to_gumnut_person_id(id)
+        target_person: PersonResponseDto | None = None
+        results: List[PersonResponseDto] = []
 
         for item in request.data:
             gumnut_asset_id = uuid_to_gumnut_asset_id(item.assetId)
-            gumnut_target_person_id = uuid_to_gumnut_person_id(item.personId)
+            gumnut_source_person_id = uuid_to_gumnut_person_id(item.personId)
 
             # Find all faces belonging to the source person on this asset
             faces = [
@@ -455,15 +457,14 @@ async def reassign_faces(
 
             for face in faces:
                 await client.faces.update(face.id, person_id=gumnut_target_person_id)
-            seen_targets[gumnut_target_person_id] = None
 
-        # Fetch and return the target people in Immich format (insertion order)
-        result: List[PersonResponseDto] = []
-        for person_id in seen_targets:
-            gumnut_person = await client.people.retrieve(person_id)
-            result.append(convert_gumnut_person_to_immich(gumnut_person))
+            # Fetch target person once, return for each successful item
+            if target_person is None:
+                gumnut_person = await client.people.retrieve(gumnut_target_person_id)
+                target_person = convert_gumnut_person_to_immich(gumnut_person)
+            results.append(target_person)
 
-        return result
+        return results
 
     except HTTPException:
         raise

--- a/routers/api/people.py
+++ b/routers/api/people.py
@@ -428,6 +428,9 @@ async def reassign_faces(
     (URL {id}). Returns the target person if any faces were reassigned.
     """
     try:
+        if not request.data:
+            return []
+
         gumnut_target_person_id = uuid_to_gumnut_person_id(id)
 
         # Validate and cache the target person before modifying any faces

--- a/tests/unit/api/test_people.py
+++ b/tests/unit/api/test_people.py
@@ -980,9 +980,10 @@ class TestReassignFaces:
     """Test the reassign_faces endpoint."""
 
     @pytest.mark.anyio
-    async def test_reassign_faces_empty_data(self, sample_uuid):
+    async def test_reassign_faces_empty_data(self, sample_uuid, sample_gumnut_person):
         """Test reassign with no face items returns empty list."""
         mock_client = Mock()
+        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
         request = AssetFaceUpdateDto(data=[])
 
         result = await reassign_faces(sample_uuid, request, client=mock_client)
@@ -1033,7 +1034,7 @@ class TestReassignFaces:
 
     @pytest.mark.anyio
     async def test_reassign_faces_no_face_found_skips(
-        self, sample_uuid, mock_sync_cursor_page
+        self, sample_uuid, sample_gumnut_person, mock_sync_cursor_page
     ):
         """Test that missing faces are skipped without error."""
         target_uuid = sample_uuid  # URL param = target
@@ -1041,6 +1042,7 @@ class TestReassignFaces:
         asset_uuid = uuid4()
 
         mock_client = Mock()
+        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
         mock_client.faces.list = Mock(
             return_value=mock_sync_cursor_page([])  # No face found
         )
@@ -1057,13 +1059,14 @@ class TestReassignFaces:
         assert result == []
 
     @pytest.mark.anyio
-    async def test_reassign_faces_api_error(self, sample_uuid):
+    async def test_reassign_faces_api_error(self, sample_uuid, sample_gumnut_person):
         """Test error handling during reassignment."""
         target_uuid = sample_uuid  # URL param = target
         source_uuid = uuid4()  # body personId = source
         asset_uuid = uuid4()
 
         mock_client = Mock()
+        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
         mock_client.faces.list = Mock(
             side_effect=Exception("500 Internal Server Error")
         )
@@ -1116,7 +1119,7 @@ class TestReassignFaces:
 
     @pytest.mark.anyio
     async def test_reassign_faces_multiple_sources_to_single_target(
-        self, sample_uuid, mock_sync_cursor_page
+        self, sample_uuid, sample_gumnut_person, mock_sync_cursor_page
     ):
         """Multiple items with different source persons all reassign to the URL target."""
         target_uuid = sample_uuid  # URL param = single target
@@ -1132,6 +1135,7 @@ class TestReassignFaces:
 
         # Return one face per asset
         mock_client = Mock()
+        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
         mock_client.faces.list = Mock(
             side_effect=[
                 mock_sync_cursor_page([mock_face_a]),
@@ -1140,22 +1144,6 @@ class TestReassignFaces:
             ]
         )
         mock_client.faces.update = AsyncMock()
-
-        # Mock target person
-        target_person = Mock()
-        target_person.id = uuid_to_gumnut_person_id(target_uuid)
-        target_person.name = "Target Person"
-        target_person.birth_date = None
-        target_person.is_favorite = False
-        target_person.is_hidden = False
-        target_person.thumbnail_face_id = None
-        target_person.thumbnail_face_url = None
-        target_person.asset_urls = None
-        target_person.asset_count = 1
-        target_person.created_at = datetime.now(timezone.utc)
-        target_person.updated_at = datetime.now(timezone.utc)
-
-        mock_client.people.retrieve = AsyncMock(return_value=target_person)
 
         # Request: faces from source_1 and source_2 across 3 assets
         request = AssetFaceUpdateDto(
@@ -1179,9 +1167,9 @@ class TestReassignFaces:
         assert list_calls[1][1]["person_id"] == uuid_to_gumnut_person_id(source_2)
         assert list_calls[2][1]["person_id"] == uuid_to_gumnut_person_id(source_1)
 
-        # Result: target person returned once per successful item
-        assert len(result) == 3
-        assert all(r.name == "Target Person" for r in result)
+        # Result: target person returned once (not per item)
+        assert len(result) == 1
+        assert hasattr(result[0], "name")
 
-        # Target person fetched only once (cached)
+        # Target person fetched once upfront
         assert mock_client.people.retrieve.call_count == 1

--- a/tests/unit/api/test_people.py
+++ b/tests/unit/api/test_people.py
@@ -980,15 +980,16 @@ class TestReassignFaces:
     """Test the reassign_faces endpoint."""
 
     @pytest.mark.anyio
-    async def test_reassign_faces_empty_data(self, sample_uuid, sample_gumnut_person):
-        """Test reassign with no face items returns empty list."""
+    async def test_reassign_faces_empty_data(self, sample_uuid):
+        """Test reassign with no face items returns empty list without API calls."""
         mock_client = Mock()
-        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
         request = AssetFaceUpdateDto(data=[])
 
         result = await reassign_faces(sample_uuid, request, client=mock_client)
 
         assert result == []
+        # No API calls should be made for empty data
+        mock_client.people.retrieve.assert_not_called()
 
     @pytest.mark.anyio
     async def test_reassign_faces_success(

--- a/tests/unit/api/test_people.py
+++ b/tests/unit/api/test_people.py
@@ -993,14 +993,19 @@ class TestReassignFaces:
     async def test_reassign_faces_success(
         self, sample_uuid, sample_gumnut_person, mock_sync_cursor_page
     ):
-        """Test successful face reassignment."""
-        target_uuid = uuid4()
+        """Test successful face reassignment.
+
+        URL {id} (sample_uuid) is the target person.
+        Body personId (source_uuid) is the source person (current face owner).
+        """
+        target_uuid = sample_uuid  # URL param = target
+        source_uuid = uuid4()  # body personId = source
         asset_uuid = uuid4()
 
         # Mock face found on source person's asset
         mock_face = Mock()
         mock_face.id = "face_abc123"
-        mock_face.person_id = uuid_to_gumnut_person_id(sample_uuid)
+        mock_face.person_id = uuid_to_gumnut_person_id(source_uuid)
 
         mock_client = Mock()
         mock_client.faces.list = Mock(return_value=mock_sync_cursor_page([mock_face]))
@@ -1008,17 +1013,17 @@ class TestReassignFaces:
         mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
 
         request = AssetFaceUpdateDto(
-            data=[AssetFaceUpdateItem(assetId=asset_uuid, personId=target_uuid)]
+            data=[AssetFaceUpdateItem(assetId=asset_uuid, personId=source_uuid)]
         )
 
-        result = await reassign_faces(sample_uuid, request, client=mock_client)
+        result = await reassign_faces(target_uuid, request, client=mock_client)
 
-        # Verify face was looked up by source person + asset
+        # Verify face was looked up by source person (body) + asset
         mock_client.faces.list.assert_called_once_with(
-            person_id=uuid_to_gumnut_person_id(sample_uuid),
+            person_id=uuid_to_gumnut_person_id(source_uuid),
             asset_id=uuid_to_gumnut_asset_id(asset_uuid),
         )
-        # Verify face was reassigned to target person
+        # Verify face was reassigned to target person (URL)
         mock_client.faces.update.assert_called_once_with(
             "face_abc123", person_id=uuid_to_gumnut_person_id(target_uuid)
         )
@@ -1031,7 +1036,8 @@ class TestReassignFaces:
         self, sample_uuid, mock_sync_cursor_page
     ):
         """Test that missing faces are skipped without error."""
-        target_uuid = uuid4()
+        target_uuid = sample_uuid  # URL param = target
+        source_uuid = uuid4()  # body personId = source
         asset_uuid = uuid4()
 
         mock_client = Mock()
@@ -1041,10 +1047,10 @@ class TestReassignFaces:
         mock_client.faces.update = AsyncMock()
 
         request = AssetFaceUpdateDto(
-            data=[AssetFaceUpdateItem(assetId=asset_uuid, personId=target_uuid)]
+            data=[AssetFaceUpdateItem(assetId=asset_uuid, personId=source_uuid)]
         )
 
-        result = await reassign_faces(sample_uuid, request, client=mock_client)
+        result = await reassign_faces(target_uuid, request, client=mock_client)
 
         # Face update should not have been called
         mock_client.faces.update.assert_not_called()
@@ -1053,7 +1059,8 @@ class TestReassignFaces:
     @pytest.mark.anyio
     async def test_reassign_faces_api_error(self, sample_uuid):
         """Test error handling during reassignment."""
-        target_uuid = uuid4()
+        target_uuid = sample_uuid  # URL param = target
+        source_uuid = uuid4()  # body personId = source
         asset_uuid = uuid4()
 
         mock_client = Mock()
@@ -1062,11 +1069,11 @@ class TestReassignFaces:
         )
 
         request = AssetFaceUpdateDto(
-            data=[AssetFaceUpdateItem(assetId=asset_uuid, personId=target_uuid)]
+            data=[AssetFaceUpdateItem(assetId=asset_uuid, personId=source_uuid)]
         )
 
         with pytest.raises(HTTPException) as exc_info:
-            await reassign_faces(sample_uuid, request, client=mock_client)
+            await reassign_faces(target_uuid, request, client=mock_client)
 
         assert exc_info.value.status_code == 500
 
@@ -1075,7 +1082,8 @@ class TestReassignFaces:
         self, sample_uuid, sample_gumnut_person, mock_sync_cursor_page
     ):
         """All faces for (source person, asset) should be reassigned, not just the first."""
-        target_uuid = uuid4()
+        target_uuid = sample_uuid  # URL param = target
+        source_uuid = uuid4()  # body personId = source
         asset_uuid = uuid4()
 
         mock_face_1 = Mock()
@@ -1091,12 +1099,12 @@ class TestReassignFaces:
         mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
 
         request = AssetFaceUpdateDto(
-            data=[AssetFaceUpdateItem(assetId=asset_uuid, personId=target_uuid)]
+            data=[AssetFaceUpdateItem(assetId=asset_uuid, personId=source_uuid)]
         )
 
-        result = await reassign_faces(sample_uuid, request, client=mock_client)
+        result = await reassign_faces(target_uuid, request, client=mock_client)
 
-        # Both faces should be updated
+        # Both faces should be updated to the target person (URL)
         assert mock_client.faces.update.call_count == 2
         mock_client.faces.update.assert_any_call(
             "face_aaa", person_id=uuid_to_gumnut_person_id(target_uuid)
@@ -1107,12 +1115,13 @@ class TestReassignFaces:
         assert len(result) == 1
 
     @pytest.mark.anyio
-    async def test_reassign_faces_multi_target_dedup_and_ordering(
+    async def test_reassign_faces_multiple_sources_to_single_target(
         self, sample_uuid, mock_sync_cursor_page
     ):
-        """Multiple items targeting the same person should dedup; order is first-seen."""
-        target_1 = uuid4()
-        target_2 = uuid4()
+        """Multiple items with different source persons all reassign to the URL target."""
+        target_uuid = sample_uuid  # URL param = single target
+        source_1 = uuid4()
+        source_2 = uuid4()
         asset_a = uuid4()
         asset_b = uuid4()
         asset_c = uuid4()
@@ -1132,56 +1141,47 @@ class TestReassignFaces:
         )
         mock_client.faces.update = AsyncMock()
 
-        # Create distinct person mocks so we can verify ordering
-        person_1 = Mock()
-        person_1.id = uuid_to_gumnut_person_id(target_1)
-        person_1.name = "Person One"
-        person_1.birth_date = None
-        person_1.is_favorite = False
-        person_1.is_hidden = False
-        person_1.thumbnail_face_id = None
-        person_1.thumbnail_face_url = None
-        person_1.asset_urls = None
-        person_1.asset_count = 1
-        person_1.created_at = datetime.now(timezone.utc)
-        person_1.updated_at = datetime.now(timezone.utc)
+        # Mock target person
+        target_person = Mock()
+        target_person.id = uuid_to_gumnut_person_id(target_uuid)
+        target_person.name = "Target Person"
+        target_person.birth_date = None
+        target_person.is_favorite = False
+        target_person.is_hidden = False
+        target_person.thumbnail_face_id = None
+        target_person.thumbnail_face_url = None
+        target_person.asset_urls = None
+        target_person.asset_count = 1
+        target_person.created_at = datetime.now(timezone.utc)
+        target_person.updated_at = datetime.now(timezone.utc)
 
-        person_2 = Mock()
-        person_2.id = uuid_to_gumnut_person_id(target_2)
-        person_2.name = "Person Two"
-        person_2.birth_date = None
-        person_2.is_favorite = False
-        person_2.is_hidden = False
-        person_2.thumbnail_face_id = None
-        person_2.thumbnail_face_url = None
-        person_2.asset_urls = None
-        person_2.asset_count = 1
-        person_2.created_at = datetime.now(timezone.utc)
-        person_2.updated_at = datetime.now(timezone.utc)
+        mock_client.people.retrieve = AsyncMock(return_value=target_person)
 
-        async def mock_retrieve(person_id):
-            if person_id == uuid_to_gumnut_person_id(target_1):
-                return person_1
-            return person_2
-
-        mock_client.people.retrieve = AsyncMock(side_effect=mock_retrieve)
-
-        # Request: A→target_1, B→target_2, C→target_1
+        # Request: faces from source_1 and source_2 across 3 assets
         request = AssetFaceUpdateDto(
             data=[
-                AssetFaceUpdateItem(assetId=asset_a, personId=target_1),
-                AssetFaceUpdateItem(assetId=asset_b, personId=target_2),
-                AssetFaceUpdateItem(assetId=asset_c, personId=target_1),
+                AssetFaceUpdateItem(assetId=asset_a, personId=source_1),
+                AssetFaceUpdateItem(assetId=asset_b, personId=source_2),
+                AssetFaceUpdateItem(assetId=asset_c, personId=source_1),
             ]
         )
 
-        result = await reassign_faces(sample_uuid, request, client=mock_client)
+        result = await reassign_faces(target_uuid, request, client=mock_client)
 
-        # All 3 faces updated
+        # All 3 faces updated to the target
         assert mock_client.faces.update.call_count == 3
-        # Result should have 2 people in first-seen order: target_1 then target_2
-        assert len(result) == 2
-        assert result[0].name == "Person One"
-        assert result[1].name == "Person Two"
-        # people.retrieve called once per unique target, not 3 times
-        assert mock_client.people.retrieve.call_count == 2
+        for call in mock_client.faces.update.call_args_list:
+            assert call[1]["person_id"] == uuid_to_gumnut_person_id(target_uuid)
+
+        # Faces looked up by source person IDs
+        list_calls = mock_client.faces.list.call_args_list
+        assert list_calls[0][1]["person_id"] == uuid_to_gumnut_person_id(source_1)
+        assert list_calls[1][1]["person_id"] == uuid_to_gumnut_person_id(source_2)
+        assert list_calls[2][1]["person_id"] == uuid_to_gumnut_person_id(source_1)
+
+        # Result: target person returned once per successful item
+        assert len(result) == 3
+        assert all(r.name == "Target Person" for r in result)
+
+        # Target person fetched only once (cached)
+        assert mock_client.people.retrieve.call_count == 1


### PR DESCRIPTION
## Summary
- The `PUT /api/people/{id}/reassign` endpoint had source and target person semantics reversed compared to the Immich API spec
- Immich uses URL `{id}` as the **target** person (reassign TO) and body `personId` as the **source** (current face owner), but the adapter treated them the other way around
- This caused all face reassign attempts from the Immich web app to silently fail — the adapter queried for faces belonging to the wrong person, found nothing, and returned an empty 200

## Linear
https://linear.app/gumnut-ai/issue/GUM-505/fix-reversed-sourcetarget-semantics-in-people-reassign-endpoint

## Test plan
- [x] All 667 existing tests pass
- [x] Updated reassign tests verify correct source/target mapping
- [x] Linting, formatting, and type checking pass
- [ ] Manual test: use Immich web app to reassign a face and verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)