### PR TITLE
Populate user_agent.original on Sentry spans (GUM-570)

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from config.logging import init_logging
 from contextlib import asynccontextmanager
 
 from routers.middleware.auth_middleware import AuthMiddleware
+from routers.middleware.observability_middleware import ObservabilityTagsMiddleware
 from routers import static, well_known
 from routers.utils.spa_static_files import SPAStaticFiles
 from routers.api.sync import routes as sync_routes
@@ -90,6 +91,12 @@ configure_exception_handlers(app)
 
 # Add authentication middleware
 app.add_middleware(AuthMiddleware)
+
+# Attach `user_agent.original` to Sentry spans. Added last so it wraps
+# outermost in the Starlette stack and runs before auth — guarantees the
+# attribute is attached even on 401s from `AuthMiddleware`.
+# See routers/middleware/observability_middleware.py.
+app.add_middleware(ObservabilityTagsMiddleware)
 
 # Mount Socket.IO app first
 app.mount("/api/socket.io", websockets.socket_app)

--- a/routers/middleware/observability_middleware.py
+++ b/routers/middleware/observability_middleware.py
@@ -11,8 +11,6 @@ Currently emits one span attribute:
 
 Registered last in `main.py` so it wraps outermost and attaches attributes
 even on auth 401 short-circuits from `AuthMiddleware`.
