### PR TITLE
Tag Sentry transactions with interaction channel (GUM-561)

### DIFF
--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -61,6 +61,8 @@ This format is enforced by the global exception handler in `config/exceptions.py
 
 **Note:** In middleware (e.g., `auth_middleware.py`), you must return `JSONResponse` directly with this format, as `HTTPException` raised in `BaseHTTPMiddleware.dispatch()` is not caught by FastAPI's exception handlers due to Starlette's middleware architecture.
 
+**Middleware registration order:** `app.add_middleware()` prepends to the Starlette stack — the **last** `add_middleware` call wraps outermost and runs **first** on every request. Middleware that must run before an auth or rate-limit short-circuit (e.g., Sentry tags that should attach even on 401/429) must be added last in `main.py`, not first.
+
 For the full error handling strategy including rate limit protection and per-item error tracking, see the [adapter architecture doc](../architecture/adapter-architecture.md#error-handling).
 
 ### Defining Endpoint Parameters

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from config.logging import init_logging
 from contextlib import asynccontextmanager
 
 from routers.middleware.auth_middleware import AuthMiddleware
+from routers.middleware.channel_middleware import ChannelTaggingMiddleware
 from routers import static, well_known
 from routers.utils.spa_static_files import SPAStaticFiles
 from routers.api.sync import routes as sync_routes
@@ -90,6 +91,11 @@ configure_exception_handlers(app)
 
 # Add authentication middleware
 app.add_middleware(AuthMiddleware)
+
+# Tag Sentry transactions with the interaction channel (mobile / web / generic).
+# Added last so it wraps outermost in the Starlette stack and runs before
+# AuthMiddleware — guarantees the tag is attached even on 401 responses.
+app.add_middleware(ChannelTaggingMiddleware)
 
 # Mount Socket.IO app first
 app.mount("/api/socket.io", websockets.socket_app)

--- a/routers/middleware/channel_middleware.py
+++ b/routers/middleware/channel_middleware.py
@@ -2,8 +2,8 @@
 
 Every request into immich-adapter gets a `channel` tag indicating how the
 user interacted: `immich-mobile-android`, `immich-mobile-ios`, `immich-web`,
-or the generic `immich-adapter` fallback when the User-Agent doesn't match
-any known client. Unlike the photos-api equivalent middleware — which leaves
+or the generic `immich-api` fallback when the User-Agent doesn't match any
+known client. Unlike the photos-api equivalent middleware — which leaves
 unclassified requests untagged — every request here is tagged because all
 traffic through this service is adapter traffic by definition. Tagging at
 request entry lets Sentry aggregate traffic, latency, and error rates per
@@ -48,7 +48,7 @@ def resolve_channel(user_agent: str) -> str:
     if ua.startswith("Mozilla/") and _BROWSER_RE.search(ua):
         return "immich-web"
 
-    return "immich-adapter"
+    return "immich-api"
 
 
 class ChannelTaggingMiddleware(BaseHTTPMiddleware):

--- a/routers/middleware/channel_middleware.py
+++ b/routers/middleware/channel_middleware.py
@@ -3,8 +3,11 @@
 Every request into immich-adapter gets a `channel` tag indicating how the
 user interacted: `immich-mobile-android`, `immich-mobile-ios`, `immich-web`,
 or the generic `immich-adapter` fallback when the User-Agent doesn't match
-any known client. Tagging at request entry lets Sentry aggregate traffic,
-latency, and error rates per channel without sampling Render request logs.
+any known client. Unlike the photos-api equivalent middleware — which leaves
+unclassified requests untagged — every request here is tagged because all
+traffic through this service is adapter traffic by definition. Tagging at
+request entry lets Sentry aggregate traffic, latency, and error rates per
+channel without sampling Render request logs.
 """
 
 from __future__ import annotations
@@ -23,7 +26,7 @@ CHANNEL_TAG = "channel"
 # `immich-{ios,android}/<version>` form documented in the GUM-561 spec as a
 # safety net for future client versions.
 _IMMICH_MOBILE_RE = re.compile(
-    r"^(?:Immich_(?P<platform1>iOS|Android)_|immich-(?P<platform2>ios|android)/)",
+    r"^(?:Immich_|immich-)(ios|android)[_/]",
     re.IGNORECASE,
 )
 
@@ -36,7 +39,7 @@ def resolve_channel(user_agent: str) -> str:
 
     match = _IMMICH_MOBILE_RE.match(ua)
     if match:
-        platform = (match.group("platform1") or match.group("platform2") or "").lower()
+        platform = match.group(1).lower()
         if platform == "android":
             return "immich-mobile-android"
         if platform == "ios":

--- a/routers/middleware/channel_middleware.py
+++ b/routers/middleware/channel_middleware.py
@@ -1,0 +1,63 @@
+"""Tag Sentry transactions with the interaction channel for immich-adapter.
+
+Every request into immich-adapter gets a `channel` tag indicating how the
+user interacted: `immich-mobile-android`, `immich-mobile-ios`, `immich-web`,
+or the generic `immich-adapter` fallback when the User-Agent doesn't match
+any known client. Tagging at request entry lets Sentry aggregate traffic,
+latency, and error rates per channel without sampling Render request logs.
+"""
+
+from __future__ import annotations
+
+import re
+
+import sentry_sdk
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
+
+CHANNEL_TAG = "channel"
+
+# Immich mobile app UAs are `Immich_iOS_<version>` / `Immich_Android_<version>`
+# (the format emitted by the Immich clients). We also accept the lower-case
+# `immich-{ios,android}/<version>` form documented in the GUM-561 spec as a
+# safety net for future client versions.
+_IMMICH_MOBILE_RE = re.compile(
+    r"^(?:Immich_(?P<platform1>iOS|Android)_|immich-(?P<platform2>ios|android)/)",
+    re.IGNORECASE,
+)
+
+_BROWSER_RE = re.compile(r"\b(Chrome|Safari|Firefox)\b")
+
+
+def resolve_channel(user_agent: str) -> str:
+    """Classify an immich-adapter request into an interaction channel."""
+    ua = user_agent or ""
+
+    match = _IMMICH_MOBILE_RE.match(ua)
+    if match:
+        platform = (match.group("platform1") or match.group("platform2") or "").lower()
+        if platform == "android":
+            return "immich-mobile-android"
+        if platform == "ios":
+            return "immich-mobile-ios"
+
+    if ua.startswith("Mozilla/") and _BROWSER_RE.search(ua):
+        return "immich-web"
+
+    return "immich-adapter"
+
+
+class ChannelTaggingMiddleware(BaseHTTPMiddleware):
+    """Tag the active Sentry transaction with the request's interaction channel."""
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        channel = resolve_channel(request.headers.get("user-agent", ""))
+        sentry_sdk.set_tag(CHANNEL_TAG, channel)
+        span = sentry_sdk.get_current_span()
+        if span is not None:
+            span.set_data(CHANNEL_TAG, channel)
+
+        return await call_next(request)

--- a/tests/unit/middleware/test_channel_middleware.py
+++ b/tests/unit/middleware/test_channel_middleware.py
@@ -111,3 +111,40 @@ class TestChannelTaggingMiddleware:
 
         assert response.status_code == 200
         mock_set_tag.assert_called_once_with(CHANNEL_TAG, "immich-mobile-ios")
+
+    def test_tag_set_before_early_rejection(self):
+        """Verify ChannelTaggingMiddleware runs outermost, so responses from a
+        downstream middleware that short-circuits (e.g., AuthMiddleware 401)
+        still have the channel tag attached."""
+        from starlette.middleware.base import BaseHTTPMiddleware
+        from starlette.responses import JSONResponse
+
+        class _ShortCircuit401(BaseHTTPMiddleware):
+            async def dispatch(self, request, call_next):
+                return JSONResponse({"detail": "unauthorized"}, status_code=401)
+
+        app = FastAPI()
+        # Mirror the registration order in main.py: auth-type middleware first,
+        # ChannelTaggingMiddleware last (wraps outermost, runs first).
+        app.add_middleware(_ShortCircuit401)
+        app.add_middleware(ChannelTaggingMiddleware)
+
+        @app.get("/api/assets")
+        async def _assets():
+            return {"ok": True}
+
+        with (
+            patch(
+                "routers.middleware.channel_middleware.sentry_sdk.set_tag"
+            ) as mock_set_tag,
+            patch(
+                "routers.middleware.channel_middleware.sentry_sdk.get_current_span",
+                return_value=None,
+            ),
+        ):
+            response = TestClient(app).get(
+                "/api/assets", headers={"user-agent": "Immich_iOS_1.94.0"}
+            )
+
+        assert response.status_code == 401
+        mock_set_tag.assert_called_once_with(CHANNEL_TAG, "immich-mobile-ios")

--- a/tests/unit/middleware/test_channel_middleware.py
+++ b/tests/unit/middleware/test_channel_middleware.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 
 from routers.middleware.channel_middleware import (
     CHANNEL_TAG,
@@ -39,11 +41,11 @@ class TestResolveChannel:
                 "Firefox/125.0",
                 "immich-web",
             ),
-            # Unknown UAs fall back to generic immich-adapter tag
-            ("", "immich-adapter"),
-            ("curl/8.4.0", "immich-adapter"),
-            ("Mozilla/5.0 (unknown bot)", "immich-adapter"),
-            ("Python/3.13 requests/2.31", "immich-adapter"),
+            # Unknown UAs fall back to the generic immich-api tag
+            ("", "immich-api"),
+            ("curl/8.4.0", "immich-api"),
+            ("Mozilla/5.0 (unknown bot)", "immich-api"),
+            ("Python/3.13 requests/2.31", "immich-api"),
         ],
     )
     def test_classification(self, user_agent: str, expected: str):
@@ -71,8 +73,8 @@ class TestChannelTaggingMiddleware:
                 "Mozilla/5.0 (Macintosh) AppleWebKit/605 Chrome/122",
                 "immich-web",
             ),
-            ("curl/8.4.0", "immich-adapter"),
-            ("", "immich-adapter"),
+            ("curl/8.4.0", "immich-api"),
+            ("", "immich-api"),
         ],
     )
     def test_tag_set_on_active_scope(
@@ -116,8 +118,6 @@ class TestChannelTaggingMiddleware:
         """Verify ChannelTaggingMiddleware runs outermost, so responses from a
         downstream middleware that short-circuits (e.g., AuthMiddleware 401)
         still have the channel tag attached."""
-        from starlette.middleware.base import BaseHTTPMiddleware
-        from starlette.responses import JSONResponse
 
         class _ShortCircuit401(BaseHTTPMiddleware):
             async def dispatch(self, request, call_next):

--- a/tests/unit/middleware/test_channel_middleware.py
+++ b/tests/unit/middleware/test_channel_middleware.py
@@ -1,0 +1,113 @@
+"""Unit tests for ChannelTaggingMiddleware."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from routers.middleware.channel_middleware import (
+    CHANNEL_TAG,
+    ChannelTaggingMiddleware,
+    resolve_channel,
+)
+
+
+class TestResolveChannel:
+    @pytest.mark.parametrize(
+        "user_agent,expected",
+        [
+            # Immich mobile apps (actual client UA format)
+            ("Immich_iOS_1.94.0", "immich-mobile-ios"),
+            ("Immich_Android_1.95.1", "immich-mobile-android"),
+            # Lower-case spec format
+            ("immich-ios/1.94.0", "immich-mobile-ios"),
+            ("immich-android/1.95.1", "immich-mobile-android"),
+            # Browsers
+            (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_4) AppleWebKit/605.1.15 "
+                "(KHTML, like Gecko) Version/17.4 Safari/605.1.15",
+                "immich-web",
+            ),
+            (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+                "immich-web",
+            ),
+            (
+                "Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 "
+                "Firefox/125.0",
+                "immich-web",
+            ),
+            # Unknown UAs fall back to generic immich-adapter tag
+            ("", "immich-adapter"),
+            ("curl/8.4.0", "immich-adapter"),
+            ("Mozilla/5.0 (unknown bot)", "immich-adapter"),
+            ("Python/3.13 requests/2.31", "immich-adapter"),
+        ],
+    )
+    def test_classification(self, user_agent: str, expected: str):
+        assert resolve_channel(user_agent) == expected
+
+
+class TestChannelTaggingMiddleware:
+    @pytest.fixture
+    def client(self):
+        app = FastAPI()
+        app.add_middleware(ChannelTaggingMiddleware)
+
+        @app.get("/api/ping")
+        async def _ping():
+            return {"ok": True}
+
+        return TestClient(app)
+
+    @pytest.mark.parametrize(
+        "user_agent,expected",
+        [
+            ("Immich_iOS_1.94.0", "immich-mobile-ios"),
+            ("Immich_Android_1.95.1", "immich-mobile-android"),
+            (
+                "Mozilla/5.0 (Macintosh) AppleWebKit/605 Chrome/122",
+                "immich-web",
+            ),
+            ("curl/8.4.0", "immich-adapter"),
+            ("", "immich-adapter"),
+        ],
+    )
+    def test_tag_set_on_active_scope(
+        self, client: TestClient, user_agent: str, expected: str
+    ):
+        mock_span = MagicMock()
+        with (
+            patch(
+                "routers.middleware.channel_middleware.sentry_sdk.set_tag"
+            ) as mock_set_tag,
+            patch(
+                "routers.middleware.channel_middleware.sentry_sdk.get_current_span",
+                return_value=mock_span,
+            ),
+        ):
+            headers = {"user-agent": user_agent} if user_agent else {}
+            response = client.get("/api/ping", headers=headers)
+
+        assert response.status_code == 200
+        mock_set_tag.assert_called_once_with(CHANNEL_TAG, expected)
+        mock_span.set_data.assert_called_once_with(CHANNEL_TAG, expected)
+
+    def test_tag_still_set_when_no_active_span(self, client: TestClient):
+        with (
+            patch(
+                "routers.middleware.channel_middleware.sentry_sdk.set_tag"
+            ) as mock_set_tag,
+            patch(
+                "routers.middleware.channel_middleware.sentry_sdk.get_current_span",
+                return_value=None,
+            ),
+        ):
+            response = client.get(
+                "/api/ping", headers={"user-agent": "Immich_iOS_1.94.0"}
+            )
+
+        assert response.status_code == 200
+        mock_set_tag.assert_called_once_with(CHANNEL_TAG, "immich-mobile-ios")


### PR DESCRIPTION
## Summary
- Add `ChannelTaggingMiddleware` that classifies each request as `immich-mobile-android`, `immich-mobile-ios`, `immich-web`, or the generic `immich-api` fallback based on User-Agent, and sets the `channel` tag on the active Sentry transaction plus span data.
- Registered as the outermost middleware in `main.py` so the tag is attached even on `AuthMiddleware` 401s.
- Document the Starlette middleware registration-order gotcha in `docs/references/code-practices.md` so the invariant is preserved when middleware is added or reordered.

## Linear
https://linear.app/gumnut-ai/issue/GUM-561/tag-sentry-spans-with-interaction-channel-mcp-immich-adapter-web-api

## Companion PR
The photos-api half lives at gumnut-ai/photos#492. Each service has its own middleware (no shared code). Either PR can merge independently.

## Test plan
- [x] Unit tests cover classification for every channel value: real Immich mobile UA format (`Immich_iOS_<v>`, `Immich_Android_<v>`), the spec's lowercase form (`immich-ios/<v>`, `immich-android/<v>`), browsers (Chrome/Safari/Firefox on macOS/Windows/Linux), and the generic fallback.
- [x] Regression test `test_tag_set_before_early_rejection` verifies the outermost-registration invariant by running ChannelTaggingMiddleware above a short-circuit middleware that returns 401 — the 401 response still gets the `immich-mobile-ios` tag.
- [x] Full immich-adapter unit test suite passes.
- [ ] After merge: verify in Sentry that adapter traffic from each client type shows the expected `channel` tag, enabling `group by channel` aggregation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)