### PR TITLE
Populate top-level width/height on asset responses (GUM-589)

### DIFF
--- a/routers/utils/asset_conversion.py
+++ b/routers/utils/asset_conversion.py
@@ -267,7 +267,7 @@ def build_asset_upload_ready_payload(
         duration=None,
         fileCreatedAt=file_created_at,
         fileModifiedAt=file_modified_at,
-        height=None,
+        height=int(gumnut_asset.height) if gumnut_asset.height else None,
         isEdited=False,
         isFavorite=False,
         libraryId=None,
@@ -277,7 +277,7 @@ def build_asset_upload_ready_payload(
         stackId=None,
         type=mime_type_to_asset_type(gumnut_asset.mime_type),
         visibility=AssetVisibility.timeline,
-        width=None,
+        width=int(gumnut_asset.width) if gumnut_asset.width else None,
     )
 
     sync_exif = extract_sync_exif(gumnut_asset, asset_uuid)
@@ -349,7 +349,7 @@ def convert_gumnut_asset_to_immich(
         createdAt=created_at_fallback,
         duration="00:00:00.000000" if asset_type == AssetTypeEnum.VIDEO else "",
         hasMetadata=True,
-        height=None,
+        height=float(gumnut_asset.height) if gumnut_asset.height else None,
         isArchived=False,
         isEdited=False,
         isFavorite=False,
@@ -360,6 +360,6 @@ def convert_gumnut_asset_to_immich(
         owner=current_user,
         thumbhash="",
         visibility=AssetVisibility.timeline,
-        width=None,
+        width=float(gumnut_asset.width) if gumnut_asset.width else None,
         people=people,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,8 @@ def sample_gumnut_asset():
     asset.duration_in_seconds = None
     asset.library_id = "library-789"
     asset.checksum = "abc123"
+    asset.width = 1920
+    asset.height = 1080
     asset.people = []  # Empty list for people
     asset.exif = None  # No EXIF data
     return asset


### PR DESCRIPTION
## Summary

- Populate top-level `width` / `height` on `AssetResponseDto` and `SyncAssetV1` from the Gumnut asset, instead of hardcoding `None`.
- Fixes portrait images rendering stretched into a square in the Immich web photo viewer on production.

## Why

Immich v2.7.5 introduced `AdaptiveImage.svelte` ([upstream #26636](https://github.com/immich-app/immich/pull/26636)). It sizes the image wrapper `<div>` from `asset.width` / `asset.height` and fills with `<img class="h-full w-full">` (no `object-contain`). When those fields are `null`, it falls back to a `1:1` aspect ratio, squeezing non-square images into a square.

The adapter was populating dimensions only on the nested `exifInfo.exifImageWidth/Height`, leaving the top-level fields null — so the viewer always took the fallback path.

See [GUM-589](https://linear.app/gumnut-ai/issue/GUM-589/portrait-images-stretched-to-square-in-immich-web-photo-viewer) for full root-cause analysis, including DOM captures from prod and API response evidence.

## Changes

- `routers/utils/asset_conversion.py`:
  - `convert_gumnut_asset_to_immich`: set `AssetResponseDto.width` / `.height` (`float | None`) from `gumnut_asset.width/height`.
  - `build_asset_upload_ready_payload`: set `SyncAssetV1.width` / `.height` (`int | None`) the same way, so sync stream events carry the correct dimensions.
- `tests/conftest.py`: `sample_gumnut_asset` fixture now sets `width=1920, height=1080`. Without this, `Mock()` auto-returned truthy Mock objects, which blew up the new `float()` / `int()` casts.

## Test plan

- [x] `uv run ruff format` / `ruff check` — clean
- [x] `uv run pyright routers/utils/asset_conversion.py` — 0 errors
- [x] `uv run pytest` — 673 passed
- [ ] Re-extract Immich web bundle locally (`./scripts/extract-immich-web.py -f ./static`) and verify a portrait photo renders with correct aspect ratio at localhost:8001
- [ ] Verify `GET /api/assets/{id}` returns non-null top-level `width` / `height`

🤖 Generated with [Claude Code](https://claude.com/claude-code)