### PR TITLE
GUM-552: set unimplemented server features to false

### DIFF
--- a/docs/design-docs/immich-adapter-gap-analysis.md
+++ b/docs/design-docs/immich-adapter-gap-analysis.md
@@ -2,7 +2,7 @@
 title: "Immich Adapter Gap Analysis"
 status: active
 created: 2026-04-15
-last-updated: 2026-04-15
+last-updated: 2026-04-21
 ---
 
 # Immich Adapter Gap Analysis
@@ -293,7 +293,7 @@ Most server info endpoints return hardcoded fake data (storage, statistics, feat
 
 | Endpoint | Current behavior | Impact |
 |----------|-----------------|--------|
-| `GET /server/features` | Hardcoded feature flags | **Medium** — Clients use this to enable/disable UI features. Incorrect flags may show UI for non-existent features. |
+| `GET /server/features` | Static flags, accurate (GUM-552) | **None** — Flags now reflect actual adapter capabilities. |
 | `GET /server/config` | Hardcoded config | **Medium** — OAuth config and trash settings are hardcoded. |
 | `GET /server/storage` | Fake disk usage | **Low** — Cosmetic in admin panel |
 | `GET /server/statistics` | All zeros | **Low** — Admin panel stats |
@@ -306,9 +306,9 @@ Most server info endpoints return hardcoded fake data (storage, statistics, feat
 
 **Effort**: **S** — Most of these are about returning accurate data rather than implementing new functionality. The features endpoint is the most important: it should reflect what Gumnut actually supports so Immich clients hide unsupported UI elements.
 
-> **Design decision —** The `GET /server/features` endpoint is the highest-value fix in this group. Currently, the adapter sets `duplicateDetection: true`, `map: true`, `reverseGeocoding: true`, `trash: true`, and `sidecar: true` — all for features that are not implemented. Setting these to `false` would cause Immich clients to hide the corresponding UI elements, reducing user confusion. This is a quick win.
+> **Design decision —** The `GET /server/features` endpoint is the highest-value fix in this group. Previously the adapter set `duplicateDetection: true`, `map: true`, `reverseGeocoding: true`, `trash: true`, and `sidecar: true` for features that aren't implemented. GUM-552 flipped those flags to `false` so Immich clients hide the corresponding UI. `smartSearch`, `facialRecognition`, `search`, `oauth`, and `oauthAutoLaunch` remain `true` because they are backed by real implementations.
 
-**Recommendation**: **Close** the features endpoint (S, adapter-only). Revisit storage/statistics if admin features are needed.
+**Recommendation**: **Closed** for features (GUM-552). Revisit storage/statistics if admin features are needed.
 
 ---
 

--- a/routers/api/server.py
+++ b/routers/api/server.py
@@ -28,16 +28,23 @@ router = APIRouter(
 )
 
 
-fake_features = {
+# Feature flags advertised to Immich clients. Each flag must reflect what the
+# adapter actually implements — clients use these to show/hide UI, so flipping
+# one to True without a working implementation surfaces non-functional UI.
+server_features = {
     "smartSearch": True,
     "facialRecognition": True,
-    "duplicateDetection": True,
-    "map": True,
-    "reverseGeocoding": True,
+    # Duplicate detection endpoints are stubs; no dedup is performed.
+    "duplicateDetection": False,
+    # Map + reverse geocoding endpoints are stubs; no location data is served.
+    "map": False,
+    "reverseGeocoding": False,
     "importFaces": False,
-    "sidecar": True,
+    # Sidecar (.xmp) files are not processed.
+    "sidecar": False,
     "search": True,
-    "trash": True,
+    # Trash endpoints are stubs; delete goes straight through.
+    "trash": False,
     "oauth": True,
     # Auto-redirect to OAuth provider on login page instead of showing login form
     "oauthAutoLaunch": True,
@@ -178,7 +185,7 @@ fake_media_types = {
 
 @router.get("/features")
 async def get_features() -> ServerFeaturesDto:
-    return ServerFeaturesDto(**fake_features)
+    return ServerFeaturesDto(**server_features)
 
 
 @router.get("/config")

--- a/tests/integration/test_server_features.py
+++ b/tests/integration/test_server_features.py
@@ -1,0 +1,50 @@
+"""Integration tests for GET /api/server/features."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+class TestServerFeaturesEndpoint:
+    def test_unimplemented_features_are_disabled(self, client):
+        """Flags for stub features must be false so clients hide their UI."""
+        response = client.get("/api/server/features")
+        assert response.status_code == 200
+
+        data = response.json()
+        for flag in (
+            "duplicateDetection",
+            "map",
+            "reverseGeocoding",
+            "trash",
+            "sidecar",
+        ):
+            assert data[flag] is False, f"{flag} must be False — endpoint is a stub"
+
+    def test_implemented_features_are_enabled(self, client):
+        """Flags for features backed by real implementations stay true."""
+        response = client.get("/api/server/features")
+        assert response.status_code == 200
+
+        data = response.json()
+        for flag in (
+            "smartSearch",
+            "facialRecognition",
+            "search",
+            "oauth",
+            "oauthAutoLaunch",
+        ):
+            assert data[flag] is True, f"{flag} should be True"
+
+    def test_password_login_disabled(self, client):
+        """Password login is disabled — OAuth is the only login method."""
+        response = client.get("/api/server/features")
+        assert response.status_code == 200
+        assert response.json()["passwordLogin"] is False


### PR DESCRIPTION
## Summary

- Flip `duplicateDetection`, `map`, `reverseGeocoding`, `trash`, and `sidecar` to `false` in the `GET /api/server/features` response — all five back stub endpoints, so the old `true` values caused Immich clients to surface UI for features that silently do nothing.
- Rename the backing dict from `fake_features` to `server_features` since the values now reflect real adapter capabilities; `smartSearch`, `facialRecognition`, `search`, `oauth`, and `oauthAutoLaunch` remain `true` because they are backed by real implementations.
- Add `tests/integration/test_server_features.py` covering the disabled set, the enabled set, and the unchanged `passwordLogin: false` invariant.
- Update `docs/design-docs/immich-adapter-gap-analysis.md` §14 so it reflects the completed fix instead of motivating one.

## Linear

https://linear.app/gumnut-ai/issue/GUM-552/server-features-endpoint-return-accurate-feature-flags

## Test plan

- [x] `uv run pytest` — 676 tests pass, including the three new ones
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run pyright` clean
- [ ] In a running Immich web client pointed at the adapter, verify duplicate detection, map, reverse geocoding, trash, and sidecar UI are hidden; smart/metadata search and face grouping still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)