-
-Mirrors the photos-api `ObservabilityTagsMiddleware`. See GUM-570.
 """
 
 from __future__ import annotations

--- a/routers/middleware/observability_middleware.py
+++ b/routers/middleware/observability_middleware.py
@@ -1,0 +1,41 @@
+"""Attach observability attributes to the active Sentry span.
+
+Currently emits one span attribute:
+
+- `user_agent.original` — the raw `User-Agent` header, following the
+  OpenTelemetry semantic convention. Answers "who is the caller?" The
+  Sentry SDK doesn't populate this on spans automatically (it only
+  attaches UA to error event context / session tracking), so we set it
+  explicitly. High-cardinality, so it's a span attribute rather than a
+  tag.
+
+Registered last in `main.py` so it wraps outermost and attaches attributes
+even on auth 401 short-circuits from `AuthMiddleware`.
+
+Mirrors the photos-api `ObservabilityTagsMiddleware`. See GUM-570.
+"""
+
+from __future__ import annotations
+
+import sentry_sdk
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
+
+USER_AGENT_ATTRIBUTE = "user_agent.original"
+
+
+class ObservabilityTagsMiddleware(BaseHTTPMiddleware):
+    """Attach `user_agent.original` to the active Sentry span."""
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        user_agent = request.headers.get("user-agent", "")
+
+        if user_agent:
+            span = sentry_sdk.get_current_span()
+            if span is not None:
+                span.set_data(USER_AGENT_ATTRIBUTE, user_agent)
+
+        return await call_next(request)

--- a/tests/unit/middleware/test_observability_middleware.py
+++ b/tests/unit/middleware/test_observability_middleware.py
@@ -1,0 +1,132 @@
+"""Unit tests for ObservabilityTagsMiddleware."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from routers.middleware.observability_middleware import (
+    USER_AGENT_ATTRIBUTE,
+    ObservabilityTagsMiddleware,
+)
+
+
+class TestObservabilityTagsMiddleware:
+    @pytest.mark.anyio
+    async def test_user_agent_is_set_on_span(self):
+        """A populated User-Agent header should land on the span as
+        `user_agent.original` (OpenTelemetry semantic convention)."""
+        app = FastAPI()
+        app.add_middleware(ObservabilityTagsMiddleware)
+
+        @app.get("/echo")
+        async def _echo():
+            return {"ok": True}
+
+        mock_span = MagicMock()
+        with patch(
+            "routers.middleware.observability_middleware.sentry_sdk.get_current_span",
+            return_value=mock_span,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://testserver"
+            ) as client:
+                response = await client.get(
+                    "/echo", headers={"user-agent": "Immich_iOS_1.94.0"}
+                )
+
+        assert response.status_code == 200
+        mock_span.set_data.assert_called_once_with(
+            USER_AGENT_ATTRIBUTE, "Immich_iOS_1.94.0"
+        )
+
+    @pytest.mark.anyio
+    async def test_user_agent_not_set_when_header_missing(self):
+        """Missing User-Agent header should not emit an empty
+        `user_agent.original` attribute — skip the call entirely so Sentry
+        queries can distinguish "attribute absent" from "attribute empty"."""
+        app = FastAPI()
+        app.add_middleware(ObservabilityTagsMiddleware)
+
+        @app.get("/echo")
+        async def _echo():
+            return {"ok": True}
+
+        mock_span = MagicMock()
+        with patch(
+            "routers.middleware.observability_middleware.sentry_sdk.get_current_span",
+            return_value=mock_span,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://testserver"
+            ) as client:
+                response = await client.get("/echo", headers={"user-agent": ""})
+
+        assert response.status_code == 200
+        mock_span.set_data.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_no_span_does_not_raise(self):
+        """No active transaction (span is None) should not raise."""
+        app = FastAPI()
+        app.add_middleware(ObservabilityTagsMiddleware)
+
+        @app.get("/echo")
+        async def _echo():
+            return {"ok": True}
+
+        with patch(
+            "routers.middleware.observability_middleware.sentry_sdk.get_current_span",
+            return_value=None,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://testserver"
+            ) as client:
+                response = await client.get(
+                    "/echo", headers={"user-agent": "Immich_Android_1.100.0"}
+                )
+
+        assert response.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_attribute_set_before_early_rejection(self):
+        """Verify ObservabilityTagsMiddleware runs outermost, so responses
+        from a downstream middleware that short-circuits (e.g., auth 401)
+        still have the UA attribute attached."""
+
+        class _ShortCircuit401(BaseHTTPMiddleware):
+            async def dispatch(
+                self, request: Request, call_next: RequestResponseEndpoint
+            ) -> Response:
+                return JSONResponse({"detail": "unauthorized"}, status_code=401)
+
+        app = FastAPI()
+        # Mirror main.py registration order: AuthMiddleware added first
+        # (innermost), Observability last (outermost, runs first).
+        app.add_middleware(_ShortCircuit401)
+        app.add_middleware(ObservabilityTagsMiddleware)
+
+        @app.get("/api/protected")
+        async def _protected():
+            return {"ok": True}
+
+        mock_span = MagicMock()
+        with patch(
+            "routers.middleware.observability_middleware.sentry_sdk.get_current_span",
+            return_value=mock_span,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://testserver"
+            ) as client:
+                response = await client.get(
+                    "/api/protected", headers={"user-agent": "Immich_iOS_1.94.0"}
+                )
+
+        assert response.status_code == 401
+        mock_span.set_data.assert_called_once_with(
+            USER_AGENT_ATTRIBUTE, "Immich_iOS_1.94.0"
+        )


### PR DESCRIPTION
## Summary
- Add `ObservabilityTagsMiddleware` that emits `user_agent.original` (OpenTelemetry semantic convention) on the active Sentry span.
- Registered after `AuthMiddleware` in `main.py` so it wraps outermost — the attribute attaches even on 401 short-circuits.
- The Sentry SDK reads User-Agent into session tracking only; it doesn't populate this on spans automatically, so we set it explicitly.

## Linear
https://linear.app/gumnut-ai/issue/GUM-570

## Related
- photos-api side: gumnut-ai/photos PR for GUM-570 (paired)

## Test plan
- [x] `uv run pytest tests/unit/middleware/` — 18 passed (4 new)
- [x] `uv run ruff format` / `uv run ruff check` / `uv run pyright` — clean
- [ ] After deploy: Sentry span explorer query `user_agent.original` over a recent window returns real UA strings instead of zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)