### PR TITLE
Warn at startup when static/ diverges from .immich-container-tag

### DIFF
--- a/docs/guides/running-with-immich-web.md
+++ b/docs/guides/running-with-immich-web.md
@@ -39,6 +39,8 @@ Run the extraction script to pull the web files from the Immich Docker image int
 
 The script reads the Immich version from `.immich-container-tag`, pulls `ghcr.io/immich-app/immich-server:<tag>`, and copies the pre-built web files into `static/`. The `-f` flag overwrites any existing files.
 
+The script also writes a marker file `static/.extracted-tag` recording which tag it extracted. The adapter reads this marker at startup and logs a loud warning if it no longer matches `.immich-container-tag` — your cue to re-run the extraction. CI and fresh clones (no marker present) are unaffected.
+
 Other useful options:
 
 ```bash

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 
 from fastapi import FastAPI
 from config.exceptions import configure_exception_handlers
@@ -55,6 +56,32 @@ init_sentry()
 logger = logging.getLogger(__name__)
 
 
+def _warn_on_web_bundle_drift() -> None:
+    # The marker is written by scripts/extract-immich-web.py. It only exists
+    # on developer machines that have run the extraction; CI and fresh
+    # clones silently skip this check.
+    tag_file = Path(".immich-container-tag")
+    marker_file = Path("static/.extracted-tag")
+    if not (tag_file.exists() and marker_file.exists()):
+        return
+    expected = tag_file.read_text().strip()
+    actual = marker_file.read_text().strip()
+    if expected != actual:
+        bar = "=" * 72
+        logger.warning(
+            "\n%s\n"
+            "  IMMICH WEB BUNDLE IS STALE\n"
+            "  .immich-container-tag: %s\n"
+            "  static/.extracted-tag: %s\n"
+            "  Run: ./scripts/extract-immich-web.py -f ./static\n"
+            "%s",
+            bar,
+            expected,
+            actual,
+            bar,
+        )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """
@@ -70,6 +97,8 @@ async def lifespan(app: FastAPI):
             "streaming_upload_threshold_bytes=0: all uploads use streaming path, "
             "which skips iOS live photo .MOV detection"
         )
+
+    _warn_on_web_bundle_drift()
 
     yield
     # Ensure singleton HTTP clients are closed on shutdown

--- a/scripts/extract-immich-web.py
+++ b/scripts/extract-immich-web.py
@@ -282,6 +282,12 @@ Examples:
 
         print_success(f"Web files extracted successfully to: {output_dir}")
 
+        # Record the extracted tag so the adapter can detect drift between
+        # static/ and .immich-container-tag at startup. See main.py lifespan.
+        marker = output_dir / ".extracted-tag"
+        marker.write_text(tag + "\n")
+        print_info(f"Wrote extraction marker: {marker} = {tag}")
+
         # Show stats
         size = get_directory_size(output_dir)
         if size:

--- a/scripts/extract-immich-web.py
+++ b/scripts/extract-immich-web.py
@@ -282,12 +282,6 @@ Examples:
 
         print_success(f"Web files extracted successfully to: {output_dir}")
 
-        # Record the extracted tag so the adapter can detect drift between
-        # static/ and .immich-container-tag at startup. See main.py lifespan.
-        marker = output_dir / ".extracted-tag"
-        marker.write_text(tag + "\n")
-        print_info(f"Wrote extraction marker: {marker} = {tag}")
-
         # Show stats
         size = get_directory_size(output_dir)
         if size:
@@ -302,6 +296,14 @@ Examples:
         else:
             print_error("Warning: Expected files may be missing")
             return 1
+
+        # Record the extracted tag so the adapter can detect drift between
+        # static/ and .immich-container-tag at startup. See main.py lifespan.
+        # Written after verification so a failed extraction doesn't leave a
+        # stale marker claiming success.
+        marker = output_dir / ".extracted-tag"
+        marker.write_text(tag + "\n")
+        print_info(f"Wrote extraction marker: {marker} = {tag}")
 
         print_success("Done! Container cleaned up.")
         return 0


### PR DESCRIPTION
## Summary

- `.immich-container-tag` pins the Immich web version for local dev; `scripts/extract-immich-web.py` pulls that tag's Docker image and populates `static/`. Nothing currently signals when the two drift — developers can run a UI that silently lags the pinned version for months.
- `scripts/extract-immich-web.py` now writes `static/.extracted-tag` with the tag it extracted (after the final key-file verification, so a failed extraction can't leave a stale success marker).
- `main.py` lifespan reads both files at startup and logs a loud `WARNING` on mismatch, naming both tags and the fix command. Check silently skips when either file is missing — keeping CI and fresh clones quiet.
- Production image is unaffected: `.dockerignore` excludes `static/` and the Dockerfile re-extracts from `ghcr.io/immich-app/immich-server:${IMMICH_VERSION}` at build time, so no marker ever ships.
- No explicit `.gitignore` entry needed — the marker is already covered by the existing `static/*` rule (verified with `git check-ignore`).

### Sample Warning

```
========================================================================
  IMMICH WEB BUNDLE IS STALE
  .immich-container-tag: v2.7.5
  static/.extracted-tag: v2.7.4
  Run: ./scripts/extract-immich-web.py -f ./static
========================================================================
```

## Linear

https://linear.app/gumnut-ai/issue/GUM-590/detect-drift-between-immich-adapterstatic-and-immich-container-tag

## Test plan

Manual verification against the three cases the helper must handle:

- [x] Marker absent (fresh clone / CI) → no warning
- [x] Marker matches `.immich-container-tag` → no warning
- [x] Marker differs from `.immich-container-tag` → loud WARNING prints both tags and the fix command
- [x] `uv run pytest` — 676 passed, no new warnings surfaced as test failures
- [x] `uv run ruff format` / `ruff check` / `pyright` — clean
- [x] `git check-ignore -v static/.extracted-tag` → hits `static/*`
- [ ] Reviewer: bump `.immich-container-tag` to a different tag (e.g., `v2.7.4`) without re-extracting, restart the adapter, confirm the WARNING fires on the next startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)