### PR TITLE
Verify payload FK refs against production (GUM-545)

### DIFF
--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Sync Stream Architecture"
-last-updated: 2026-04-02
+last-updated: 2026-04-16
 ---
 
 # Sync Stream Architecture
@@ -21,11 +21,11 @@ Event types are classified into `_DELETE_EVENT_TYPES` (construct delete sync eve
 
 ## Face person_id Handling
 
-`face_created` events have person_id nulled out (face detection never assigns a person). `face_updated` events use the causally-consistent person_id from the event payload instead of current entity state. After payload override, person_id is nulled if the person returned 404 during fetch (deleted entity) and no person checkpoint exists.
+`face_created` events have person_id nulled out (face detection never assigns a person). `face_updated` events use the causally-consistent person_id from the event payload instead of current entity state. For every face batch, payload person_ids are collected (see `extract_payload_fk_refs`) and verified against production via `people.list` — IDs that return 404 are recorded in `stats.not_found_ids["person"]` and nulled out on the outgoing event, regardless of whether a `PersonV1` checkpoint exists. This prevents stale payload references (from clustering runs that predate a person's deletion) from leaking across sync cycles and causing FK violations on the client.
 
 ## Album Cover Handling
 
-`album_updated` events use the causally-consistent `album_cover_asset_id` from the event payload instead of the entity's current computed cover (which is derived at fetch time via a lateral join and may reference an asset outside the sync window). After payload override, cover is nulled if the asset returned 404 during fetch and no asset checkpoint exists.
+`album_updated` events use the causally-consistent `album_cover_asset_id` from the event payload instead of the entity's current computed cover (which is derived at fetch time via a lateral join and may reference an asset outside the sync window). Payload cover asset IDs are verified against production the same way face person_ids are — 404s null the cover regardless of `AssetV1` checkpoint state.
 
 ## Adding a New Sync Type Version
 

--- a/docs/design-docs/sync-stream-event-ordering.md
+++ b/docs/design-docs/sync-stream-event-ordering.md
@@ -2,7 +2,7 @@
 title: "Sync Stream Event Ordering"
 status: active
 created: 2026-03-13
-last-updated: 2026-03-15
+last-updated: 2026-04-16
 ---
 
 # Sync Stream Event Ordering
@@ -59,6 +59,29 @@ The payload fix solved the time-window problem but introduced a deletion-orderin
 The two-phase fix handles ordering within a sync cycle, but the payload override can still reference an entity that was deleted after the event was recorded. On a fresh sync (no prior data), the deleted entity returns 404 during fetch and is never streamed. The face/album arrives with a reference to a non-existent entity, causing an FK violation.
 
 Fix: after applying a payload override, check if the referenced entity ID is in the set of IDs that returned 404 during fetch (`stats.not_found_ids`). If so, null it out. The guard is skipped when the referenced entity type has a checkpoint, since the entity may exist on the client from a prior sync cycle. Applies to both `face_updated` (person_id) and `album_updated` (album_cover_asset_id).
+
+### Fix 5: Verify payload references against production (GUM-545)
+
+Fix 4 only populated `not_found_ids` for entities deleted within the current sync window — if the referenced entity was deleted before the window started, the adapter never tried to fetch it and had no 404 to record. Combined with Fix 4's checkpoint-skip guard ("the entity may exist on the client from a prior sync cycle"), this leaked stale payload references across cycles:
+
+1. Prior cycle: client acked `person_created P1` and, later, `person_deleted P1`. Client no longer has P1 locally, but `PersonV1` checkpoint has advanced past both events.
+2. Current cycle: `face_updated` with payload `{"person_id": P1}` sits in the face window; no person events remain for the face's clustering runs outside this window.
+3. Fix 4's guard skipped the null-out because `PersonV1` was in `checkpoint_map`. The payload person_id leaked through.
+4. Mobile client tried to insert the face referencing P1 — SQLite FK violation (`asset_face_entity` → `person`), sync stuck.
+
+Concrete production timeline for the face that surfaced GUM-545 (event IDs from photos-api):
+
+- 79099 `person_created P1`
+- 79100 `face_updated` payload person_id=P1
+- 79117 `face_updated` payload person_id=P_mid (clustering reassigned)
+- 79161 `person_deleted P1`
+- 79183 `face_updated` payload person_id=P_final (current state)
+
+Any client whose `AssetFaceV1` checkpoint lags at cursor < 79100 while `PersonV1` is past 79161 will receive the stale event 79100 and FK-fail.
+
+Fix: scan each event batch for payload-referenced FK IDs before streaming (see `extract_payload_fk_refs` in `fk_integrity.py`) and batch-fetch any IDs that are neither already streamed nor already known-404. Missing IDs from that fetch populate `stats.not_found_ids` — which is now authoritative about production existence regardless of the client's checkpoint state. The checkpoint-skip guard in `null_deleted_fk_references` is removed: a confirmed 404 overrides any assumption about what the client may still hold, because the client necessarily processed the corresponding `*_deleted` event in the cycle that advanced its checkpoint. Applies to both `face_updated` (person_id) and `album_updated` (album_cover_asset_id).
+
+Cost: one extra bulk list call per face/album batch that contains payload references to entities not seen elsewhere in the cycle. In practice this is one call per cycle for most sessions.
 
 ## How the Real Immich Server Avoids This
 

--- a/docs/design-docs/sync-stream-event-ordering.md
+++ b/docs/design-docs/sync-stream-event-ordering.md
@@ -110,6 +110,14 @@ If the stream is interrupted between phase 1 (upserts) and phase 2 (deletes), de
 
 This is an acceptable tradeoff: permanently stuck sync (the bug) is far worse than occasionally stale deleted entities (recoverable).
 
+## Known Tradeoff: Fix 5 Verification Uses Current State, Not Snapshot
+
+The Fix 5 verification fetch (`people.list` / `assets.list` for payload-referenced IDs) reads the live production state of those entities, while the surrounding event stream is bounded by `created_at_lt=sync_started_at` (a point-in-time snapshot). If a person or asset is deleted *during* a sync cycle — after `sync_started_at` but before the face/album phase runs the verification — the verification will see a 404 and null the reference even though it was valid at the snapshot. The corresponding `*_deleted` event falls outside the current cycle's window (its cursor > `sync_started_at`), so it arrives in the next cycle instead.
+
+End-state impact: none. The client still receives the delete event in the next cycle; the face/album converges to the same final state (orphan reference, or cascaded to NULL). The only visible difference is a brief interval where the client shows the reference already nulled instead of "valid but about to be deleted." For the concrete GUM-545 FK-violation failure mode this is strictly safer (no stuck sync), and the cosmetic inconsistency resolves within one sync cycle.
+
+Making the verification snapshot-aware would require either an event-timeline check (query for `*_deleted` events with cursor ≤ `sync_started_at`) or a cross-repo `as_of` parameter on the list endpoints. Both add meaningful complexity for a cosmetic win; not implemented.
+
 ## Future Alternative: Direct Entity Queries
 
 A potential long-term alternative is querying entity endpoints directly (like the real Immich server) rather than replaying events:

--- a/docs/design-docs/sync-stream-event-ordering.md
+++ b/docs/design-docs/sync-stream-event-ordering.md
@@ -81,7 +81,7 @@ Any client whose `AssetFaceV1` checkpoint lags at cursor < 79100 while `PersonV1
 
 Fix: scan each event batch for payload-referenced FK IDs before streaming (see `extract_payload_fk_refs` in `fk_integrity.py`) and batch-fetch any IDs that are neither already streamed nor already known-404. Missing IDs from that fetch populate `stats.not_found_ids` — which is now authoritative about production existence regardless of the client's checkpoint state. The checkpoint-skip guard in `null_deleted_fk_references` is removed: a confirmed 404 overrides any assumption about what the client may still hold, because the client necessarily processed the corresponding `*_deleted` event in the cycle that advanced its checkpoint. Applies to both `face_updated` (person_id) and `album_updated` (album_cover_asset_id).
 
-Cost: one extra bulk list call per face/album batch that contains payload references to entities not seen elsewhere in the cycle. In practice this is one call per cycle for most sessions.
+Cost: one extra bulk list call per event batch per referenced type for IDs not yet streamed or already-known 404 in this cycle. Verified-present IDs are not memoized across batches, so a live entity referenced by events spanning multiple `EVENTS_PAGE_SIZE=200` batches (e.g., large re-clustering runs) is re-fetched once per batch. In practice this collapses to one call per cycle per referenced type for most sessions (single batch, single call).
 
 ## How the Real Immich Server Avoids This
 

--- a/routers/api/sync/fk_integrity.py
+++ b/routers/api/sync/fk_integrity.py
@@ -3,7 +3,9 @@
 import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, NamedTuple
+
+from gumnut.types.events_response import Data as EventData
 
 from routers.immich_models import SyncEntityType
 from routers.api.sync.types import EntityType
@@ -16,6 +18,41 @@ FK_REFERENCES: dict[str, list[tuple[str, str]]] = {
     "face": [("person_id", "person"), ("asset_id", "asset")],
     "album_asset": [("album_id", "album"), ("asset_id", "asset")],
     "album": [("album_cover_asset_id", "asset")],
+}
+
+
+class PayloadFKOverride(NamedTuple):
+    """Declares a payload key the adapter applies as a causally-consistent FK override.
+
+    event_type: the event_type on which this override is applied (e.g. "face_updated").
+    payload_key: the key in event.payload carrying the referenced ID.
+    referenced_type: the gumnut entity type that the ID refers to (e.g. "person").
+    """
+
+    event_type: str
+    payload_key: str
+    referenced_type: str
+
+
+# Payload keys that the adapter applies as causally-consistent FK overrides
+# (see payload_override). Used to collect referenced IDs up front so we can
+# verify they still exist in production, regardless of whether the referenced
+# entity type is being streamed in this cycle.
+PAYLOAD_FK_OVERRIDES: dict[str, list[PayloadFKOverride]] = {
+    "face": [
+        PayloadFKOverride(
+            event_type="face_updated",
+            payload_key="person_id",
+            referenced_type="person",
+        ),
+    ],
+    "album": [
+        PayloadFKOverride(
+            event_type="album_updated",
+            payload_key="album_cover_asset_id",
+            referenced_type="asset",
+        ),
+    ],
 }
 
 # Map gumnut entity type -> SyncEntityType(s) for FK checkpoint lookups.
@@ -119,15 +156,21 @@ def null_deleted_fk_references(
     gumnut_entity_type: str,
     entity: EntityType,
     stats: SyncStreamStats,
-    checkpoint_map: dict[SyncEntityType, Checkpoint],
     event_type: str,
     cursor: str,
 ) -> EntityType:
     """Null FK fields that reference entities confirmed deleted (404 during fetch).
 
-    Uses FK_REFERENCES to discover which fields to check. Skips fields whose
-    referenced entity type has a checkpoint — the entity may exist on the
-    client from a prior sync cycle.
+    Uses FK_REFERENCES to discover which fields to check. A 404 in
+    ``stats.not_found_ids`` is authoritative for this sync cycle — the entity
+    does not exist in production, so the client must not hold a reference to
+    it regardless of any prior-cycle checkpoint (the client may have processed
+    the delete in an earlier cycle and no longer has the entity locally).
+
+    Callers are responsible for populating ``stats.not_found_ids`` for payload-
+    referenced types that are not otherwise streamed (see
+    ``extract_payload_fk_refs`` and the verification step in
+    ``_stream_entity_type``).
 
     Returns the (possibly updated) entity.
     """
@@ -139,10 +182,6 @@ def null_deleted_fk_references(
     for attr_name, ref_type in refs:
         ref_id = getattr(entity, attr_name, None)
         if ref_id is None:
-            continue
-
-        ref_sync_types = _GUMNUT_TYPE_TO_SYNC_TYPES.get(ref_type)
-        if ref_sync_types and any(t in checkpoint_map for t in ref_sync_types):
             continue
 
         if ref_id in stats.not_found_ids.get(ref_type, set()):
@@ -164,3 +203,36 @@ def null_deleted_fk_references(
         entity = entity.model_copy(update=updates)
 
     return entity
+
+
+def extract_payload_fk_refs(
+    gumnut_entity_type: str,
+    events: list[EventData],
+) -> dict[str, set[str]]:
+    """Collect payload-referenced FK IDs from a batch of events.
+
+    For each event whose payload carries a causally-consistent FK override
+    (see ``PAYLOAD_FK_OVERRIDES``), extract the referenced ID and group by
+    referenced entity type. Returns ``{ref_type: {ref_ids...}}``.
+
+    The caller uses this set to verify those IDs still exist in production
+    before the face/album event is streamed to the client. Without this check
+    the adapter would send references to entities deleted between sync cycles,
+    causing FK violations on the mobile client.
+    """
+    overrides = PAYLOAD_FK_OVERRIDES.get(gumnut_entity_type)
+    if not overrides:
+        return {}
+
+    result: dict[str, set[str]] = defaultdict(set)
+    for event in events:
+        if not isinstance(event.payload, dict):
+            continue
+        for override in overrides:
+            if event.event_type != override.event_type:
+                continue
+            should_apply, value = payload_override(event.payload, override.payload_key)
+            if should_apply and value is not None:
+                result[override.referenced_type].add(value)
+
+    return result

--- a/routers/api/sync/fk_integrity.py
+++ b/routers/api/sync/fk_integrity.py
@@ -38,6 +38,11 @@ class PayloadFKOverride(NamedTuple):
 # (see payload_override). Used to collect referenced IDs up front so we can
 # verify they still exist in production, regardless of whether the referenced
 # entity type is being streamed in this cycle.
+#
+# Invariant: every (event_type, payload_key, referenced_type) entry here must
+# have a matching (field=payload_key, referenced_type) entry in FK_REFERENCES
+# for the same entity type — otherwise null_deleted_fk_references will not
+# null the payload-overridden field when its referenced entity 404s.
 PAYLOAD_FK_OVERRIDES: dict[str, list[PayloadFKOverride]] = {
     "face": [
         PayloadFKOverride(

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -209,6 +209,15 @@ async def _stream_entity_type(
             missing = unknown_ids - ref_map.keys()
             if missing:
                 stats.not_found_ids[ref_type].update(missing)
+                logger.info(
+                    "Payload FK verification found deleted entities",
+                    extra={
+                        "entity_type": gumnut_entity_type,
+                        "referenced_type": ref_type,
+                        "missing_count": len(missing),
+                        "missing_ids": sorted(missing),
+                    },
+                )
 
         # Process events in order
         for event in events:

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -40,6 +40,7 @@ from routers.api.sync.events import (
 from routers.api.sync.fk_integrity import (
     SyncStreamStats,
     check_fk_references,
+    extract_payload_fk_refs,
     null_deleted_fk_references,
     payload_override,
 )
@@ -184,6 +185,31 @@ async def _stream_entity_type(
         if not_returned:
             stats.not_found_ids[gumnut_entity_type].update(not_returned)
 
+        # Verify that IDs referenced in event payloads (e.g. face_updated's
+        # person_id, album_updated's album_cover_asset_id) still exist in
+        # production. The payload override captures the causally-consistent
+        # value at event time, but the referenced entity may have been deleted
+        # since. A confirmed 404 adds the ID to stats.not_found_ids so
+        # null_deleted_fk_references can strip the reference before the event
+        # reaches the client — otherwise the client hits a SQLite FK violation
+        # (e.g., asset_face_entity → person) on insert. See the
+        # sync-stream-event-ordering design doc, "Fix 5".
+        payload_refs = extract_payload_fk_refs(gumnut_entity_type, events)
+        for ref_type, ref_ids in payload_refs.items():
+            unknown_ids = (
+                ref_ids
+                - stats.streamed_ids.get(ref_type, set())
+                - stats.not_found_ids.get(ref_type, set())
+            )
+            if not unknown_ids:
+                continue
+            ref_map, _ = await fetch_entities_map(
+                gumnut_client, ref_type, list(unknown_ids)
+            )
+            missing = unknown_ids - ref_map.keys()
+            if missing:
+                stats.not_found_ids[ref_type].update(missing)
+
         # Process events in order
         for event in events:
             if event.event_type in _SKIPPED_EVENT_TYPES:
@@ -298,14 +324,15 @@ async def _stream_entity_type(
                         )
 
                 # Null FK fields that reference entities confirmed deleted
-                # (returned 404 during fetch). Uses FK_REFERENCES to
-                # discover which fields to check. Skipped when the
-                # referenced entity type has a checkpoint.
+                # (returned 404 during fetch or payload-ref verification above).
+                # A confirmed 404 is authoritative regardless of the client's
+                # checkpoint state — if the entity is gone in prod, any prior
+                # client copy has been cleaned up by an earlier person/asset
+                # delete event.
                 entity = null_deleted_fk_references(
                     gumnut_entity_type,
                     entity,
                     stats,
-                    checkpoint_map,
                     event.event_type,
                     event.cursor,
                 )

--- a/tests/unit/api/sync/test_sync_stream_payload.py
+++ b/tests/unit/api/sync/test_sync_stream_payload.py
@@ -25,6 +25,7 @@ from tests.unit.api.sync.conftest import (
     TEST_UUID,
     collect_stream,
     create_mock_album_data,
+    create_mock_asset_data,
     create_mock_entity_page,
     create_mock_event,
     create_mock_events_response,
@@ -285,8 +286,16 @@ class TestFacePersonIdOverride:
             payload={"person_id": payload_person_id},
         )
 
+        # The adapter verifies payload-referenced people exist in production
+        # before using them; mock people.list to return the referenced person.
+        payload_person_data = create_mock_person_data(updated_at)
+        payload_person_data.id = payload_person_id
+
         mock_client.events.get.return_value = create_mock_events_response([face_event])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.people.list.return_value = create_mock_entity_page(
+            [payload_person_data]
+        )
 
         sync_started_at = datetime(2025, 1, 20, 10, 0, 0, tzinfo=timezone.utc)
 
@@ -486,13 +495,35 @@ class TestAlbumCoverPayloadOverride:
         self,
         album_data: Any,
         album_event: Any,
+        payload_cover_assets: list[Any] | None = None,
     ) -> dict[str, Any]:
-        """Stream a single album event and return the parsed sync event data."""
+        """Stream a single album event and return the parsed sync event data.
+
+        ``payload_cover_assets`` lets callers control what the adapter sees
+        when it verifies that a payload-referenced album_cover_asset_id still
+        exists in production. Default (None): treat the referenced asset as
+        extant by mirroring the payload cover id into an asset mock so the
+        verification fetch succeeds. Pass an empty list to simulate the asset
+        being deleted.
+        """
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)
         mock_client.events.get.return_value = create_mock_events_response([album_event])
         mock_client.albums.list.return_value = create_mock_entity_page([album_data])
+
+        if payload_cover_assets is None:
+            payload_cover_id: str | None = None
+            if isinstance(album_event.payload, dict):
+                payload_cover_id = album_event.payload.get("album_cover_asset_id")
+            payload_cover_assets = []
+            if payload_cover_id:
+                cover_asset = create_mock_asset_data(updated_at)
+                cover_asset.id = payload_cover_id
+                payload_cover_assets = [cover_asset]
+        mock_client.assets.list.return_value = create_mock_entity_page(
+            payload_cover_assets
+        )
 
         results = []
         async for item in _stream_entity_type(
@@ -701,15 +732,17 @@ class TestFacePayloadOverrideDeletedPerson:
 
     @pytest.mark.anyio
     async def test_face_updated_keeps_person_id_when_person_synced_prior_cycle(self):
-        """face_updated payload person_id is kept when person was synced in a prior cycle.
+        """face_updated payload person_id is kept when person still exists in prod.
 
         Scenario (incremental sync, person checkpoint exists):
         1. Person P1 was synced in a prior cycle (client has it locally)
         2. face_updated event recorded with person_id=P1 in payload
         3. Person P1 is NOT modified in this sync window (no person events)
-        4. The adapter should keep person_id=P1 -- the client already has it
+        4. Person P1 still exists in production (verification fetch returns it)
+        5. The adapter should keep person_id=P1 -- the client has it locally
+           and the reference is still valid
 
-        This ensures the fix for deleted persons doesn't break incremental syncs
+        This ensures the Fix 5 verification doesn't break incremental syncs
         where the person exists but simply wasn't modified in this window.
         """
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
@@ -733,8 +766,15 @@ class TestFacePayloadOverrideDeletedPerson:
             payload={"person_id": payload_person_id},
         )
 
+        # Verification fetch: P1 still exists in production
+        payload_person_data = create_mock_person_data(updated_at)
+        payload_person_data.id = payload_person_id
+
         mock_client.events.get.return_value = create_mock_events_response([face_event])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.people.list.return_value = create_mock_entity_page(
+            [payload_person_data]
+        )
 
         sync_started_at = datetime(2025, 1, 20, 10, 0, 0, tzinfo=timezone.utc)
 
@@ -1017,6 +1057,98 @@ class TestFacePayloadOverrideDeletedPerson:
                 f"person was deleted (404)"
             )
 
+    @pytest.mark.anyio
+    async def test_face_updated_nulls_person_id_when_person_deleted_across_cycles(
+        self,
+    ):
+        """GUM-545 regression: deleted person across sync cycles still nulls out.
+
+        The Fix 4 guard only covered fresh syncs: it skipped the null-out when
+        a PersonV1 checkpoint existed, assuming "the client must still have
+        this person from a prior sync." That assumption is wrong when the
+        person was deleted server-side between cycles — the client's
+        person_deleted event already removed it locally.
+
+        Scenario (reproduces GUM-545):
+        - Prior cycle(s): client received person P1 (checkpoint advanced past
+          P1 creation) and the subsequent person_deleted P1 (checkpoint past
+          delete). Client no longer has P1 locally.
+        - Current cycle: no new person events (all that's left for faces).
+          face_updated event for F is in the window with payload person_id=P1
+          (stale reference from when clustering assigned F to P1).
+        - The adapter must verify P1 still exists in prod and, seeing it
+          doesn't (404), null out the reference — even though PersonV1 has a
+          checkpoint.
+        """
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        mock_user = create_mock_user(updated_at)
+        mock_client = create_mock_gumnut_client(mock_user)
+
+        # The deleted person's ID (not in the current window, not returned
+        # by people.list — matches production state where the person is gone)
+        deleted_person_uuid = UUID("00000000-0000-0000-0000-000000000099")
+        deleted_person_id = uuid_to_gumnut_person_id(deleted_person_uuid)
+
+        # Face currently references a different live person (re-clustered)
+        face_data = create_mock_face_data(updated_at)
+        assert face_data.person_id != deleted_person_id
+
+        # face_updated event's payload carries the stale deleted person_id
+        face_event = create_mock_event(
+            entity_type="face",
+            entity_id=face_data.id,
+            event_type="face_updated",
+            created_at=updated_at,
+            cursor="cursor_face_1",
+            payload={"person_id": deleted_person_id},
+        )
+
+        mock_client.events.get.return_value = create_mock_events_response([face_event])
+        mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        # Verification fetch returns empty — person is deleted in prod
+        mock_client.people.list.return_value = create_mock_entity_page([])
+
+        sync_started_at = datetime(2025, 1, 20, 10, 0, 0, tzinfo=timezone.utc)
+
+        # PersonV1 checkpoint exists: client synced persons in a prior cycle
+        # (and processed the delete event for this person). This is the state
+        # that made Fix 4 skip the null-out and leak the stale reference.
+        checkpoint_map = {
+            SyncEntityType.PersonV1: Checkpoint(
+                entity_type=SyncEntityType.PersonV1,
+                cursor="prior_cursor",
+                updated_at=updated_at,
+            ),
+        }
+
+        stats = SyncStreamStats()
+        results = []
+        async for item in _stream_entity_type(
+            gumnut_client=mock_client,
+            gumnut_entity_type="face",
+            sync_entity_type=SyncEntityType.AssetFaceV1,
+            owner_id=str(TEST_UUID),
+            checkpoint=None,
+            sync_started_at=sync_started_at,
+            stats=stats,
+            checkpoint_map=checkpoint_map,
+        ):
+            results.append(item)
+
+        assert len(results) == 1
+        json_line, _count = results[0]
+        event_data = json.loads(json_line.strip())
+
+        assert event_data["data"]["personId"] is None, (
+            "face_updated must null person_id when the payload references a "
+            "person deleted in a prior cycle — PersonV1 checkpoint does not "
+            "prove the client still holds the person locally"
+        )
+        assert deleted_person_id in stats.not_found_ids["person"], (
+            "Verification step should have recorded the deleted person in "
+            "not_found_ids so null_deleted_fk_references can strip the reference"
+        )
+
 
 class TestAlbumPayloadOverrideDeletedAsset:
     """Tests for album_updated payload override when the referenced asset is deleted.
@@ -1101,6 +1233,75 @@ class TestAlbumPayloadOverrideDeletedAsset:
             "asset was deleted (404 on fetch)"
         )
 
+    @pytest.mark.anyio
+    async def test_album_updated_nulls_cover_when_asset_deleted_across_cycles(self):
+        """Same GUM-545 failure mode, applied to album cover references.
+
+        Scenario: client has an AssetV1 checkpoint past the cover asset's
+        delete. The current cycle replays an older album_updated event whose
+        payload references the deleted asset. Fix 5 must verify the asset
+        still exists in prod and null the reference on 404, even though an
+        AssetV1 checkpoint exists.
+        """
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        mock_user = create_mock_user(updated_at)
+        mock_client = create_mock_gumnut_client(mock_user)
+
+        deleted_asset_uuid = UUID("00000000-0000-0000-0000-000000000088")
+        deleted_asset_id = uuid_to_gumnut_asset_id(deleted_asset_uuid)
+
+        album_data = create_mock_album_data(
+            updated_at, album_cover_asset_id=None, asset_count=0
+        )
+        album_event = create_mock_event(
+            entity_type="album",
+            entity_id=album_data.id,
+            event_type="album_updated",
+            created_at=updated_at,
+            cursor="cursor_a1",
+            payload={"album_cover_asset_id": deleted_asset_id},
+        )
+
+        mock_client.events.get.return_value = create_mock_events_response([album_event])
+        mock_client.albums.list.return_value = create_mock_entity_page([album_data])
+        # Verification fetch returns empty -- the asset was deleted in prod
+        mock_client.assets.list.return_value = create_mock_entity_page([])
+
+        sync_started_at = datetime(2025, 1, 20, 10, 0, 0, tzinfo=timezone.utc)
+
+        checkpoint_map = {
+            SyncEntityType.AssetV1: Checkpoint(
+                entity_type=SyncEntityType.AssetV1,
+                cursor="prior_cursor",
+                updated_at=updated_at,
+            ),
+        }
+
+        stats = SyncStreamStats()
+        results = []
+        async for item in _stream_entity_type(
+            gumnut_client=mock_client,
+            gumnut_entity_type="album",
+            sync_entity_type=SyncEntityType.AlbumV1,
+            owner_id=str(TEST_UUID),
+            checkpoint=None,
+            sync_started_at=sync_started_at,
+            stats=stats,
+            checkpoint_map=checkpoint_map,
+        ):
+            results.append(item)
+
+        assert len(results) == 1
+        json_line, _count = results[0]
+        event_data = json.loads(json_line.strip())
+
+        assert event_data["data"]["thumbnailAssetId"] is None, (
+            "album_updated must null thumbnailAssetId when the payload cover "
+            "references an asset deleted across sync cycles, even with an "
+            "AssetV1 checkpoint"
+        )
+        assert deleted_asset_id in stats.not_found_ids["asset"]
+
 
 class TestAssetFaceV2Converter:
     """Tests for the AssetFaceV2 sync converter."""
@@ -1172,8 +1373,15 @@ class TestAssetFaceV2Converter:
             payload={"person_id": payload_person_id},
         )
 
+        # Verification fetch: the payload-referenced person still exists in prod
+        payload_person_data = create_mock_person_data(updated_at)
+        payload_person_data.id = payload_person_id
+
         mock_client.events.get.return_value = create_mock_events_response([face_event])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.people.list.return_value = create_mock_entity_page(
+            [payload_person_data]
+        )
 
         sync_started_at = datetime(2025, 1, 20, 10, 0, 0, tzinfo=timezone.utc)
 

--- a/tests/unit/api/sync/test_sync_stream_payload.py
+++ b/tests/unit/api/sync/test_sync_stream_payload.py
@@ -1061,15 +1061,15 @@ class TestFacePayloadOverrideDeletedPerson:
     async def test_face_updated_nulls_person_id_when_person_deleted_across_cycles(
         self,
     ):
-        """GUM-545 regression: deleted person across sync cycles still nulls out.
+        """Regression: payload references to persons deleted across sync cycles must be nulled.
 
-        The Fix 4 guard only covered fresh syncs: it skipped the null-out when
-        a PersonV1 checkpoint existed, assuming "the client must still have
-        this person from a prior sync." That assumption is wrong when the
-        person was deleted server-side between cycles — the client's
-        person_deleted event already removed it locally.
+        The prior fix's checkpoint-skip guard covered only fresh syncs: it
+        skipped the null-out when a PersonV1 checkpoint existed, assuming
+        "the client must still have this person from a prior sync." That
+        assumption is wrong when the person was deleted server-side between
+        cycles — the client's person_deleted event already removed it locally.
 
-        Scenario (reproduces GUM-545):
+        Scenario:
         - Prior cycle(s): client received person P1 (checkpoint advanced past
           P1 creation) and the subsequent person_deleted P1 (checkpoint past
           delete). Client no longer has P1 locally.
@@ -1235,13 +1235,15 @@ class TestAlbumPayloadOverrideDeletedAsset:
 
     @pytest.mark.anyio
     async def test_album_updated_nulls_cover_when_asset_deleted_across_cycles(self):
-        """Same GUM-545 failure mode, applied to album cover references.
+        """Regression: payload cover references to assets deleted across cycles must be nulled.
 
-        Scenario: client has an AssetV1 checkpoint past the cover asset's
-        delete. The current cycle replays an older album_updated event whose
-        payload references the deleted asset. Fix 5 must verify the asset
-        still exists in prod and null the reference on 404, even though an
-        AssetV1 checkpoint exists.
+        Same cross-cycle failure mode as faces: the client has an AssetV1
+        checkpoint past the cover asset's delete event. The current cycle
+        replays an older album_updated event whose payload references the
+        deleted asset. The adapter must verify the asset still exists in prod
+        and null the reference on 404, even though an AssetV1 checkpoint
+        exists (the checkpoint does not prove the client still holds the
+        asset locally — it has already processed the delete).
         """
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)


### PR DESCRIPTION
## Summary

- Fixes a cross-cycle FK-violation bug where mobile clients with a `PersonV1` checkpoint past a `person_deleted` event still received stale `face_updated` events referencing that person, causing `SqliteException(787) FOREIGN KEY constraint failed` on `asset_face_entity` insert and stuck sync.
- Adds a payload-FK verification step in `_stream_entity_type`: for each face/album batch, payload-referenced FK IDs (`face_updated.person_id`, `album_updated.album_cover_asset_id`) are collected via a new `extract_payload_fk_refs` helper and verified against production. Confirmed 404s populate `stats.not_found_ids`, which is now authoritative regardless of the client's checkpoint state — the old checkpoint-skip guard in `null_deleted_fk_references` is removed.
- Updates the `sync-stream-event-ordering` design doc with a Fix 5 section (including the concrete production timeline that surfaced the bug) and the `sync-stream-architecture` overview's person/cover handling notes.

## Linear

https://linear.app/gumnut-ai/issue/GUM-545/debug-another-sync-issue

## Test plan

- [x] `uv run pytest` — all 669 tests pass
- [x] `uv run ruff format` / `uv run ruff check` clean
- [x] `uv run pyright` — 0 errors
- [x] New regression tests assert both face and album cross-cycle scenarios (`test_face_updated_nulls_person_id_when_person_deleted_across_cycles`, `test_album_updated_nulls_cover_when_asset_deleted_across_cycles`), including that `stats.not_found_ids` is populated as expected
- [x] Three existing tests updated whose default empty list mocks would now trigger the new null-out (verification step only treats an ID as 404 when the fetch confirms absence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)