### PR TITLE
Centralize Gumnut SDK error handling in a global FastAPI handler (GUM-619)

### DIFF
--- a/config/exceptions.py
+++ b/config/exceptions.py
@@ -1,29 +1,136 @@
 """Exception handlers for the immich-adapter."""
 
 from http import HTTPStatus
+from typing import Any
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, status
 from fastapi.exceptions import HTTPException
 from fastapi.responses import JSONResponse
+from gumnut import (
+    APIConnectionError,
+    APIResponseValidationError,
+    APIStatusError,
+    GumnutError,
+    RateLimitError,
+)
+
+from routers.utils.error_mapping import (
+    extract_detail_from_status_error,
+    log_upstream_response,
+    logger,
+)
+
+
+def _immich_response(status_code: int, message: str) -> JSONResponse:
+    """Build a JSONResponse in Immich's expected error shape."""
+    try:
+        error_name = HTTPStatus(status_code).phrase
+    except ValueError:
+        error_name = "Error"
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            "message": message,
+            "statusCode": status_code,
+            "error": error_name,
+        },
+    )
 
 
 async def _immich_http_exception_handler(
     request: Request, exc: HTTPException
 ) -> JSONResponse:
     """Format HTTP errors in Immich's expected format."""
-    try:
-        error_name = HTTPStatus(exc.status_code).phrase
-    except ValueError:
-        error_name = "Error"
+    response = _immich_response(exc.status_code, str(exc.detail))
+    if exc.headers:
+        response.headers.update(exc.headers)
+    return response
 
-    return JSONResponse(
-        status_code=exc.status_code,
-        content={
-            "message": exc.detail,
-            "statusCode": exc.status_code,
-            "error": error_name,
-        },
-        headers=exc.headers,
+
+def _route_context(request: Request) -> str:
+    """Return a stable context string for log records derived from the route."""
+    route = request.scope.get("route")
+    name = getattr(route, "name", None) or getattr(route, "path", None)
+    return name or f"{request.method} {request.url.path}"
+
+
+async def _gumnut_error_handler(request: Request, exc: GumnutError) -> JSONResponse:
+    """Map any Gumnut SDK exception to an Immich-shaped JSON response.
+
+    Routes that need to enrich the log record with call-site context
+    (e.g. upload paths) should catch the SDK exception themselves and use
+    `map_gumnut_error(extra=..., exc_info=True)` instead of letting the
+    error reach this handler.
+    """
+    context = _route_context(request)
+
+    # RateLimitError must never surface as 429 to Immich clients — they
+    # have no 429 handling and would break (sync failures, broken thumbs).
+    if isinstance(exc, RateLimitError):
+        log_upstream_response(
+            logger,
+            context=context,
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            message="SDK retries exhausted for rate-limited request",
+            exc_info=True,
+        )
+        return _immich_response(
+            status.HTTP_502_BAD_GATEWAY,
+            "Upstream temporarily unavailable",
+        )
+
+    if isinstance(exc, APIStatusError):
+        detail = extract_detail_from_status_error(exc)
+        log_extra: dict[str, Any] = {"error_detail": detail[:500]}
+        log_upstream_response(
+            logger,
+            context=context,
+            status_code=exc.status_code,
+            message=f"Gumnut SDK error in {context}: {exc.message}",
+            extra=log_extra,
+            exc_info=True,
+        )
+        return _immich_response(exc.status_code, detail)
+
+    if isinstance(exc, APIResponseValidationError):
+        # Schema mismatch is a contract bug — log at 502 ERROR severity, not
+        # the upstream 2xx (which would demote to INFO).
+        log_upstream_response(
+            logger,
+            context=context,
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            message=f"Gumnut SDK returned invalid response in {context}: {exc.message}",
+            exc_info=True,
+        )
+        return _immich_response(
+            status.HTTP_502_BAD_GATEWAY,
+            "Upstream returned invalid response",
+        )
+
+    if isinstance(exc, APIConnectionError):
+        log_upstream_response(
+            logger,
+            context=context,
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            message=f"Gumnut SDK connection error in {context}: {exc.message}",
+            exc_info=True,
+        )
+        return _immich_response(
+            status.HTTP_502_BAD_GATEWAY,
+            "Upstream unreachable",
+        )
+
+    # Generic GumnutError fallback (no HTTP status, not transport).
+    log_upstream_response(
+        logger,
+        context=context,
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        message=f"Unhandled Gumnut SDK error in {context}: {exc}",
+        exc_info=True,
+    )
+    return _immich_response(
+        status.HTTP_500_INTERNAL_SERVER_ERROR,
+        "Internal error",
     )
 
 
@@ -34,3 +141,4 @@ def configure_exception_handlers(app: FastAPI) -> None:
     to appropriate HTTP responses. Add new exception handlers here as needed.
     """
     app.add_exception_handler(HTTPException, _immich_http_exception_handler)  # type: ignore[arg-type]
+    app.add_exception_handler(GumnutError, _gumnut_error_handler)  # type: ignore[arg-type]

--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -290,18 +290,34 @@ All HTTP errors conform to Immich's expected format:
 
 Route handlers raise `HTTPException(status_code=..., detail="...")` and a global handler formats the response. Middleware returns `JSONResponse` directly (since `HTTPException` doesn't work in `BaseHTTPMiddleware`).
 
+### Gumnut SDK error mapping
+
+A global `GumnutError` exception handler in `config/exceptions.py` (registered in `main.py`) maps any Stainless SDK exception raised during request handling to an Immich-shaped JSON response. Routes do not need per-call `try/except` for SDK errors — they bubble to the handler.
+
+Dispatch is by `isinstance` against the typed SDK hierarchy:
+
+| SDK exception | Client status | Detail |
+|---------------|---------------|--------|
+| `RateLimitError` | 502 | "Upstream temporarily unavailable" |
+| `APIStatusError` subclasses (`NotFoundError`, `AuthenticationError`, …) | `exc.status_code` | from `body.detail` / `body.message` / `body.error` / `exc.message` |
+| `APIResponseValidationError` | 502 | "Upstream returned invalid response" |
+| `APIConnectionError` / `APITimeoutError` | 502 | "Upstream unreachable" |
+| generic `GumnutError` | 500 | "Internal error" |
+
+`map_gumnut_error` in `routers/utils/error_mapping.py` is reserved for the upload paths (`_upload_buffered`, `_upload_streaming`), which need to enrich the upstream log record with call-site context (filename, device IDs, `exc_info=True`) that the global handler can't see.
+
 ### Rate limit protection
 
 Immich clients have no HTTP 429 handling — a rate limit response causes sync failures, broken thumbnails, and upload errors with no automatic recovery. The adapter protects against this:
 
 1. The Gumnut SDK (Stainless-generated) has built-in retry with exponential backoff and jitter for 429/5xx responses
-2. If SDK retries are exhausted, `map_gumnut_error` catches `RateLimitError` and returns **502 Bad Gateway** (not 429) to Immich clients. 502 is semantically correct — the adapter is a gateway and the upstream is unavailable. 503 would imply the adapter itself is overloaded, which isn't the case.
+2. If SDK retries are exhausted, the global `GumnutError` handler maps `RateLimitError` to **502 Bad Gateway** (not 429) for Immich clients. 502 is semantically correct — the adapter is a gateway and the upstream is unavailable. 503 would imply the adapter itself is overloaded, which isn't the case. (The upload paths' `map_gumnut_error` does the same when called directly.)
 3. Immich clients display a generic error on 5xx and do not automatically retry — there is no risk of tight retry loops from the client side
 4. Custom retry wrappers must not be added on top of SDK retry (causes retry amplification)
 
 ### Per-item error handling
 
-Bulk operations (delete assets, update people, add assets to albums) process items individually and track per-item results. A failure on one item doesn't abort the entire operation — the adapter continues processing remaining items and returns a result array with success/error status per item.
+Bulk operations (delete assets, update people, add assets to albums) process items individually and track per-item results. A failure on one item doesn't abort the entire operation — the adapter continues processing remaining items and returns a result array with success/error status per item. The shared `classify_bulk_item_error()` helper in `routers/utils/error_mapping.py` maps `APIStatusError` subclasses to the canonical `not_found` / `no_permission` / `unknown` buckets; per-endpoint nuances (e.g. `ConflictError` → `duplicate`) are layered on top.
 
 ## Endpoint Implementation Status
 

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -1,6 +1,6 @@
 ---
 title: "Code Practices"
-last-updated: 2026-04-02
+last-updated: 2026-04-24
 ---
 
 # Code Practices
@@ -104,20 +104,48 @@ Forgetting step 2 causes silent drift — the served web UI stays on the old Imm
 - Wrap low-level exceptions (e.g., Redis, HTTP client errors) in domain-specific exceptions
 - Example: `SessionStore` catches `redis.exceptions.RedisError` and raises `SessionStoreError`
 
+### Gumnut SDK Errors
+
+The global handler in `config/exceptions.py` maps any `GumnutError` raised during request handling to an Immich-shaped JSON response, so most routes do **not** need to wrap SDK calls in `try/except`. Just call the SDK and let the error bubble:
+
+```python
+@router.get("/{id}")
+async def get_album(id: UUID, client: AsyncGumnut = Depends(get_authenticated_gumnut_client)):
+    return await client.albums.retrieve(uuid_to_gumnut_album_id(id))
+```
+
+The handler dispatches by isinstance against the typed Stainless exception hierarchy (`APIStatusError` subclasses → mapped status; `RateLimitError` → 502; `APIConnectionError` → 502; `APIResponseValidationError` → 502; generic `GumnutError` → 500).
+
+For per-item handling inside bulk endpoints (where one failure shouldn't abort the batch), catch the specific typed exception and continue:
+
+```python
+for asset_uuid in request.ids:
+    try:
+        await client.assets.delete(uuid_to_gumnut_asset_id(asset_uuid))
+    except NotFoundError:
+        # Already gone; expected during sync.
+        continue
+    except APIStatusError as e:
+        log_upstream_response(logger, ..., status_code=e.status_code, ...)
+        continue
+```
+
+Use `map_gumnut_error(e, context, extra=..., exc_info=True)` only when the call site needs to enrich the upstream log record with context the global handler can't see — most commonly the upload paths logging filename / device ids / tracebacks.
+
 ### Immich Client Error Handling
 
 - **Observed behavior:** Immich mobile and web clients have no HTTP 429 (rate limit) handling. A 429 causes sync failures, broken thumbnails, and upload errors with no automatic recovery.
 - **Adapter contract:**
   - Never forward 429 responses from photos-api to Immich clients.
   - The Gumnut SDK (Stainless-generated) has built-in retry for 429, 5xx, and connection errors with exponential backoff, ±25% jitter, and `Retry-After` header support (see [SDK retry docs](https://www.stainless.com/docs/sdks/configure/client/#retries)). Configure `max_retries` on the client — **do not add a custom retry wrapper** on top, as it will stack with SDK retry and cause retry amplification.
-  - `map_gumnut_error` must catch `RateLimitError` explicitly and return 502 (not 429) to Immich clients. The default error mapping would pass through the 429 status code.
+  - The global `GumnutError` handler catches `RateLimitError` explicitly and returns 502 (not 429) to Immich clients. `map_gumnut_error` does the same when called directly from upload paths.
 
 ## Testing
 
 - All tests should be async and use `@pytest.mark.anyio` decorator
 - Run tests from the project directory, not repository root
 - Use model factories for test data creation
-- Do not assert on logging in tests — logging is non-functional behavior. Tests should assert on observable outputs (return values, side effects, emitted events), not on whether a particular log message was emitted.
+- Avoid asserting on logging in tests by default — logging is usually non-functional behavior. Exception: when log level itself is an explicit contract (for example, upstream status severity policy), assertions may verify level/metadata while avoiding brittle full-message matching.
 - When mocking SDK paginator calls used with `async for` (e.g., `client.faces.list`), use `Mock(return_value=MockSyncCursorPage([...]))` — not `AsyncMock`. `AsyncMock` wraps the return in a coroutine, which breaks `async for` iteration. Use `AsyncMock` only for calls consumed with `await`.
 - Do not add `__init__.py` to test directories — the project uses pytest's rootdir-based import resolution. Adding `__init__.py` switches pytest to package-based imports, breaking test discovery.
 
@@ -131,6 +159,16 @@ logger.info("WebSocket connected", extra={"sid": sid, "user_id": user_id, "devic
 ```
 
 This enables better searching and correlation in Sentry.
+
+### Upstream response log levels
+
+For responses/errors from upstream photos-api/Gumnut calls, use status-based severity:
+
+- `404` → `INFO`
+- Other `4xx` (including `400`, `401`, `403`, `422`, `429`) → `WARNING`
+- `5xx` → `ERROR`
+
+When possible, use shared helpers in `routers/utils/error_mapping.py` (`upstream_status_log_level` / `log_upstream_response`) instead of ad-hoc `if/else` logging branches.
 
 **Reserved `extra` keys**: Python's `LogRecord` has reserved attributes (`filename`, `module`, `name`, `msg`, `args`, `levelname`, `pathname`, `lineno`, etc.). Using these as `extra` keys causes a `KeyError` at runtime. Use prefixed names instead (e.g., `upload_filename` instead of `filename`).
 

--- a/routers/api/albums.py
+++ b/routers/api/albums.py
@@ -3,10 +3,13 @@ from uuid import UUID
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
-from gumnut import AsyncGumnut
+from gumnut import APIStatusError, AsyncGumnut, ConflictError, GumnutError
 
+from routers.utils.error_mapping import (
+    classify_bulk_item_error,
+    log_bulk_transport_error,
+)
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
-from routers.utils.error_mapping import map_gumnut_error, check_for_error_by_code
 from routers.utils.current_user import get_current_user
 from routers.immich_models import (
     AlbumResponseDto,
@@ -56,25 +59,18 @@ async def get_all_albums(
         # Shared albums not supported in this adapter
         return []
 
-    try:
-        kwargs = {}
-        if asset_id:
-            kwargs["asset_id"] = uuid_to_gumnut_asset_id(asset_id)
+    kwargs = {}
+    if asset_id:
+        kwargs["asset_id"] = uuid_to_gumnut_asset_id(asset_id)
 
-        gumnut_albums = client.albums.list(**kwargs)
+    gumnut_albums = client.albums.list(**kwargs)
 
-        # Convert Gumnut albums to AlbumResponseDto format
-        immich_albums = [
-            convert_gumnut_album_to_immich(
-                album, current_user, asset_count=album.asset_count
-            )
-            async for album in gumnut_albums
-        ]
-
-        return immich_albums
-
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to fetch albums") from e
+    return [
+        convert_gumnut_album_to_immich(
+            album, current_user, asset_count=album.asset_count
+        )
+        async for album in gumnut_albums
+    ]
 
 
 @router.get("/statistics")
@@ -86,25 +82,16 @@ async def get_album_statistics(
     Since Gumnut doesn't support shared albums, all albums are considered owned and not shared.
     """
 
-    try:
-        # Get all albums to count them
-        gumnut_albums = client.albums.list()
+    gumnut_albums = client.albums.list()
+    albums_list = [a async for a in gumnut_albums]
+    total_albums = len(albums_list)
 
-        # Count albums by converting AsyncPaginator to list
-        albums_list = [a async for a in gumnut_albums]
-        total_albums = len(albums_list)
-
-        # Since Gumnut doesn't support shared albums, all albums are:
-        # - owned by the current user
-        # - not shared
-        return AlbumStatisticsResponseDto(
-            notShared=total_albums,  # All albums are not shared
-            owned=total_albums,  # All albums are owned by current user
-            shared=0,  # No shared albums in Gumnut
-        )
-
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to fetch album statistics") from e
+    # Gumnut doesn't support shared albums, so all albums are owned and unshared.
+    return AlbumStatisticsResponseDto(
+        notShared=total_albums,
+        owned=total_albums,
+        shared=0,
+    )
 
 
 @router.get("/{id}")
@@ -121,38 +108,29 @@ async def get_album_info(
     If withoutAssets is False, also fetch and include the album's assets.
     """
 
-    try:
-        gumnut_album_id = uuid_to_gumnut_album_id(id)
+    gumnut_album_id = uuid_to_gumnut_album_id(id)
 
-        # Retrieve the specific album from Gumnut
-        gumnut_album = await client.albums.retrieve(gumnut_album_id)
+    # Retrieve the specific album from Gumnut
+    gumnut_album = await client.albums.retrieve(gumnut_album_id)
 
-        # Convert assets to AssetResponseDto format
-        immich_assets = []
-        if not withoutAssets:
-            async for gumnut_asset in client.assets.list(album_id=gumnut_album_id):
-                try:
-                    immich_asset = convert_gumnut_asset_to_immich(
-                        gumnut_asset, current_user
-                    )
-                    immich_assets.append(immich_asset)
-                except Exception as convert_error:
-                    logger.warning(
-                        f"Warning: Could not convert asset {gumnut_asset}: {convert_error}"
-                    )
+    immich_assets = []
+    if not withoutAssets:
+        async for gumnut_asset in client.assets.list(album_id=gumnut_album_id):
+            try:
+                immich_assets.append(
+                    convert_gumnut_asset_to_immich(gumnut_asset, current_user)
+                )
+            except Exception as convert_error:
+                logger.warning(
+                    f"Warning: Could not convert asset {gumnut_asset}: {convert_error}"
+                )
 
-        # Convert Gumnut album to AlbumResponseDto format using utility function
-        immich_album = convert_gumnut_album_to_immich(
-            gumnut_album,
-            current_user,
-            assets=immich_assets,
-            asset_count=gumnut_album.asset_count,
-        )
-
-        return immich_album
-
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to fetch album") from e
+    return convert_gumnut_album_to_immich(
+        gumnut_album,
+        current_user,
+        assets=immich_assets,
+        asset_count=gumnut_album.asset_count,
+    )
 
 
 @router.post("", status_code=201)
@@ -166,25 +144,13 @@ async def create_album(
     Note: albumUsers and assetIds are not supported by the Gumnut SDK.
     """
 
-    try:
-        album_name = request.albumName or ""
+    gumnut_album = await client.albums.create(
+        name=request.albumName or "",
+        description=request.description,
+        # Note: albumUsers and assetIds are not supported in this adapter
+    )
 
-        # Create the album
-        gumnut_album = await client.albums.create(
-            name=album_name,
-            description=request.description,
-            # Note: albumUsers and assetIds are not supported in this adapter
-        )
-
-        # Convert Gumnut album to AlbumResponseDto format using utility function
-        immich_album = convert_gumnut_album_to_immich(
-            gumnut_album, current_user, asset_count=0
-        )
-
-        return immich_album
-
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to create album") from e
+    return convert_gumnut_album_to_immich(gumnut_album, current_user, asset_count=0)
 
 
 @router.put("/{id}/assets")
@@ -200,68 +166,45 @@ async def add_assets_to_album(
     Returns a list of results indicating success/failure for each asset.
     """
 
-    try:
-        gumnut_album_id = uuid_to_gumnut_album_id(id)
+    gumnut_album_id = uuid_to_gumnut_album_id(id)
 
-        # Verify album exists first
+    response = []
+    for asset_uuid in request.ids:
+        asset_uuid_str = str(asset_uuid)
         try:
-            await client.albums.retrieve(gumnut_album_id)
-        except Exception as e:
-            if check_for_error_by_code(e, 404):
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"Album not found {id} -> {gumnut_album_id}",
+            gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
+            await client.albums.assets_associations.add(
+                gumnut_album_id, asset_ids=[gumnut_asset_id]
+            )
+            response.append(BulkIdResponseDto(id=asset_uuid_str, success=True))
+        except ConflictError:
+            response.append(
+                BulkIdResponseDto(
+                    id=asset_uuid_str, success=False, error=Error1.duplicate
                 )
-            raise  # Re-raise other exceptions
-
-        # Process each asset ID
-        response = []
-
-        for asset_uuid in request.ids:
-            asset_uuid_str = str(asset_uuid)
-            try:
-                gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
-
-                # Add asset to album using Gumnut SDK
-                await client.albums.assets_associations.add(
-                    gumnut_album_id, asset_ids=[gumnut_asset_id]
+            )
+        except APIStatusError as asset_error:
+            response.append(
+                BulkIdResponseDto(
+                    id=asset_uuid_str,
+                    success=False,
+                    error=classify_bulk_item_error(asset_error, Error1),
                 )
+            )
+        except GumnutError as asset_error:
+            response.append(
+                BulkIdResponseDto(
+                    id=asset_uuid_str, success=False, error=Error1.unknown
+                )
+            )
+            log_bulk_transport_error(
+                logger,
+                context="add_assets_to_album",
+                exc=asset_error,
+                extra={"asset_id": asset_uuid_str, "album_id": str(id)},
+            )
 
-                # Success response
-                response.append(BulkIdResponseDto(id=asset_uuid_str, success=True))
-
-            except Exception as asset_error:
-                # Handle individual asset errors
-                error_msg = str(asset_error).lower()
-                if "duplicate" in error_msg or "already exists" in error_msg:
-                    response.append(
-                        BulkIdResponseDto(
-                            id=asset_uuid_str, success=False, error=Error1.duplicate
-                        )
-                    )
-                elif (
-                    check_for_error_by_code(asset_error, 404)
-                    or "not found" in error_msg
-                ):
-                    response.append(
-                        BulkIdResponseDto(
-                            id=asset_uuid_str, success=False, error=Error1.not_found
-                        )
-                    )
-                else:
-                    response.append(
-                        BulkIdResponseDto(
-                            id=asset_uuid_str, success=False, error=Error1.unknown
-                        )
-                    )
-
-        return response
-
-    except HTTPException:
-        # Re-raise HTTP exceptions (like 404 for album not found)
-        raise
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to update album assets") from e
+    return response
 
 
 @router.patch("/{id}")
@@ -276,43 +219,22 @@ async def update_album(
     Only name and description are supported by the Gumnut SDK.
     """
 
-    try:
-        gumnut_album_id = uuid_to_gumnut_album_id(id)
+    gumnut_album_id = uuid_to_gumnut_album_id(id)
 
-        # Verify album exists first
-        try:
-            current_album = await client.albums.retrieve(gumnut_album_id)
-        except Exception as e:
-            if check_for_error_by_code(e, 404):
-                raise HTTPException(status_code=404, detail="Album not found")
-            raise  # Re-raise other exceptions
+    update_params = {}
+    if request.albumName is not None:
+        update_params["name"] = request.albumName
+    if request.description is not None:
+        update_params["description"] = request.description
 
-        # Prepare update parameters
-        update_params = {}
-        if request.albumName is not None:
-            update_params["name"] = request.albumName
-        if request.description is not None:
-            update_params["description"] = request.description
+    if update_params:
+        # SDK raises NotFoundError on missing album → handled by global handler.
+        updated_album = await client.albums.update(gumnut_album_id, **update_params)
+    else:
+        # No-op update still needs to validate existence.
+        updated_album = await client.albums.retrieve(gumnut_album_id)
 
-        # Only call update if there are supported parameters to update
-        if update_params:
-            updated_album = await client.albums.update(gumnut_album_id, **update_params)
-        else:
-            # No supported updates, return current album
-            updated_album = current_album
-
-        # Convert Gumnut album to AlbumResponseDto format using utility function
-        immich_album = convert_gumnut_album_to_immich(
-            updated_album, current_user, asset_count=0
-        )
-
-        return immich_album
-
-    except HTTPException:
-        # Re-raise HTTP exceptions (like 404 for album not found)
-        raise
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to update album") from e
+    return convert_gumnut_album_to_immich(updated_album, current_user, asset_count=0)
 
 
 @router.delete("/{id}/assets")
@@ -326,68 +248,39 @@ async def remove_asset_from_album(
     Returns a list of results indicating success/failure for each asset removal.
     """
 
-    try:
-        gumnut_album_id = uuid_to_gumnut_album_id(id)
+    gumnut_album_id = uuid_to_gumnut_album_id(id)
 
-        # Verify album exists first
+    response = []
+    for asset_uuid in request.ids:
+        asset_uuid_str = str(asset_uuid)
         try:
-            await client.albums.retrieve(gumnut_album_id)
-        except Exception as e:
-            if check_for_error_by_code(e, 404):
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"Album not found {id} -> {gumnut_album_id}",
+            gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
+            await client.albums.assets_associations.remove(
+                gumnut_album_id, asset_ids=[gumnut_asset_id]
+            )
+            response.append(BulkIdResponseDto(id=asset_uuid_str, success=True))
+        except APIStatusError as asset_error:
+            response.append(
+                BulkIdResponseDto(
+                    id=asset_uuid_str,
+                    success=False,
+                    error=classify_bulk_item_error(asset_error, Error1),
                 )
-            raise  # Re-raise other exceptions
-
-        # Process each asset ID
-        response = []
-
-        for asset_uuid in request.ids:
-            asset_uuid_str = str(asset_uuid)
-            try:
-                gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
-
-                # Remove asset from album using Gumnut SDK
-                await client.albums.assets_associations.remove(
-                    gumnut_album_id, asset_ids=[gumnut_asset_id]
+            )
+        except GumnutError as asset_error:
+            response.append(
+                BulkIdResponseDto(
+                    id=asset_uuid_str, success=False, error=Error1.unknown
                 )
+            )
+            log_bulk_transport_error(
+                logger,
+                context="remove_asset_from_album",
+                exc=asset_error,
+                extra={"asset_id": asset_uuid_str, "album_id": str(id)},
+            )
 
-                # Success response
-                response.append(BulkIdResponseDto(id=asset_uuid_str, success=True))
-
-            except Exception as asset_error:
-                # Handle individual asset errors
-                error_msg = str(asset_error).lower()
-                if (
-                    check_for_error_by_code(asset_error, 404)
-                    or "not found" in error_msg
-                ):
-                    response.append(
-                        BulkIdResponseDto(
-                            id=asset_uuid_str, success=False, error=Error1.not_found
-                        )
-                    )
-                elif "not in album" in error_msg or "not member" in error_msg:
-                    response.append(
-                        BulkIdResponseDto(
-                            id=asset_uuid_str, success=False, error=Error1.not_found
-                        )
-                    )
-                else:
-                    response.append(
-                        BulkIdResponseDto(
-                            id=asset_uuid_str, success=False, error=Error1.unknown
-                        )
-                    )
-
-        return response
-
-    except HTTPException:
-        # Re-raise HTTP exceptions (like 404 for album not found)
-        raise
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to remove album assets") from e
+    return response
 
 
 @router.delete("/{id}", status_code=204)
@@ -399,28 +292,9 @@ async def delete_album(
     Delete an album using the Gumnut SDK.
     """
 
-    try:
-        gumnut_album_id = uuid_to_gumnut_album_id(id)
-
-        # Verify album exists first
-        try:
-            await client.albums.retrieve(gumnut_album_id)
-        except Exception as e:
-            if check_for_error_by_code(e, 404):
-                raise HTTPException(status_code=404, detail="Album not found")
-            raise  # Re-raise other exceptions
-
-        # Delete the album using Gumnut SDK
-        await client.albums.delete(gumnut_album_id)
-
-        # Return 204 No Content response
-        return Response(status_code=204)
-
-    except HTTPException:
-        # Re-raise HTTP exceptions (like 404 for album not found)
-        raise
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to delete album") from e
+    # SDK raises NotFoundError on missing album → handled by global handler.
+    await client.albums.delete(uuid_to_gumnut_album_id(id))
+    return Response(status_code=204)
 
 
 @router.put("/assets")
@@ -435,59 +309,41 @@ async def add_assets_to_albums(
     Returns a single result indicating overall success/failure.
     """
 
-    try:
-        gumnut_asset_ids = [
-            uuid_to_gumnut_asset_id(asset_uuid) for asset_uuid in request.assetIds
-        ]
+    gumnut_asset_ids = [
+        uuid_to_gumnut_asset_id(asset_uuid) for asset_uuid in request.assetIds
+    ]
 
-        successful_operations = 0
-        total_operations = len(request.albumIds)
-        first_error = None
+    successful_operations = 0
+    total_operations = len(request.albumIds)
+    first_error: BulkIdErrorReason | None = None
 
-        for album_uuid in request.albumIds:
-            try:
-                gumnut_album_id = uuid_to_gumnut_album_id(album_uuid)
-
-                # Verify album exists first
-                try:
-                    await client.albums.retrieve(gumnut_album_id)
-                except Exception as e:
-                    if check_for_error_by_code(e, 404):
-                        if first_error is None:
-                            first_error = BulkIdErrorReason.not_found
-                        continue
-                    raise  # Re-raise other exceptions
-
-                # Add assets to album using Gumnut SDK
-                await client.albums.assets_associations.add(
-                    gumnut_album_id, asset_ids=gumnut_asset_ids
-                )
-                successful_operations += 1
-
-            except Exception as album_error:
-                # Handle individual album errors
-                error_msg = str(album_error).lower()
-                if first_error is None:
-                    if (
-                        check_for_error_by_code(album_error, 404)
-                        or "not found" in error_msg
-                    ):
-                        first_error = BulkIdErrorReason.not_found
-                    elif "duplicate" in error_msg or "already exists" in error_msg:
-                        first_error = BulkIdErrorReason.duplicate
-                    else:
-                        first_error = BulkIdErrorReason.unknown
-
-        # Return success only if all operations succeeded
-        if successful_operations == total_operations:
-            return AlbumsAddAssetsResponseDto(success=True)
-        else:
-            return AlbumsAddAssetsResponseDto(
-                success=False, error=first_error or BulkIdErrorReason.unknown
+    for album_uuid in request.albumIds:
+        try:
+            await client.albums.assets_associations.add(
+                uuid_to_gumnut_album_id(album_uuid), asset_ids=gumnut_asset_ids
+            )
+            successful_operations += 1
+        except ConflictError:
+            if first_error is None:
+                first_error = BulkIdErrorReason.duplicate
+        except APIStatusError as album_error:
+            if first_error is None:
+                first_error = classify_bulk_item_error(album_error, BulkIdErrorReason)
+        except GumnutError as album_error:
+            if first_error is None:
+                first_error = BulkIdErrorReason.unknown
+            log_bulk_transport_error(
+                logger,
+                context="add_assets_to_albums",
+                exc=album_error,
+                extra={"album_id": str(album_uuid)},
             )
 
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to add assets to albums") from e
+    if successful_operations == total_operations:
+        return AlbumsAddAssetsResponseDto(success=True)
+    return AlbumsAddAssetsResponseDto(
+        success=False, error=first_error or BulkIdErrorReason.unknown
+    )
 
 
 @router.delete("/{id}/user/{userId}", status_code=204)

--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -18,13 +18,18 @@ from fastapi import (
     status,
 )
 from fastapi.responses import JSONResponse, StreamingResponse
-from gumnut import AsyncGumnut, GumnutError
+from gumnut import APIStatusError, AsyncGumnut, GumnutError, NotFoundError
 from gumnut.types.asset_response import AssetResponse
 
 from config.settings import Settings, get_settings
 from routers.utils.cdn_client import DEFAULT_FORWARDED_HEADERS, stream_from_cdn
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
-from routers.utils.error_mapping import map_gumnut_error, check_for_error_by_code
+from routers.utils.error_mapping import (
+    log_bulk_transport_error,
+    log_upstream_response,
+    map_gumnut_error,
+    truncated_error_detail,
+)
 from routers.utils.current_user import get_current_user, get_current_user_id
 from pydantic import ValidationError
 from socketio.exceptions import SocketIOError
@@ -102,36 +107,26 @@ async def _retrieve_and_stream_variant(
     Returns:
         StreamingResponse streaming CDN bytes to the Immich client.
     """
-    try:
-        gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
+    gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
+    asset = await client.assets.retrieve(gumnut_asset_id)
 
-        asset = await client.assets.retrieve(gumnut_asset_id)
-
-        if not asset.asset_urls or variant not in asset.asset_urls:
-            logger.warning(
-                "Asset variant not available",
-                extra={"variant": variant, "asset_id": gumnut_asset_id},
-            )
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Asset variant '{variant}' not available",
-            )
-
-        variant_info = asset.asset_urls[variant]
-        cdn_url = variant_info.url
-        mimetype = variant_info.mimetype
-
-        return await stream_from_cdn(
-            cdn_url,
-            mimetype,
-            range_header=range_header,
-            forwarded_headers=forwarded_headers,
+    if not asset.asset_urls or variant not in asset.asset_urls:
+        logger.warning(
+            "Asset variant not available",
+            extra={"variant": variant, "asset_id": gumnut_asset_id},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Asset variant '{variant}' not available",
         )
 
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to fetch asset") from e
+    variant_info = asset.asset_urls[variant]
+    return await stream_from_cdn(
+        variant_info.url,
+        variant_info.mimetype,
+        range_header=range_header,
+        forwarded_headers=forwarded_headers,
+    )
 
 
 def _immich_checksum_to_base64(checksum: str) -> str:
@@ -176,54 +171,39 @@ async def bulk_upload_check(
     Check which assets from a bulk upload already exist in Gumnut.
     """
 
-    try:
-        results = []
-        # Convert Immich checksums (hex or base64) to base64 for Gumnut
-        # Build a map to avoid converting each checksum twice
-        checksum_to_b64 = {
-            asset.checksum: _immich_checksum_to_base64(asset.checksum)
-            for asset in request.assets
-        }
+    results = []
+    # Build a map to avoid converting each checksum twice
+    checksum_to_b64 = {
+        asset.checksum: _immich_checksum_to_base64(asset.checksum)
+        for asset in request.assets
+    }
 
-        existing_assets_response = await client.assets.check_existence(
-            checksum_sha1s=list(checksum_to_b64.values())
-        )
-        existing_assets = existing_assets_response.assets
+    existing_assets_response = await client.assets.check_existence(
+        checksum_sha1s=list(checksum_to_b64.values())
+    )
 
-        # Build a lookup map from base64 checksum to existing asset
-        b64_to_existing_asset = {
-            existing_asset.checksum_sha1: existing_asset
-            for existing_asset in existing_assets
-            if existing_asset.checksum_sha1
-        }
+    b64_to_existing_asset = {
+        existing_asset.checksum_sha1: existing_asset
+        for existing_asset in existing_assets_response.assets
+        if existing_asset.checksum_sha1
+    }
 
-        for asset in request.assets:
-            # Look up the pre-computed base64 checksum
-            checksum_b64 = checksum_to_b64[asset.checksum]
-            existing_asset = b64_to_existing_asset.get(checksum_b64)
+    for asset in request.assets:
+        existing_asset = b64_to_existing_asset.get(checksum_to_b64[asset.checksum])
+        if existing_asset:
+            results.append(
+                {
+                    "id": asset.id,
+                    "action": "reject",
+                    "reason": "duplicate",
+                    "assetId": str(safe_uuid_from_asset_id(existing_asset.id)),
+                    "isTrashed": False,
+                }
+            )
+        else:
+            results.append({"id": asset.id, "action": "accept"})
 
-            if existing_asset:
-                results.append(
-                    {
-                        "id": asset.id,
-                        "action": "reject",
-                        "reason": "duplicate",
-                        "assetId": str(safe_uuid_from_asset_id(existing_asset.id)),
-                        "isTrashed": False,
-                    }
-                )
-            else:
-                results.append(
-                    {
-                        "id": asset.id,
-                        "action": "accept",
-                    }
-                )
-
-        return AssetBulkUploadCheckResponseDto(results=results)
-
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to check bulk upload assets") from e
+    return AssetBulkUploadCheckResponseDto(results=results)
 
 
 @router.post("/exist")
@@ -234,17 +214,13 @@ async def check_existing_assets(
     """
     Check if multiple assets exist on the server and return all existing.
     """
-    try:
-        existing_assets_response = await client.assets.check_existence(
-            device_id=request.deviceId, device_asset_ids=request.deviceAssetIds
-        )
-        existing_ids = [
-            str(safe_uuid_from_asset_id(asset.id))
-            for asset in existing_assets_response.assets
-        ]
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to check existing assets") from e
-
+    existing_assets_response = await client.assets.check_existence(
+        device_id=request.deviceId, device_asset_ids=request.deviceAssetIds
+    )
+    existing_ids = [
+        str(safe_uuid_from_asset_id(asset.id))
+        for asset in existing_assets_response.assets
+    ]
     return CheckExistingAssetsResponseDto(existingIds=existing_ids)
 
 
@@ -480,19 +456,18 @@ async def _upload_buffered(
             )
 
         except Exception as e:
-            logger.error(
-                "Upload failed",
+            raise map_gumnut_error(
+                e,
+                "Failed to upload asset",
                 extra={
                     "upload_filename": asset_data.filename,
                     "content_type": asset_data.content_type,
                     "device_asset_id": device_asset_id,
                     "device_id": device_id,
                     "strategy": "buffered",
-                    "error": str(e),
                 },
                 exc_info=True,
-            )
-            raise map_gumnut_error(e, "Failed to upload asset") from e
+            ) from e
 
 
 async def _upload_streaming(
@@ -580,17 +555,24 @@ async def _upload_streaming(
             status_code=status.HTTP_502_BAD_GATEWAY, detail="Upload failed"
         )
     except Exception as e:
-        logger.error(
-            "Streaming upload failed",
-            extra={
-                "upload_filename": pipeline.form_parser.filename if pipeline else None,
-                "content_type": pipeline.form_parser.content_type if pipeline else None,
-                "strategy": "streaming",
-                "error": str(e),
-            },
+        log_extra = {"strategy": "streaming"}
+        if pipeline is not None:
+            form_parser = pipeline.form_parser
+            if form_parser.filename:
+                log_extra["upload_filename"] = form_parser.filename
+            if form_parser.content_type:
+                log_extra["content_type"] = form_parser.content_type
+            if device_asset_id := form_parser.form_fields.get("deviceAssetId"):
+                log_extra["device_asset_id"] = device_asset_id
+            if device_id := form_parser.form_fields.get("deviceId"):
+                log_extra["device_id"] = device_id
+
+        raise map_gumnut_error(
+            e,
+            "Failed to upload asset",
+            extra=log_extra,
             exc_info=True,
-        )
-        raise map_gumnut_error(e, "Failed to upload asset") from e
+        ) from e
 
 
 @router.put("", status_code=204)
@@ -617,64 +599,66 @@ async def delete_assets(
     Deletes assets by their IDs. The force parameter is ignored as Gumnut handles deletion directly.
     """
 
-    try:
-        # Process each asset ID for deletion
-        for asset_uuid in request.ids:
+    for asset_uuid in request.ids:
+        try:
+            gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
+            await client.assets.delete(gumnut_asset_id)
+
             try:
-                gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
+                await emit_user_event(
+                    WebSocketEvent.ASSET_DELETE,
+                    str(current_user_id),
+                    str(asset_uuid),
+                )
+            except SocketIOError as ws_error:
+                logger.warning(
+                    "Failed to emit WebSocket event after asset delete",
+                    extra={
+                        "asset_id": str(asset_uuid),
+                        "gumnut_id": str(gumnut_asset_id),
+                        "error": str(ws_error),
+                    },
+                )
 
-                await client.assets.delete(gumnut_asset_id)
+        except NotFoundError as asset_error:
+            # Asset is already gone; expected during sync, log and continue.
+            log_upstream_response(
+                logger,
+                context="delete_assets",
+                status_code=404,
+                message=f"Asset {asset_uuid} not found during deletion",
+                extra={
+                    "asset_id": str(asset_uuid),
+                    "gumnut_id": str(gumnut_asset_id),
+                    "error_detail": truncated_error_detail(asset_error),
+                },
+            )
+        except APIStatusError as asset_error:
+            # Don't abort bulk delete on individual upstream errors.
+            log_upstream_response(
+                logger,
+                context="delete_assets",
+                status_code=asset_error.status_code,
+                message=f"Failed to delete asset {asset_uuid}",
+                extra={
+                    "asset_id": str(asset_uuid),
+                    "gumnut_id": str(gumnut_asset_id),
+                    "error_detail": truncated_error_detail(asset_error),
+                },
+            )
+        except GumnutError as asset_error:
+            # Immich expects best-effort partial deletion; record per-item.
+            log_bulk_transport_error(
+                logger,
+                context="delete_assets",
+                exc=asset_error,
+                extra={
+                    "asset_id": str(asset_uuid),
+                    "gumnut_id": str(gumnut_asset_id),
+                },
+            )
 
-                # Emit WebSocket event for real-time timeline sync
-                try:
-                    await emit_user_event(
-                        WebSocketEvent.ASSET_DELETE,
-                        str(current_user_id),
-                        str(asset_uuid),
-                    )
-                except SocketIOError as ws_error:
-                    logger.warning(
-                        "Failed to emit WebSocket event after asset delete",
-                        extra={
-                            "asset_id": str(asset_uuid),
-                            "gumnut_id": str(gumnut_asset_id),
-                            "error": str(ws_error),
-                        },
-                    )
-
-            except GumnutError as asset_error:
-                # Log individual asset errors but continue with other deletions
-                if (
-                    check_for_error_by_code(asset_error, 404)
-                    or "not found" in str(asset_error).lower()
-                ):
-                    # Asset already deleted or doesn't exist, continue
-                    logger.warning(
-                        f"Warning: Asset {asset_uuid} not found during deletion",
-                        extra={
-                            "asset_id": str(asset_uuid),
-                            "gumnut_id": str(gumnut_asset_id),
-                            "error": str(asset_error),
-                        },
-                    )
-                    continue
-                else:
-                    # For other errors, log but continue
-                    logger.warning(
-                        f"Warning: Failed to delete asset {asset_uuid}",
-                        extra={
-                            "asset_id": str(asset_uuid),
-                            "gumnut_id": str(gumnut_asset_id),
-                            "error": str(asset_error),
-                        },
-                    )
-                    continue
-
-        # Return 204 No Content on successful completion
-        return Response(status_code=204)
-
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to delete assets") from e
+    return Response(status_code=204)
 
 
 @router.get("/device/{deviceId}", deprecated=True)
@@ -702,34 +686,25 @@ async def get_asset_statistics(
     Counts total assets and categorizes them by type (images vs videos) using mime_type.
     """
 
-    try:
-        # Get all assets from Gumnut
-        gumnut_assets = client.assets.list()
+    gumnut_assets = client.assets.list()
 
-        # Count assets by type
-        total_assets = 0
-        image_count = 0
-        video_count = 0
+    total_assets = 0
+    image_count = 0
+    video_count = 0
 
-        async for asset in gumnut_assets:
-            total_assets += 1
+    async for asset in gumnut_assets:
+        total_assets += 1
+        asset_type = mime_type_to_asset_type(asset.mime_type)
+        if asset_type == AssetTypeEnum.IMAGE:
+            image_count += 1
+        elif asset_type == AssetTypeEnum.VIDEO:
+            video_count += 1
 
-            # Check mime_type to determine if it's an image or video
-            asset_type = mime_type_to_asset_type(asset.mime_type)
-            if asset_type == AssetTypeEnum.IMAGE:
-                image_count += 1
-            elif asset_type == AssetTypeEnum.VIDEO:
-                video_count += 1
-            # Note: Other types (audio, etc.) are not counted separately but are included in total
-
-        return AssetStatsResponseDto(
-            images=image_count,
-            videos=video_count,
-            total=total_assets,
-        )
-
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to fetch asset statistics") from e
+    return AssetStatsResponseDto(
+        images=image_count,
+        videos=video_count,
+        total=total_assets,
+    )
 
 
 @router.get("/random", deprecated=True)
@@ -796,19 +771,9 @@ async def get_asset_info(
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
     current_user: UserResponseDto = Depends(get_current_user),
 ) -> AssetResponseDto:
-    try:
-        gumnut_asset_id = uuid_to_gumnut_asset_id(id)
-
-        # Retrieve the specific asset from Gumnut
-        gumnut_asset = await client.assets.retrieve(gumnut_asset_id)
-
-        # Convert Gumnut asset to AssetResponseDto format
-        immich_asset = convert_gumnut_asset_to_immich(gumnut_asset, current_user)
-
-        return immich_asset
-
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to fetch asset") from e
+    gumnut_asset_id = uuid_to_gumnut_asset_id(id)
+    gumnut_asset = await client.assets.retrieve(gumnut_asset_id)
+    return convert_gumnut_asset_to_immich(gumnut_asset, current_user)
 
 
 @router.get(

--- a/routers/api/faces.py
+++ b/routers/api/faces.py
@@ -13,7 +13,6 @@ from routers.immich_models import (
     PersonResponseDto,
     SourceType,
 )
-from routers.utils.error_mapping import map_gumnut_error
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
 from routers.utils.gumnut_id_conversion import (
     safe_uuid_from_face_id,
@@ -40,11 +39,8 @@ async def delete_face(
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
 ):
     """Deletes a specific face by ID."""
-    try:
-        gumnut_face_id = uuid_to_gumnut_face_id(id)
-        await client.faces.delete(gumnut_face_id)
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to delete face") from e
+    gumnut_face_id = uuid_to_gumnut_face_id(id)
+    await client.faces.delete(gumnut_face_id)
 
 
 @router.put("/{id}", response_model=PersonResponseDto)
@@ -54,14 +50,11 @@ async def reassign_faces_by_id(
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
 ):
     """Reassigns a face to a different person."""
-    try:
-        gumnut_face_id = uuid_to_gumnut_face_id(id)
-        gumnut_person_id = uuid_to_gumnut_person_id(request.id)
-        await client.faces.update(gumnut_face_id, person_id=gumnut_person_id)
-        gumnut_person = await client.people.retrieve(gumnut_person_id)
-        return convert_gumnut_person_to_immich(gumnut_person)
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to reassign face") from e
+    gumnut_face_id = uuid_to_gumnut_face_id(id)
+    gumnut_person_id = uuid_to_gumnut_person_id(request.id)
+    await client.faces.update(gumnut_face_id, person_id=gumnut_person_id)
+    gumnut_person = await client.people.retrieve(gumnut_person_id)
+    return convert_gumnut_person_to_immich(gumnut_person)
 
 
 @router.get("")
@@ -70,54 +63,50 @@ async def get_faces(
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
 ) -> List[AssetFaceResponseDto]:
     """Get all faces detected in an asset."""
-    try:
-        gumnut_asset_id = uuid_to_gumnut_asset_id(id)
+    gumnut_asset_id = uuid_to_gumnut_asset_id(id)
 
-        faces = [f async for f in client.faces.list(asset_id=gumnut_asset_id)]
-        if not faces:
-            return []
+    faces = [f async for f in client.faces.list(asset_id=gumnut_asset_id)]
+    if not faces:
+        return []
 
-        asset = await client.assets.retrieve(gumnut_asset_id)
+    asset = await client.assets.retrieve(gumnut_asset_id)
 
-        image_width = asset.width or 0
-        image_height = asset.height or 0
+    image_width = asset.width or 0
+    image_height = asset.height or 0
 
-        # Batch-fetch unique people referenced by faces
-        person_ids = {f.person_id for f in faces if f.person_id}
-        people_by_id: dict[str, PersonResponseDto] = {}
-        for person_id in person_ids:
-            try:
-                gumnut_person = await client.people.retrieve(person_id)
-                people_by_id[person_id] = convert_gumnut_person_to_immich(gumnut_person)
-            except Exception:
-                logger.warning(
-                    "Failed to fetch person for face",
-                    extra={"person_id": person_id, "asset_id": gumnut_asset_id},
-                )
-
-        result: List[AssetFaceResponseDto] = []
-        for face in faces:
-            bb = face.bounding_box or {}
-            person = people_by_id.get(face.person_id) if face.person_id else None
-
-            result.append(
-                AssetFaceResponseDto(
-                    id=safe_uuid_from_face_id(face.id),
-                    boundingBoxX1=bb.get("x", 0),
-                    boundingBoxX2=bb.get("x", 0) + bb.get("w", 0),
-                    boundingBoxY1=bb.get("y", 0),
-                    boundingBoxY2=bb.get("y", 0) + bb.get("h", 0),
-                    imageWidth=image_width,
-                    imageHeight=image_height,
-                    person=person,
-                    sourceType=SourceType.machine_learning,
-                )
+    # Batch-fetch unique people referenced by faces
+    person_ids = {f.person_id for f in faces if f.person_id}
+    people_by_id: dict[str, PersonResponseDto] = {}
+    for person_id in person_ids:
+        try:
+            gumnut_person = await client.people.retrieve(person_id)
+            people_by_id[person_id] = convert_gumnut_person_to_immich(gumnut_person)
+        except Exception:
+            logger.warning(
+                "Failed to fetch person for face",
+                extra={"person_id": person_id, "asset_id": gumnut_asset_id},
             )
 
-        return result
+    result: List[AssetFaceResponseDto] = []
+    for face in faces:
+        bb = face.bounding_box or {}
+        person = people_by_id.get(face.person_id) if face.person_id else None
 
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to fetch faces") from e
+        result.append(
+            AssetFaceResponseDto(
+                id=safe_uuid_from_face_id(face.id),
+                boundingBoxX1=bb.get("x", 0),
+                boundingBoxX2=bb.get("x", 0) + bb.get("w", 0),
+                boundingBoxY1=bb.get("y", 0),
+                boundingBoxY2=bb.get("y", 0) + bb.get("h", 0),
+                imageWidth=image_width,
+                imageHeight=image_height,
+                person=person,
+                sourceType=SourceType.machine_learning,
+            )
+        )
+
+    return result
 
 
 @router.post("", status_code=201)

--- a/routers/api/people.py
+++ b/routers/api/people.py
@@ -4,12 +4,16 @@ from fastapi.responses import StreamingResponse
 from uuid import UUID
 import logging
 
-from gumnut import AsyncGumnut
+from gumnut import APIStatusError, AsyncGumnut, GumnutError
 from gumnut.types import PersonResponse
 
 from routers.utils.cdn_client import stream_from_cdn
+from routers.utils.error_mapping import (
+    classify_bulk_item_error,
+    log_bulk_transport_error,
+    log_upstream_response,
+)
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
-from routers.utils.error_mapping import map_gumnut_error, check_for_error_by_code
 from routers.immich_models import (
     AssetFaceUpdateDto,
     BulkIdResponseDto,
@@ -95,18 +99,13 @@ async def create_person(
     """
     Create a new person.
     """
-    try:
-        gumnut_person = await client.people.create(
-            name=person_data.name,
-            birth_date=person_data.birthDate,
-            is_favorite=person_data.isFavorite,
-            is_hidden=person_data.isHidden,
-        )
-
-        return convert_gumnut_person_to_immich(gumnut_person)
-
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to create person") from e
+    gumnut_person = await client.people.create(
+        name=person_data.name,
+        birth_date=person_data.birthDate,
+        is_favorite=person_data.isFavorite,
+        is_hidden=person_data.isHidden,
+    )
+    return convert_gumnut_person_to_immich(gumnut_person)
 
 
 @router.put("")
@@ -161,32 +160,57 @@ async def update_people(
             results.append(
                 BulkIdResponseDto(id=person_item.id, success=False, error=error)
             )
-            logger.warning(
-                "HTTPException in bulk person update for %s: %s %s",
-                person_item.id,
-                he.status_code,
-                he.detail,
+            log_upstream_response(
+                logger,
+                context="update_people",
+                status_code=he.status_code,
+                message=(
+                    f"HTTPException in bulk person update for {person_item.id}: "
+                    f"{he.status_code} {he.detail}"
+                ),
+                extra={"person_id": person_item.id},
             )
-        except Exception as e:
-            error_msg = str(e).lower()
-            if check_for_error_by_code(e, 404) or "not found" in error_msg:
-                results.append(
-                    BulkIdResponseDto(
-                        id=person_item.id, success=False, error=Error1.not_found
-                    )
+        except APIStatusError as person_error:
+            results.append(
+                BulkIdResponseDto(
+                    id=person_item.id,
+                    success=False,
+                    error=classify_bulk_item_error(person_error, Error1),
                 )
-            elif check_for_error_by_code(e, 401) or "invalid api key" in error_msg:
-                results.append(
-                    BulkIdResponseDto(
-                        id=person_item.id, success=False, error=Error1.no_permission
-                    )
+            )
+            log_upstream_response(
+                logger,
+                context="update_people",
+                status_code=person_error.status_code,
+                message=f"Failed bulk person update for {person_item.id}: {person_error}",
+                extra={"person_id": person_item.id},
+            )
+        except ValueError as ve:
+            # Immich's PeopleUpdateItem.id is typed as `str` (the OpenAPI spec
+            # switches between str and UUID for people ids), so UUID(...) can
+            # raise here on malformed input. A single bad id must not abort
+            # the batch.
+            results.append(
+                BulkIdResponseDto(
+                    id=person_item.id, success=False, error=Error1.unknown
                 )
-            else:
-                results.append(
-                    BulkIdResponseDto(
-                        id=person_item.id, success=False, error=Error1.unknown
-                    )
+            )
+            logger.warning(
+                "Invalid person id in bulk update",
+                extra={"person_id": person_item.id, "error": str(ve)},
+            )
+        except GumnutError as person_error:
+            results.append(
+                BulkIdResponseDto(
+                    id=person_item.id, success=False, error=Error1.unknown
                 )
+            )
+            log_bulk_transport_error(
+                logger,
+                context="update_people",
+                exc=person_error,
+                extra={"person_id": person_item.id},
+            )
 
     return results
 
@@ -200,33 +224,25 @@ async def update_person(
     """
     Update a person by their id.
     """
-    try:
-        # Update the person using Gumnut SDK - only pass parameters that are not None
-        update_kwargs = {}
-        gumnut_person_id = uuid_to_gumnut_person_id(id)
-        if person_data.name is not None:
-            update_kwargs["name"] = person_data.name
-        if person_data.birthDate is not None:
-            update_kwargs["birth_date"] = person_data.birthDate
-        if person_data.isFavorite is not None:
-            update_kwargs["is_favorite"] = person_data.isFavorite
-        if person_data.isHidden is not None:
-            update_kwargs["is_hidden"] = person_data.isHidden
-        if person_data.featureFaceAssetId is not None:
-            update_kwargs["thumbnail_face_id"] = await _resolve_thumbnail_face_id(
-                client, gumnut_person_id, person_data.featureFaceAssetId
-            )
-
-        gumnut_person = await client.people.update(
-            person_id=gumnut_person_id, **update_kwargs
+    update_kwargs = {}
+    gumnut_person_id = uuid_to_gumnut_person_id(id)
+    if person_data.name is not None:
+        update_kwargs["name"] = person_data.name
+    if person_data.birthDate is not None:
+        update_kwargs["birth_date"] = person_data.birthDate
+    if person_data.isFavorite is not None:
+        update_kwargs["is_favorite"] = person_data.isFavorite
+    if person_data.isHidden is not None:
+        update_kwargs["is_hidden"] = person_data.isHidden
+    if person_data.featureFaceAssetId is not None:
+        update_kwargs["thumbnail_face_id"] = await _resolve_thumbnail_face_id(
+            client, gumnut_person_id, person_data.featureFaceAssetId
         )
 
-        return convert_gumnut_person_to_immich(gumnut_person)
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to update person") from e
+    gumnut_person = await client.people.update(
+        person_id=gumnut_person_id, **update_kwargs
+    )
+    return convert_gumnut_person_to_immich(gumnut_person)
 
 
 @router.get("")
@@ -241,40 +257,30 @@ async def get_all_people(
     """
     Get all people with optional pagination and filtering.
     """
-    try:
-        # Get all people from Gumnut
-        gumnut_people = client.people.list(name_filter="all")
-        all_people = [p async for p in gumnut_people]
+    gumnut_people = client.people.list(name_filter="all")
+    all_people = [p async for p in gumnut_people]
 
-        # Count hidden before filtering so the response includes the total
-        hidden_count = sum(1 for p in all_people if p.is_hidden)
+    # Count hidden before filtering so the response includes the total
+    hidden_count = sum(1 for p in all_people if p.is_hidden)
 
-        # Filter hidden people first (before sorting and pagination)
-        if withHidden is False:
-            all_people = [p for p in all_people if not p.is_hidden]
+    if withHidden is False:
+        all_people = [p for p in all_people if not p.is_hidden]
 
-        # Sort to match Immich's expected ordering
-        all_people.sort(key=_immich_people_sort_key)
+    all_people.sort(key=_immich_people_sort_key)
 
-        total_count = len(all_people)
+    total_count = len(all_people)
 
-        # Apply pagination after filtering and sorting
-        start_index = (page - 1) * size
-        end_index = start_index + size
-        page_people = all_people[start_index:end_index]
-        has_next_page = end_index < total_count
+    start_index = (page - 1) * size
+    end_index = start_index + size
+    page_people = all_people[start_index:end_index]
+    has_next_page = end_index < total_count
 
-        converted_people = [convert_gumnut_person_to_immich(p) for p in page_people]
-
-        return PeopleResponseDto(
-            people=converted_people,
-            hasNextPage=has_next_page,
-            total=total_count,
-            hidden=hidden_count,
-        )
-
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to fetch people") from e
+    return PeopleResponseDto(
+        people=[convert_gumnut_person_to_immich(p) for p in page_people],
+        hasNextPage=has_next_page,
+        total=total_count,
+        hidden=hidden_count,
+    )
 
 
 @router.delete("", status_code=204)
@@ -285,14 +291,9 @@ async def delete_people(
     """
     Delete multiple people by their ids.
     """
-    try:
-        for person_id in request.ids:
-            await client.people.delete(uuid_to_gumnut_person_id(person_id))
-
-        return Response(status_code=204)
-
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to delete people") from e
+    for person_id in request.ids:
+        await client.people.delete(uuid_to_gumnut_person_id(person_id))
+    return Response(status_code=204)
 
 
 @router.get(
@@ -316,30 +317,16 @@ async def get_thumbnail(
     Get a thumbnail for a person.
     Retrieves person metadata and streams the thumbnail from CDN.
     """
-    try:
-        gumnut_person = await client.people.retrieve(uuid_to_gumnut_person_id(id))
+    gumnut_person = await client.people.retrieve(uuid_to_gumnut_person_id(id))
 
-        if (
-            not gumnut_person
-            or not gumnut_person.asset_urls
-            or "thumbnail" not in gumnut_person.asset_urls
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Person or thumbnail not found",
-            )
+    if not gumnut_person.asset_urls or "thumbnail" not in gumnut_person.asset_urls:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Person thumbnail not available",
+        )
 
-        variant_info = gumnut_person.asset_urls["thumbnail"]
-        cdn_url = variant_info.url
-        mimetype = variant_info.mimetype
-
-        return await stream_from_cdn(cdn_url, mimetype)
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.warning(f"Error fetching thumbnail for person {id}: {e}")
-        raise map_gumnut_error(e, "Failed to fetch person thumbnail") from e
+    variant_info = gumnut_person.asset_urls["thumbnail"]
+    return await stream_from_cdn(variant_info.url, variant_info.mimetype)
 
 
 @router.get("/{id}")
@@ -350,19 +337,8 @@ async def get_person(
     """
     Get details for a specific person.
     """
-    try:
-        gumnut_person = await client.people.retrieve(uuid_to_gumnut_person_id(id))
-
-        if not gumnut_person:
-            raise HTTPException(status_code=404, detail="Person not found")
-
-        return convert_gumnut_person_to_immich(gumnut_person)
-
-    except HTTPException:
-        # Re-raise HTTP exceptions (like 404 for person not found)
-        raise
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to fetch person") from e
+    gumnut_person = await client.people.retrieve(uuid_to_gumnut_person_id(id))
+    return convert_gumnut_person_to_immich(gumnut_person)
 
 
 @router.get("/{id}/statistics")
@@ -373,18 +349,11 @@ async def get_person_statistics(
     """
     Get asset statistics for a specific person.
     """
-    try:
-        gumnut_assets = client.assets.list(person_id=uuid_to_gumnut_person_id(id))
+    gumnut_assets = client.assets.list(person_id=uuid_to_gumnut_person_id(id))
 
-        if not gumnut_assets:
-            return PersonStatisticsResponseDto(assets=0)
-        else:
-            return PersonStatisticsResponseDto(
-                assets=len([a async for a in gumnut_assets])
-            )
-
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to fetch person statistics") from e
+    if not gumnut_assets:
+        return PersonStatisticsResponseDto(assets=0)
+    return PersonStatisticsResponseDto(assets=len([a async for a in gumnut_assets]))
 
 
 @router.delete("/{id}", status_code=204)
@@ -395,13 +364,8 @@ async def delete_person(
     """
     Delete a person by their id.
     """
-    try:
-        await client.people.delete(uuid_to_gumnut_person_id(id))
-
-        return Response(status_code=204)
-
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to delete person") from e
+    await client.people.delete(uuid_to_gumnut_person_id(id))
+    return Response(status_code=204)
 
 
 @router.post("/{id}/merge")
@@ -427,47 +391,40 @@ async def reassign_faces(
     (body personId) on the given asset and reassigns it to the target person
     (URL {id}). Returns the target person if any faces were reassigned.
     """
-    try:
-        if not request.data:
-            return []
+    if not request.data:
+        return []
 
-        gumnut_target_person_id = uuid_to_gumnut_person_id(id)
+    gumnut_target_person_id = uuid_to_gumnut_person_id(id)
 
-        # Validate and cache the target person before modifying any faces
-        gumnut_person = await client.people.retrieve(gumnut_target_person_id)
-        target_person = convert_gumnut_person_to_immich(gumnut_person)
+    # Validate and cache the target person before modifying any faces
+    gumnut_person = await client.people.retrieve(gumnut_target_person_id)
+    target_person = convert_gumnut_person_to_immich(gumnut_person)
 
-        any_reassigned = False
-        for item in request.data:
-            gumnut_asset_id = uuid_to_gumnut_asset_id(item.assetId)
-            gumnut_source_person_id = uuid_to_gumnut_person_id(item.personId)
+    any_reassigned = False
+    for item in request.data:
+        gumnut_asset_id = uuid_to_gumnut_asset_id(item.assetId)
+        gumnut_source_person_id = uuid_to_gumnut_person_id(item.personId)
 
-            # Find all faces belonging to the source person on this asset
-            faces = [
-                f
-                async for f in client.faces.list(
-                    person_id=gumnut_source_person_id,
-                    asset_id=gumnut_asset_id,
-                )
-            ]
-            if not faces:
-                logger.warning(
-                    "No face found for source person on asset, skipping",
-                    extra={
-                        "source_person_id": gumnut_source_person_id,
-                        "target_person_id": gumnut_target_person_id,
-                        "asset_id": gumnut_asset_id,
-                    },
-                )
-                continue
+        faces = [
+            f
+            async for f in client.faces.list(
+                person_id=gumnut_source_person_id,
+                asset_id=gumnut_asset_id,
+            )
+        ]
+        if not faces:
+            logger.warning(
+                "No face found for source person on asset, skipping",
+                extra={
+                    "source_person_id": gumnut_source_person_id,
+                    "target_person_id": gumnut_target_person_id,
+                    "asset_id": gumnut_asset_id,
+                },
+            )
+            continue
 
-            for face in faces:
-                await client.faces.update(face.id, person_id=gumnut_target_person_id)
-            any_reassigned = True
+        for face in faces:
+            await client.faces.update(face.id, person_id=gumnut_target_person_id)
+        any_reassigned = True
 
-        return [target_person] if any_reassigned else []
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to reassign faces") from e
+    return [target_person] if any_reassigned else []

--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -1,13 +1,12 @@
 import logging
 from typing import List
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from uuid import UUID
 from datetime import datetime
 from gumnut import AsyncGumnut
 
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
 from routers.utils.current_user import get_current_user
-from routers.utils.error_mapping import check_for_error_by_code, map_gumnut_error
 from routers.utils.gumnut_id_conversion import uuid_to_gumnut_person_id
 from routers.utils.person_conversion import convert_gumnut_person_to_immich
 from routers.immich_models import (
@@ -103,13 +102,10 @@ async def search_person(
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
 ) -> List[PersonResponseDto]:
     """Search for people by name."""
-    try:
-        people = [p async for p in client.people.list(name=name)]
-        if withHidden is False:
-            people = [p for p in people if not p.is_hidden]
-        return [convert_gumnut_person_to_immich(p) for p in people]
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to search people") from e
+    people = [p async for p in client.people.list(name=name)]
+    if withHidden is False:
+        people = [p for p in people if not p.is_hidden]
+    return [convert_gumnut_person_to_immich(p) for p in people]
 
 
 @router.get("/places")
@@ -147,12 +143,9 @@ async def search_asset_statistics(
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
 ) -> SearchStatisticsResponseDto:
     """Get asset count statistics."""
-    try:
-        buckets = await fetch_asset_counts(client)
-        total = sum(bucket.count for bucket in buckets)
-        return SearchStatisticsResponseDto(total=total)
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to get search statistics") from e
+    buckets = await fetch_asset_counts(client)
+    total = sum(bucket.count for bucket in buckets)
+    return SearchStatisticsResponseDto(total=total)
 
 
 @router.post("/metadata")
@@ -162,42 +155,39 @@ async def search_assets(
     current_user: UserResponseDto = Depends(get_current_user),
 ) -> SearchResponseDto:
     """Search for assets by metadata filters."""
-    try:
-        person_ids = None
-        if request.personIds:
-            person_ids = [uuid_to_gumnut_person_id(pid) for pid in request.personIds]
+    person_ids = None
+    if request.personIds:
+        person_ids = [uuid_to_gumnut_person_id(pid) for pid in request.personIds]
 
-        limit = int(request.size) if request.size else 50
-        page = int(request.page) if request.page else 1
+    limit = int(request.size) if request.size else 50
+    page = int(request.page) if request.page else 1
 
-        gumnut_results = await client.search.search(
-            query=request.description,
-            captured_after=request.takenAfter,
-            captured_before=request.takenBefore,
-            person_ids=person_ids,
-            limit=limit,
-            page=page,
-        )
+    gumnut_results = await client.search.search(
+        query=request.description,
+        captured_after=request.takenAfter,
+        captured_before=request.takenBefore,
+        person_ids=person_ids,
+        limit=limit,
+        page=page,
+    )
 
-        immich_assets = []
-        if gumnut_results and gumnut_results.data:
-            for item in gumnut_results.data:
-                immich_assets.append(
-                    convert_gumnut_asset_to_immich(item.asset, current_user)
-                )
+    immich_assets = []
+    if gumnut_results and gumnut_results.data:
+        for item in gumnut_results.data:
+            immich_assets.append(
+                convert_gumnut_asset_to_immich(item.asset, current_user)
+            )
 
-        return SearchResponseDto(
-            albums=SearchAlbumResponseDto(count=0, facets=[], items=[], total=0),
-            assets=SearchAssetResponseDto(
-                count=len(immich_assets),
-                facets=[],
-                items=immich_assets,
-                nextPage="",
-                total=len(immich_assets),
-            ),
-        )
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to search assets by metadata") from e
+    return SearchResponseDto(
+        albums=SearchAlbumResponseDto(count=0, facets=[], items=[], total=0),
+        assets=SearchAssetResponseDto(
+            count=len(immich_assets),
+            facets=[],
+            items=immich_assets,
+            nextPage="",
+            total=len(immich_assets),
+        ),
+    )
 
 
 @router.post("/smart")
@@ -206,48 +196,26 @@ async def search_smart(
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
     current_user: UserResponseDto = Depends(get_current_user),
 ) -> SearchResponseDto:
-    """
-    Smart search for assets.
-    This is a stub implementation that returns empty results.
-    """
-    try:
-        gumnut_assets = await client.search.search(query=request.query)
+    """Smart search for assets."""
+    gumnut_assets = await client.search.search(query=request.query)
 
-        # Convert Gumnut assets to Immich format
-        immich_assets = []
-
-        if gumnut_assets:
-            for item in gumnut_assets.data:
-                # Convert Gumnut asset to AssetResponseDto format using utility function
-                immich_asset = convert_gumnut_asset_to_immich(item.asset, current_user)
-                immich_assets.append(immich_asset)
-
-        return SearchResponseDto(
-            albums=SearchAlbumResponseDto(count=0, facets=[], items=[], total=0),
-            assets=SearchAssetResponseDto(
-                count=len(immich_assets),
-                facets=[],
-                items=immich_assets,
-                nextPage="",
-                total=len(immich_assets),
-            ),
-        )
-
-    except Exception as e:
-        # Provide more detailed error information
-        error_msg = str(e)
-        if check_for_error_by_code(e, 401) or "Invalid API key" in error_msg:
-            raise HTTPException(status_code=401, detail="Invalid Gumnut API key")
-        elif check_for_error_by_code(e, 403):
-            raise HTTPException(status_code=403, detail="Access denied to Gumnut API")
-        elif check_for_error_by_code(e, 404):
-            raise HTTPException(
-                status_code=404, detail="Gumnut albums endpoint not found"
+    immich_assets = []
+    if gumnut_assets:
+        for item in gumnut_assets.data:
+            immich_assets.append(
+                convert_gumnut_asset_to_immich(item.asset, current_user)
             )
-        else:
-            raise HTTPException(
-                status_code=500, detail=f"Failed to fetch albums: {error_msg}"
-            )
+
+    return SearchResponseDto(
+        albums=SearchAlbumResponseDto(count=0, facets=[], items=[], total=0),
+        assets=SearchAssetResponseDto(
+            count=len(immich_assets),
+            facets=[],
+            items=immich_assets,
+            nextPage="",
+            total=len(immich_assets),
+        ),
+    )
 
 
 @router.get("/cities")

--- a/routers/api/sync/routes.py
+++ b/routers/api/sync/routes.py
@@ -38,7 +38,6 @@ from routers.immich_models import (
 )
 from routers.utils.asset_conversion import convert_gumnut_asset_to_immich
 from routers.utils.current_user import get_current_user
-from routers.utils.error_mapping import map_gumnut_error
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
 
 from routers.api.sync.events import to_ack_string
@@ -500,11 +499,9 @@ async def get_sync_stream(
     # Fetch current user before starting the stream. This ensures auth
     # errors (e.g. expired JWT) return a proper HTTP 401 instead of being
     # silently swallowed inside the streaming generator after the 200
-    # status has already been committed.
-    try:
-        current_user = await gumnut_client.users.me()
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to authenticate for sync stream") from e
+    # status has already been committed. SDK errors bubble to the global
+    # GumnutError handler.
+    current_user = await gumnut_client.users.me()
 
     return StreamingResponse(
         generate_sync_stream(gumnut_client, request, checkpoint_map, current_user),

--- a/routers/api/timeline.py
+++ b/routers/api/timeline.py
@@ -15,7 +15,6 @@ from routers.immich_models import (
 )
 from routers.utils.asset_conversion import mime_type_to_asset_type
 from routers.utils.current_user import get_current_user_id
-from routers.utils.error_mapping import map_gumnut_error
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
 from routers.utils.gumnut_id_conversion import (
     safe_uuid_from_asset_id,
@@ -83,32 +82,28 @@ async def get_time_buckets(
     ):
         return []  # Gumnut does not support favorites, trashed, hidden, archived or locked assets, so return empty list
 
-    try:
-        album_id = uuid_to_gumnut_album_id(albumId) if albumId else None
-        person_id = uuid_to_gumnut_person_id(personId) if personId else None
+    album_id = uuid_to_gumnut_album_id(albumId) if albumId else None
+    person_id = uuid_to_gumnut_person_id(personId) if personId else None
 
-        raw_buckets = await fetch_asset_counts(
-            client, album_id=album_id, person_id=person_id
+    raw_buckets = await fetch_asset_counts(
+        client, album_id=album_id, person_id=person_id
+    )
+
+    # Map to Immich format: normalize time_bucket to month start (YYYY-MM-01)
+    buckets = [
+        TimeBucketsResponseDto(
+            timeBucket=bucket.time_bucket.strftime("%Y-%m-01"),
+            count=bucket.count,
         )
+        for bucket in raw_buckets
+    ]
 
-        # Map to Immich format: normalize time_bucket to month start (YYYY-MM-01)
-        buckets = [
-            TimeBucketsResponseDto(
-                timeBucket=bucket.time_bucket.strftime("%Y-%m-01"),
-                count=bucket.count,
-            )
-            for bucket in raw_buckets
-        ]
+    # The counts endpoint returns results in descending order by default.
+    # Reverse only if ascending order is requested.
+    if order == AssetOrder.asc:
+        buckets.reverse()
 
-        # The counts endpoint returns results in descending order by default.
-        # Reverse only if ascending order is requested.
-        if order == AssetOrder.asc:
-            buckets.reverse()
-
-        return buckets
-
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to fetch timeline buckets") from e
+    return buckets
 
 
 @router.get("/bucket")
@@ -146,121 +141,101 @@ async def get_time_bucket(
     However, this causes the OpenAPI Compatibility Validator to show a warning for this endpoint.
     """
 
-    try:
-        # Compute month boundaries from timeBucket for server-side date filtering.
-        # The Immich client may send naive ("2024-01-01T00:00:00") or UTC-aware
-        # ("2024-01-01T00:00:00.000Z") timestamps. We always strip timezone info
-        # so boundaries are naive, matching the photos-api counts endpoint which
-        # groups by date_trunc("month", local_datetime) on the naive column.
-        # Uses a half-open interval [month_start, next_month_start) for clean boundaries.
-        bucket_date = datetime.fromisoformat(timeBucket).replace(tzinfo=None)
-        month_start = bucket_date.replace(
-            day=1, hour=0, minute=0, second=0, microsecond=0
+    # Compute month boundaries from timeBucket for server-side date filtering.
+    # The Immich client may send naive ("2024-01-01T00:00:00") or UTC-aware
+    # ("2024-01-01T00:00:00.000Z") timestamps. We always strip timezone info
+    # so boundaries are naive, matching the photos-api counts endpoint which
+    # groups by date_trunc("month", local_datetime) on the naive column.
+    # Uses a half-open interval [month_start, next_month_start) for clean boundaries.
+    bucket_date = datetime.fromisoformat(timeBucket).replace(tzinfo=None)
+    month_start = bucket_date.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    if month_start.month == 12:
+        next_month_start = month_start.replace(year=month_start.year + 1, month=1)
+    else:
+        next_month_start = month_start.replace(month=month_start.month + 1)
+    date_range_query = {
+        "local_datetime_after": month_start.isoformat(),
+        "local_datetime_before": next_month_start.isoformat(),
+    }
+
+    if albumId:
+        gumnut_album_id = uuid_to_gumnut_album_id(albumId)
+        filtered_assets = [
+            a
+            async for a in client.assets.list(
+                album_id=gumnut_album_id,
+                extra_query=date_range_query,
+            )
+        ]
+    elif personId:
+        filtered_assets = [
+            a
+            async for a in client.assets.list(
+                person_id=uuid_to_gumnut_person_id(personId),
+                extra_query=date_range_query,
+            )
+        ]
+    else:
+        filtered_assets = [
+            a async for a in client.assets.list(extra_query=date_range_query)
+        ]
+
+    asset_count = len(filtered_assets)
+
+    asset_ids = []
+    file_created_at_list = []
+    is_image_list = []
+    ratio_list = []
+    visibility_list = []
+    local_offset_hours_list = []
+
+    for asset in filtered_assets:
+        asset_id = asset.id
+        created_at = asset.local_datetime
+        aspect_ratio = (
+            asset.width / asset.height if asset.height and asset.width else 1.0
         )
-        if month_start.month == 12:
-            next_month_start = month_start.replace(year=month_start.year + 1, month=1)
+        utc_offset = asset.local_datetime.utcoffset()
+        if asset.local_datetime.tzinfo and utc_offset is not None:
+            local_datetime_offset = int(utc_offset.total_seconds() / 3600)
         else:
-            next_month_start = month_start.replace(month=month_start.month + 1)
-        date_range_query = {
-            "local_datetime_after": month_start.isoformat(),
-            "local_datetime_before": next_month_start.isoformat(),
-        }
+            local_datetime_offset = 0
 
-        if albumId:
-            gumnut_album_id = uuid_to_gumnut_album_id(albumId)
-            filtered_assets = [
-                a
-                async for a in client.assets.list(
-                    album_id=gumnut_album_id,
-                    extra_query=date_range_query,
-                )
-            ]
-        elif personId:
-            filtered_assets = [
-                a
-                async for a in client.assets.list(
-                    person_id=uuid_to_gumnut_person_id(personId),
-                    extra_query=date_range_query,
-                )
-            ]
-        else:
-            filtered_assets = [
-                a async for a in client.assets.list(extra_query=date_range_query)
-            ]
+        asset_ids.append(str(safe_uuid_from_asset_id(asset_id)))
 
-        # Build the response arrays based on filtered assets
-        asset_count = len(filtered_assets)
+        # Immich's TimeBucketAssetResponseDto needs ISO 8601 without timezone
+        # and exactly 3 digits of milliseconds (e.g., "2023-10-05T09:41:00.123").
+        file_created_at_list.append(created_at.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3])
 
-        # Initialize arrays for the response
-        asset_ids = []
-        file_created_at_list = []
-        is_image_list = []
-        ratio_list = []
-        visibility_list = []
-        local_offset_hours_list = []
+        is_image_list.append(
+            mime_type_to_asset_type(asset.mime_type) == AssetTypeEnum.IMAGE
+        )
 
-        for asset in filtered_assets:
-            asset_id = asset.id
-            created_at = asset.local_datetime
-            aspect_ratio = (
-                asset.width / asset.height if asset.height and asset.width else 1.0
-            )
-            # get the local datetime offset in hours from UTC
-            utc_offset = asset.local_datetime.utcoffset()
-            if asset.local_datetime.tzinfo and utc_offset is not None:
-                local_datetime_offset = int(utc_offset.total_seconds() / 3600)
-            else:
-                local_datetime_offset = 0
+        ratio_list.append(float(aspect_ratio))
 
-            # Convert Gumnut asset ID to UUID format for response
-            asset_ids.append(str(safe_uuid_from_asset_id(asset_id)))
+        visibility_list.append(AssetVisibility.timeline)
 
-            # Format file_created_at_list timestamp to ISO 8601 without timezone and 3 digits of milliseconds.
-            # This is a format only used for TimeBucketAssetResponseDto.
-            # Example: "2023-10-05T09:41:00.123"
-            file_created_at_list.append(
-                created_at.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
-            )
+        local_offset_hours_list.append(local_datetime_offset)
 
-            # Determine if asset is an image (vs video) based on MIME type
-            is_image_list.append(
-                mime_type_to_asset_type(asset.mime_type) == AssetTypeEnum.IMAGE
-            )
-
-            ratio_list.append(float(aspect_ratio))
-
-            # Set visibility (always timeline for now)
-            visibility_list.append(AssetVisibility.timeline)
-
-            local_offset_hours_list.append(local_datetime_offset)
-
-        # Return as dict to bypass Pydantic validation issues with None in List[str]
-        # XXX revisit this issue later
-        return {
-            # Fields that should only contain None (as specified)
-            "city": [None] * asset_count,
-            "country": [None] * asset_count,
-            "duration": [None] * asset_count,  # We don't have duration data
-            "livePhotoVideoId": [None] * asset_count,
-            "projectionType": [None] * asset_count,
-            # Real data from assets
-            "id": asset_ids,
-            "fileCreatedAt": file_created_at_list,
-            "isImage": is_image_list,
-            "ratio": ratio_list,
-            "visibility": visibility_list,
-            "localOffsetHours": local_offset_hours_list,
-            # Fixed values as specified
-            "isFavorite": [False] * asset_count,  # Always False
-            "isTrashed": [False] * asset_count,  # Always False
-            "ownerId": [str(current_user_id)] * asset_count,  # Current user as owner
-            "thumbhash": ["FBgGFYRQjHbAZpiWWpeEhWPANQZr"]
-            * asset_count,  # Fixed thumbhash
-            # Optional fields with reasonable defaults
-            "latitude": [None] * asset_count,  # No GPS data available
-            "longitude": [None] * asset_count,  # No GPS data available
-            "stack": [None] * asset_count,  # No stack information available
-        }
-
-    except Exception as e:
-        raise map_gumnut_error(e, "Failed to fetch timeline bucket") from e
+    # Return as dict to bypass Pydantic validation issues with None in List[str]
+    # XXX revisit this issue later
+    return {
+        "city": [None] * asset_count,
+        "country": [None] * asset_count,
+        "duration": [None] * asset_count,
+        "livePhotoVideoId": [None] * asset_count,
+        "projectionType": [None] * asset_count,
+        "id": asset_ids,
+        "fileCreatedAt": file_created_at_list,
+        "isImage": is_image_list,
+        "ratio": ratio_list,
+        "visibility": visibility_list,
+        "localOffsetHours": local_offset_hours_list,
+        "isFavorite": [False] * asset_count,
+        "isTrashed": [False] * asset_count,
+        "ownerId": [str(current_user_id)] * asset_count,
+        "thumbhash": ["FBgGFYRQjHbAZpiWWpeEhWPANQZr"] * asset_count,
+        "latitude": [None] * asset_count,
+        "longitude": [None] * asset_count,
+        "stack": [None] * asset_count,
+    }

--- a/routers/utils/current_user.py
+++ b/routers/utils/current_user.py
@@ -7,7 +7,6 @@ repeated calls to the Gumnut backend.
 
 from datetime import datetime, timezone
 from uuid import UUID, uuid4
-import logging
 
 from fastapi import Depends, Request
 from gumnut import AsyncGumnut
@@ -19,11 +18,8 @@ from routers.immich_models import (
     UserResponseDto,
     UserStatus,
 )
-from routers.utils.error_mapping import map_gumnut_error
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
 from routers.utils.gumnut_id_conversion import safe_uuid_from_user_id
-
-logger = logging.getLogger(__name__)
 
 
 async def get_current_user_admin(
@@ -43,12 +39,8 @@ async def get_current_user_admin(
     if hasattr(request.state, "current_user_admin"):
         return request.state.current_user_admin
 
-    # Fetch from Gumnut backend
-    try:
-        user = await client.users.me()
-    except Exception as e:
-        logger.error(f"Failed to fetch user from Gumnut: {e}")
-        raise map_gumnut_error(e, "Failed to fetch user details") from e
+    # Fetch from Gumnut backend (SDK errors bubble to the global GumnutError handler)
+    user = await client.users.me()
 
     # Map Gumnut UserResponse to Immich UserAdminResponseDto
     # Combine first_name and last_name into Immich's single "name" field

--- a/routers/utils/error_mapping.py
+++ b/routers/utils/error_mapping.py
@@ -1,87 +1,209 @@
 """
 Error mapping utilities for handling Gumnut SDK exceptions.
+
+Most adapter routes do not need to map SDK errors at all — `GumnutError` and
+its subclasses are caught by the global handler in `config/exceptions.py` and
+turned into Immich-shaped HTTP responses there.
+
+Use `map_gumnut_error` only when a call site needs to enrich the upstream log
+record with structured context that the global handler does not have (e.g.
+upload paths logging filename / device ids / `exc_info`).
 """
 
 import logging
+from enum import Enum
+from typing import Any, TypeVar
+
 from fastapi import HTTPException, status
-from gumnut import RateLimitError
+from gumnut import (
+    APIStatusError,
+    AuthenticationError,
+    GumnutError,
+    NotFoundError,
+    PermissionDeniedError,
+    RateLimitError,
+)
 
 logger = logging.getLogger(__name__)
 
+# Truncation cap for the `error_detail` field on upstream log records — keeps
+# Sentry / log search tractable while preserving enough context to debug.
+ERROR_DETAIL_MAX_CHARS = 500
 
-def check_for_error_by_code(e: Exception, code: int) -> bool:
+E = TypeVar("E", bound=Enum)
+
+
+def truncated_error_detail(exc: Exception) -> str:
+    """Stringify and truncate an exception for the `error_detail` log field."""
+    return str(exc)[:ERROR_DETAIL_MAX_CHARS]
+
+
+def extract_detail_from_status_error(exc: APIStatusError) -> str:
+    """Extract a clean detail message from a Gumnut SDK status error.
+
+    Tries `body.detail`, then `body.message`, then `body.error`, then
+    `exc.message`, then a synthesized fallback. Used by both the global
+    GumnutError handler and `map_gumnut_error`.
     """
-    Check if an exception represents a specific HTTP error code.
+    body = exc.body
+    if isinstance(body, dict):
+        for key in ("detail", "message", "error"):
+            value = body.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return exc.message or f"Upstream HTTP {exc.status_code}"
 
-    Args:
-        e: The exception to check
-        code: The HTTP status code to check for
 
-    Returns:
-        True if the exception represents the specified error code, False otherwise
+def classify_bulk_item_error(exc: APIStatusError, enum_cls: type[E]) -> E:
+    """Classify a per-item APIStatusError as an `Error1` / `BulkIdErrorReason` value.
+
+    Maps to the canonical `not_found` / `no_permission` / `unknown` buckets
+    on the supplied enum. Per-endpoint nuances (e.g. mapping `ConflictError`
+    to `duplicate`) are layered by the caller via an earlier `except`.
     """
-    # Check if the SDK exposes HTTP status code
-    if hasattr(e, "status_code"):
-        status_code = int(getattr(e, "status_code"))
-        return status_code == code
+    if isinstance(exc, NotFoundError):
+        return enum_cls["not_found"]
+    if isinstance(exc, (AuthenticationError, PermissionDeniedError)):
+        return enum_cls["no_permission"]
+    return enum_cls["unknown"]
 
-    return False
 
+def log_bulk_transport_error(
+    logger_obj: logging.Logger,
+    *,
+    context: str,
+    exc: GumnutError,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Log a per-item transport / schema-mismatch error from a bulk endpoint.
 
-def map_gumnut_error(e: Exception, context: str) -> HTTPException:
+    Use after catching a non-APIStatusError `GumnutError` inside a per-item
+    loop. The caller is responsible for recording the failure on the
+    response (e.g. appending an `unknown` `BulkIdResponseDto`) — this just
+    centralizes the log shape (502 client severity + truncated detail) so
+    every bulk endpoint emits the same field set.
     """
-    Map Gumnut SDK exceptions to appropriate HTTP exceptions.
+    log_extra: dict[str, Any] = dict(extra or {})
+    log_extra["error_detail"] = truncated_error_detail(exc)
+    log_upstream_response(
+        logger_obj,
+        context=context,
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        message=f"Transport error in {context}",
+        extra=log_extra,
+    )
+
+
+def upstream_status_log_level(status_code: int) -> int:
+    """Return log level for upstream HTTP responses.
+
+    Policy:
+    - 404 -> INFO
+    - Other 4xx -> WARNING
+    - 5xx -> ERROR
+    - Everything else -> INFO
+    """
+    if status_code == status.HTTP_404_NOT_FOUND:
+        return logging.INFO
+    if 400 <= status_code < 500:
+        return logging.WARNING
+    if status_code >= 500:
+        return logging.ERROR
+    return logging.INFO
+
+
+def log_upstream_response(
+    logger_obj: logging.Logger,
+    *,
+    context: str,
+    status_code: int,
+    message: str,
+    extra: dict[str, Any] | None = None,
+    exc_info: bool = False,
+) -> None:
+    """Log an upstream response/error using the shared status-to-level policy."""
+    log_extra: dict[str, Any] = dict(extra or {})
+    # Helper fields are authoritative and must not be overridden by caller extra.
+    log_extra["context"] = context
+    log_extra["status_code"] = status_code
+
+    logger_obj.log(
+        upstream_status_log_level(status_code),
+        message,
+        extra=log_extra,
+        exc_info=exc_info,
+    )
+
+
+def map_gumnut_error(
+    e: Exception,
+    context: str,
+    *,
+    extra: dict[str, Any] | None = None,
+    exc_info: bool = False,
+) -> HTTPException:
+    """
+    Map a Gumnut SDK exception to an HTTPException, logging at the upstream
+    severity policy.
+
+    Prefer letting SDK errors bubble to the global GumnutError handler
+    (`config/exceptions.py`). Use this helper only when the call site has
+    enriching log context (filename, device ids, etc.) that the global handler
+    cannot provide.
 
     Args:
         e: The exception from the Gumnut SDK
         context: Context string describing what operation failed
+        extra: Optional structured fields merged into the upstream log record.
+            Caller-supplied "context" / "status_code" keys are overridden by
+            this helper's authoritative values.
+        exc_info: When True, attach the current exception traceback to the
+            emitted log record.
 
     Returns:
         HTTPException with appropriate status code and detail message
     """
-    # Rate limit errors from photos-api must never reach Immich clients,
-    # which have no 429 handling and would break (sync failures, broken
-    # thumbnails). Map to 502 so the client sees an upstream error instead.
+    # Rate-limit errors must never surface as 429 to Immich clients (no 429
+    # handling on the client side; would break sync, thumbnails, uploads).
     if isinstance(e, RateLimitError):
-        logger.error(
-            "SDK retries exhausted for rate-limited request",
-            extra={"context": context, "status_code": 429},
+        log_upstream_response(
+            logger,
+            context=context,
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            message="SDK retries exhausted for rate-limited request",
+            extra=extra,
+            exc_info=exc_info,
         )
         return HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=f"{context}: Upstream temporarily unavailable",
         )
 
-    msg = str(e)
+    if isinstance(e, APIStatusError):
+        detail = extract_detail_from_status_error(e)
 
-    # Log the original error for debugging
-    logger.warning(f"Gumnut SDK error in {context}: {msg}")
+        log_extra: dict[str, Any] = dict(extra or {})
+        log_extra["error_detail"] = detail[:ERROR_DETAIL_MAX_CHARS]
+        log_upstream_response(
+            logger,
+            context=context,
+            status_code=e.status_code,
+            message=f"Gumnut SDK error in {context}: {e.message}",
+            extra=log_extra,
+            exc_info=exc_info,
+        )
+        return HTTPException(status_code=e.status_code, detail=detail)
 
-    # Try to extract clean message from SDK exception body
-    detail = None
-    body = getattr(e, "body", None)
-    if isinstance(body, dict):
-        detail = body.get("detail") or body.get("message") or body.get("error")
-
-    if not detail:
-        detail = msg
-
-    # If the SDK exposes HTTP status, use it
-    if hasattr(e, "status_code"):
-        code = int(getattr(e, "status_code"))
-        return HTTPException(status_code=code, detail=detail)
-
-    # Fallback to string matching for common HTTP errors
-    # This is still brittle but better than duplicating everywhere
-    msg_lower = msg.lower()
-    if "404" in msg or "not found" in msg_lower:
-        return HTTPException(status_code=404, detail=f"{context}: Not found")
-    elif "401" in msg or "invalid api key" in msg_lower or "unauthorized" in msg_lower:
-        return HTTPException(status_code=401, detail=f"{context}: Invalid API key")
-    elif "403" in msg or "forbidden" in msg_lower:
-        return HTTPException(status_code=403, detail=f"{context}: Access denied")
-    elif "400" in msg or "bad request" in msg_lower:
-        return HTTPException(status_code=400, detail=f"{context}: Bad request")
-
-    # Final fallback to 500
-    return HTTPException(status_code=500, detail=f"{context}: {msg}")
+    # Non-SDK exception (transport error, programmer error, etc.) — map to 500.
+    log_upstream_response(
+        logger,
+        context=context,
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        message=f"Unhandled error in {context}: {e}",
+        extra=extra,
+        exc_info=exc_info,
+    )
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=f"{context}: {e}",
+    )

--- a/services/streaming_upload.py
+++ b/services/streaming_upload.py
@@ -25,6 +25,7 @@ import httpx
 import sentry_sdk
 from fastapi import HTTPException, Request, status
 
+from routers.utils.error_mapping import log_upstream_response
 from routers.utils.gumnut_client import set_refreshed_token
 from services.streaming_form_parser import StreamingFormParser
 from services.streaming_pipe import StreamingPipe
@@ -242,15 +243,33 @@ class StreamingUploadPipeline:
                 detail="Upload failed",
             ) from e
 
-        logger.info(
-            "photos-api responded %d for %s",
-            response.status_code,
-            filename,
-            extra={
-                "status_code": response.status_code,
-                "upload_filename": filename,
-            },
-        )
+        detail: str | None = None
+        if response.status_code in (200, 201):
+            logger.info(
+                "photos-api responded %d for %s",
+                response.status_code,
+                filename,
+                extra={
+                    "status_code": response.status_code,
+                    "upload_filename": filename,
+                },
+            )
+        else:
+            try:
+                body = response.json()
+                detail = str(body.get("detail", response.text))
+            except Exception:
+                detail = response.text
+            log_upstream_response(
+                logger,
+                context="streaming_upload",
+                status_code=response.status_code,
+                message=f"photos-api upload error for {filename}",
+                extra={
+                    "upload_filename": filename,
+                    "error_detail": detail[:500],
+                },
+            )
 
         if response.status_code == 429:
             raise HTTPException(
@@ -259,19 +278,8 @@ class StreamingUploadPipeline:
             )
 
         if response.status_code not in (200, 201):
-            try:
-                body = response.json()
-                detail = body.get("detail", response.text)
-            except Exception:
+            if detail is None:
                 detail = response.text
-            logger.warning(
-                "photos-api upload error",
-                extra={
-                    "status_code": response.status_code,
-                    "detail": str(detail)[:500],
-                    "upload_filename": filename,
-                },
-            )
             # Map upstream 5xx and 401 to 502: a 401 from photos-api means
             # the adapter's internal JWT expired, not the client's session.
             # Forwarding 401 would cause Immich clients to clear their session.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,12 +13,43 @@ from datetime import datetime, timezone
 from uuid import uuid4
 from typing import List, Any
 
+import httpx
+from gumnut import APIConnectionError, APIStatusError, NotFoundError
+
 from routers.immich_models import UserResponseDto, UserAvatarColor
 from routers.utils.gumnut_id_conversion import (
     uuid_to_gumnut_album_id,
     uuid_to_gumnut_asset_id,
     uuid_to_gumnut_person_id,
 )
+
+
+def make_sdk_status_error(
+    status_code: int,
+    message: str = "upstream error",
+    body: object | None = None,
+    *,
+    cls: type[APIStatusError] = APIStatusError,
+) -> APIStatusError:
+    """Construct a Gumnut SDK APIStatusError for tests.
+
+    Use a typed subclass (e.g. NotFoundError) when isinstance dispatch matters.
+    """
+    request = httpx.Request("GET", "http://test.local/")
+    response = httpx.Response(status_code, request=request)
+    return cls(message, response=response, body=body)
+
+
+def make_sdk_connection_error(method: str = "GET") -> APIConnectionError:
+    """Construct an SDK APIConnectionError for tests (transport-failure path)."""
+    return APIConnectionError(request=httpx.Request(method, "http://test.local/"))
+
+
+@pytest.fixture
+def sdk_not_found_error():
+    """A NotFoundError instance suitable for `side_effect=` in mocks."""
+    return make_sdk_status_error(404, "Not found", cls=NotFoundError)
+
 
 # Configure anyio to use only asyncio backend
 pytest_plugins = ("anyio",)

--- a/tests/unit/api/test_albums.py
+++ b/tests/unit/api/test_albums.py
@@ -2,9 +2,10 @@
 
 import pytest
 from unittest.mock import AsyncMock, Mock
-from fastapi import HTTPException
+from gumnut import NotFoundError
 from uuid import uuid4
 
+from tests.conftest import make_sdk_status_error
 from routers.api.albums import (
     get_all_albums,
     get_album_statistics,
@@ -196,23 +197,20 @@ class TestGetAllAlbums:
         assert result == []
 
     @pytest.mark.anyio
-    async def test_get_all_albums_gumnut_error(self, mock_current_user):
-        """Test handling of Gumnut API errors."""
-        # Setup - create mock client
-        mock_client = Mock()
-        mock_client.albums.list.side_effect = Exception("API Error")
+    async def test_get_all_albums_propagates_sdk_error(self, mock_current_user):
+        """SDK errors bubble up; the global GumnutError handler maps them."""
+        from gumnut import APIStatusError
 
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        mock_client = Mock()
+        mock_client.albums.list.side_effect = make_sdk_status_error(500, "boom")
+
+        with pytest.raises(APIStatusError):
             await get_all_albums(
                 asset_id=None,
                 shared=None,
                 client=mock_client,
                 current_user=mock_current_user,
             )
-
-        assert exc_info.value.status_code == 500
-        assert "Failed to fetch albums" in str(exc_info.value.detail)
 
 
 class TestGetAlbumStatistics:
@@ -254,16 +252,14 @@ class TestGetAlbumStatistics:
         assert result.notShared == 0
 
     @pytest.mark.anyio
-    async def test_get_album_statistics_gumnut_error(self, mock_gumnut_client):
-        """Test handling of Gumnut API errors."""
-        # Setup
-        mock_gumnut_client.albums.list.side_effect = Exception("API Error")
+    async def test_get_album_statistics_propagates_sdk_error(self, mock_gumnut_client):
+        """SDK errors bubble up; the global GumnutError handler maps them."""
+        from gumnut import APIStatusError
 
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        mock_gumnut_client.albums.list.side_effect = make_sdk_status_error(500, "boom")
+
+        with pytest.raises(APIStatusError):
             await get_album_statistics(client=mock_gumnut_client)
-
-        assert exc_info.value.status_code == 500
 
 
 class TestGetAlbumInfo:
@@ -384,18 +380,16 @@ class TestGetAlbumInfo:
 
     @pytest.mark.anyio
     async def test_get_album_info_not_found(self, sample_uuid, mock_current_user):
-        """Test handling of album not found."""
-        # Setup - create mock client
+        """A NotFoundError from the SDK bubbles to the global handler (mapped to 404)."""
         mock_client = Mock()
-        mock_client.albums.retrieve = AsyncMock(side_effect=Exception("404 Not found"))
+        mock_client.albums.retrieve = AsyncMock(
+            side_effect=make_sdk_status_error(404, "Not found", cls=NotFoundError)
+        )
 
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(NotFoundError):
             await get_album_info(
                 sample_uuid, client=mock_client, current_user=mock_current_user
             )
-
-        assert exc_info.value.status_code == 404
 
 
 class TestCreateAlbum:
@@ -427,98 +421,100 @@ class TestCreateAlbum:
         )
 
     @pytest.mark.anyio
-    async def test_create_album_gumnut_error(self, mock_current_user):
-        """Test handling of Gumnut API errors during creation."""
-        # Setup - create mock client
+    async def test_create_album_propagates_sdk_error(self, mock_current_user):
+        """SDK errors bubble up; the global GumnutError handler maps them."""
+        from gumnut import APIStatusError
+
         mock_client = Mock()
-        mock_client.albums.create = AsyncMock(side_effect=Exception("API Error"))
+        mock_client.albums.create = AsyncMock(
+            side_effect=make_sdk_status_error(500, "boom")
+        )
 
         request = CreateAlbumDto(albumName="Test Album")
 
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(APIStatusError):
             await create_album(
                 request, client=mock_client, current_user=mock_current_user
             )
-
-        assert exc_info.value.status_code == 500
 
 
 class TestAddAssetsToAlbum:
     """Test the add_assets_to_album endpoint."""
 
     @pytest.mark.anyio
-    async def test_add_assets_success(self, sample_gumnut_album, sample_uuid):
+    async def test_add_assets_success(self, sample_uuid):
         """Test successful addition of assets to album."""
-        # Setup - create mock client
         mock_client = Mock()
-        mock_client.albums.retrieve = AsyncMock(return_value=sample_gumnut_album)
         mock_client.albums.assets_associations.add = AsyncMock(return_value=None)
 
         asset_id1 = uuid4()
         asset_id2 = uuid4()
+        request = BulkIdsDto(ids=[asset_id1, asset_id2])
 
-        asset_ids = [asset_id1, asset_id2]
-        request = BulkIdsDto(ids=asset_ids)
-
-        # Execute
         result = await add_assets_to_album(sample_uuid, request, client=mock_client)
 
-        # Assert
         assert len(result) == 2
         assert all(item.success is True for item in result)
         assert result[0].id == str(asset_id1)
         assert result[1].id == str(asset_id2)
-        mock_client.albums.retrieve.assert_called_once()
         assert mock_client.albums.assets_associations.add.call_count == 2
 
     @pytest.mark.anyio
-    async def test_add_assets_album_not_found(self, mock_gumnut_client, sample_uuid):
-        """Test adding assets to non-existent album."""
-        # Setup
+    async def test_add_assets_not_found(self, mock_gumnut_client, sample_uuid):
+        """A NotFoundError on the per-asset add is captured as Error1.not_found."""
         request = BulkIdsDto(ids=[uuid4()])
-        mock_gumnut_client.albums.retrieve = AsyncMock(
-            side_effect=Exception("404 Not found")
+        mock_gumnut_client.albums.assets_associations.add = AsyncMock(
+            side_effect=make_sdk_status_error(404, "Not found", cls=NotFoundError)
         )
 
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
-            await add_assets_to_album(sample_uuid, request, client=mock_gumnut_client)
+        result = await add_assets_to_album(
+            sample_uuid, request, client=mock_gumnut_client
+        )
 
-        assert exc_info.value.status_code == 404
+        assert len(result) == 1
+        assert result[0].success is False
+        assert result[0].error == Error1.not_found
 
     @pytest.mark.anyio
-    async def test_add_assets_mixed_results(self, sample_gumnut_album, sample_uuid):
-        """Test adding assets with some failures."""
-        # Setup - create mock client
+    async def test_add_assets_mixed_results(self, sample_uuid):
+        """Per-asset NotFoundError is captured as Error1.not_found, others as unknown."""
         mock_client = Mock()
-        mock_client.albums.retrieve = AsyncMock(return_value=sample_gumnut_album)
-
-        # First call succeeds, second fails
         mock_client.albums.assets_associations.add = AsyncMock(
             side_effect=[
-                None,  # Success
-                Exception("Asset not found"),  # Failure
+                None,
+                make_sdk_status_error(404, "Asset not found", cls=NotFoundError),
             ]
         )
 
         asset_id1 = uuid4()
         asset_id2 = uuid4()
+        request = BulkIdsDto(ids=[asset_id1, asset_id2])
 
-        asset_ids = [asset_id1, asset_id2]
-        request = BulkIdsDto(ids=asset_ids)
-
-        # Execute
         result = await add_assets_to_album(sample_uuid, request, client=mock_client)
 
-        # Assert
         assert len(result) == 2
         assert result[0].success is True
         assert result[0].id == str(asset_id1)
         assert result[1].success is False
         assert result[1].id == str(asset_id2)
-        # Now error is an Error1 enum, check for the not_found value
         assert result[1].error == Error1.not_found
+
+    @pytest.mark.anyio
+    async def test_add_assets_duplicate(self, sample_uuid):
+        """A ConflictError from the SDK is mapped to Error1.duplicate."""
+        from gumnut import ConflictError
+
+        mock_client = Mock()
+        mock_client.albums.assets_associations.add = AsyncMock(
+            side_effect=make_sdk_status_error(409, "duplicate", cls=ConflictError)
+        )
+
+        request = BulkIdsDto(ids=[uuid4()])
+        result = await add_assets_to_album(sample_uuid, request, client=mock_client)
+
+        assert len(result) == 1
+        assert result[0].success is False
+        assert result[0].error == Error1.duplicate
 
 
 class TestUpdateAlbum:
@@ -529,10 +525,7 @@ class TestUpdateAlbum:
         self, sample_gumnut_album, sample_uuid, mock_current_user
     ):
         """Test successful album update."""
-        # Setup - create mock client
         mock_client = Mock()
-        mock_client.albums.retrieve = AsyncMock(return_value=sample_gumnut_album)
-        # Update the sample to have the name we want to test
         sample_gumnut_album.name = "Updated Album"
         sample_gumnut_album.description = "Updated Description"
         mock_client.albums.update = AsyncMock(return_value=sample_gumnut_album)
@@ -541,16 +534,11 @@ class TestUpdateAlbum:
             albumName="Updated Album", description="Updated Description"
         )
 
-        # Execute
         result = await update_album(
             sample_uuid, request, client=mock_client, current_user=mock_current_user
         )
 
-        # Assert
-        # Now result is a real AlbumResponseDto, so use attribute access
-        assert hasattr(result, "albumName")
         assert result.albumName == "Updated Album"
-        mock_client.albums.retrieve.assert_called_once()
         mock_client.albums.update.assert_called_once()
 
     @pytest.mark.anyio
@@ -558,12 +546,10 @@ class TestUpdateAlbum:
         self, sample_gumnut_album, sample_uuid, mock_current_user
     ):
         """Test that album_cover_asset_id is converted to albumThumbnailAssetId in update_album."""
-        # Setup - set album_cover_asset_id on the updated album
         cover_asset_id = uuid_to_gumnut_asset_id(uuid4())
         sample_gumnut_album.album_cover_asset_id = cover_asset_id
 
         mock_client = Mock()
-        mock_client.albums.retrieve = AsyncMock(return_value=sample_gumnut_album)
         sample_gumnut_album.name = "Updated Album"
         sample_gumnut_album.description = "Updated Description"
         mock_client.albums.update = AsyncMock(return_value=sample_gumnut_album)
@@ -582,18 +568,16 @@ class TestUpdateAlbum:
         assert result.albumThumbnailAssetId == expected_uuid
 
     @pytest.mark.anyio
-    async def test_update_album_not_found(
+    async def test_update_album_not_found_propagates(
         self, mock_gumnut_client, sample_uuid, mock_current_user
     ):
-        """Test updating non-existent album."""
-        # Setup
+        """A NotFoundError from the SDK bubbles up to the global handler."""
         request = UpdateAlbumDto(albumName="Updated Album")
-        mock_gumnut_client.albums.retrieve = AsyncMock(
-            side_effect=Exception("404 Not found")
+        mock_gumnut_client.albums.update = AsyncMock(
+            side_effect=make_sdk_status_error(404, "Not found", cls=NotFoundError)
         )
 
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(NotFoundError):
             await update_album(
                 sample_uuid,
                 request,
@@ -601,71 +585,89 @@ class TestUpdateAlbum:
                 current_user=mock_current_user,
             )
 
-        assert exc_info.value.status_code == 404
-
 
 class TestRemoveAssetFromAlbum:
     """Test the remove_asset_from_album endpoint."""
 
     @pytest.mark.anyio
-    async def test_remove_assets_success(self, sample_gumnut_album, sample_uuid):
+    async def test_remove_assets_success(self, sample_uuid):
         """Test successful removal of assets from album."""
-        # Setup - create mock client
         mock_client = Mock()
-        mock_client.albums.retrieve = AsyncMock(return_value=sample_gumnut_album)
         mock_client.albums.assets_associations.remove = AsyncMock(return_value=None)
 
         asset_id1 = uuid4()
         asset_id2 = uuid4()
+        request = BulkIdsDto(ids=[asset_id1, asset_id2])
 
-        asset_ids = [asset_id1, asset_id2]
-        request = BulkIdsDto(ids=asset_ids)
-
-        # Execute
         result = await remove_asset_from_album(sample_uuid, request, client=mock_client)
 
-        # Assert
         assert len(result) == 2
         assert all(item.success is True for item in result)
         assert result[0].id == str(asset_id1)
         assert result[1].id == str(asset_id2)
-        mock_client.albums.retrieve.assert_called_once()
         assert mock_client.albums.assets_associations.remove.call_count == 2
+
+    @pytest.mark.anyio
+    async def test_remove_assets_not_found(self, sample_uuid):
+        """A NotFoundError on a per-asset remove is captured as Error1.not_found."""
+        mock_client = Mock()
+        mock_client.albums.assets_associations.remove = AsyncMock(
+            side_effect=make_sdk_status_error(404, "Not found", cls=NotFoundError)
+        )
+
+        request = BulkIdsDto(ids=[uuid4()])
+        result = await remove_asset_from_album(sample_uuid, request, client=mock_client)
+
+        assert len(result) == 1
+        assert result[0].success is False
+        assert result[0].error == Error1.not_found
+
+    @pytest.mark.anyio
+    async def test_remove_assets_mixed_results(self, sample_uuid):
+        """One success + one APIStatusError failure returns mixed per-item results."""
+        mock_client = Mock()
+        mock_client.albums.assets_associations.remove = AsyncMock(
+            side_effect=[None, make_sdk_status_error(500, "boom")]
+        )
+
+        asset_id1 = uuid4()
+        asset_id2 = uuid4()
+        request = BulkIdsDto(ids=[asset_id1, asset_id2])
+
+        result = await remove_asset_from_album(sample_uuid, request, client=mock_client)
+
+        assert len(result) == 2
+        assert result[0].success is True
+        assert result[0].id == str(asset_id1)
+        assert result[1].success is False
+        assert result[1].id == str(asset_id2)
+        assert result[1].error == Error1.unknown
 
 
 class TestDeleteAlbum:
     """Test the delete_album endpoint."""
 
     @pytest.mark.anyio
-    async def test_delete_album_success(
-        self, mock_gumnut_client, sample_gumnut_album, sample_uuid
-    ):
+    async def test_delete_album_success(self, mock_gumnut_client, sample_uuid):
         """Test successful album deletion."""
-        # Setup
-        mock_gumnut_client.albums.retrieve = AsyncMock(return_value=sample_gumnut_album)
         mock_gumnut_client.albums.delete = AsyncMock(return_value=None)
 
-        # Execute
         result = await delete_album(sample_uuid, client=mock_gumnut_client)
 
-        # Assert
         assert result.status_code == 204
-        mock_gumnut_client.albums.retrieve.assert_called_once()
         mock_gumnut_client.albums.delete.assert_called_once()
 
     @pytest.mark.anyio
-    async def test_delete_album_not_found(self, mock_gumnut_client, sample_uuid):
-        """Test deleting non-existent album."""
-        # Setup
-        mock_gumnut_client.albums.retrieve = AsyncMock(
-            side_effect=Exception("404 Not found")
+    async def test_delete_album_not_found_propagates(
+        self, mock_gumnut_client, sample_uuid
+    ):
+        """A NotFoundError from the SDK bubbles up to the global handler."""
+        mock_gumnut_client.albums.delete = AsyncMock(
+            side_effect=make_sdk_status_error(404, "Not found", cls=NotFoundError)
         )
 
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(NotFoundError):
             await delete_album(sample_uuid, client=mock_gumnut_client)
-
-        assert exc_info.value.status_code == 404
 
 
 class TestAddAssetsToAlbums:
@@ -674,19 +676,89 @@ class TestAddAssetsToAlbums:
     @pytest.mark.anyio
     async def test_add_assets_to_albums_success(self, sample_uuid):
         """Test successful addition of assets to multiple albums."""
-        # Setup - create mock client
         mock_client = Mock()
-        mock_client.albums.retrieve = AsyncMock(return_value=Mock())
         mock_client.albums.assets_associations.add = AsyncMock(return_value=None)
 
         album_ids = [uuid4(), uuid4()]
         asset_ids = [uuid4()]
         request = AlbumsAddAssetsDto(albumIds=album_ids, assetIds=asset_ids)
 
-        # Execute
         result = await add_assets_to_albums(request, client=mock_client)
 
-        # Assert
-        # AlbumsAddAssetsResponseDto has success and error attributes, not a results list
         assert result.success is True
         assert mock_client.albums.assets_associations.add.call_count == 2
+
+    @pytest.mark.anyio
+    async def test_add_assets_to_albums_conflict_records_duplicate(self):
+        """A ConflictError on an album add records first_error = duplicate."""
+        from gumnut import ConflictError
+
+        mock_client = Mock()
+        mock_client.albums.assets_associations.add = AsyncMock(
+            side_effect=make_sdk_status_error(409, "duplicate", cls=ConflictError)
+        )
+
+        request = AlbumsAddAssetsDto(albumIds=[uuid4()], assetIds=[uuid4()])
+        result = await add_assets_to_albums(request, client=mock_client)
+
+        assert result.success is False
+        from routers.immich_models import BulkIdErrorReason
+
+        assert result.error == BulkIdErrorReason.duplicate
+
+    @pytest.mark.anyio
+    async def test_add_assets_to_albums_not_found_records_not_found(self):
+        """A NotFoundError on an album add records first_error = not_found."""
+        mock_client = Mock()
+        mock_client.albums.assets_associations.add = AsyncMock(
+            side_effect=make_sdk_status_error(404, "Not found", cls=NotFoundError)
+        )
+
+        request = AlbumsAddAssetsDto(albumIds=[uuid4()], assetIds=[uuid4()])
+        result = await add_assets_to_albums(request, client=mock_client)
+
+        assert result.success is False
+        from routers.immich_models import BulkIdErrorReason
+
+        assert result.error == BulkIdErrorReason.not_found
+
+    @pytest.mark.anyio
+    async def test_add_assets_to_albums_first_error_is_sticky(self):
+        """`first_error` records the first failure across albums; later
+        failures with a different classification do not overwrite it."""
+        from gumnut import ConflictError
+
+        mock_client = Mock()
+        mock_client.albums.assets_associations.add = AsyncMock(
+            side_effect=[
+                make_sdk_status_error(409, "duplicate", cls=ConflictError),
+                make_sdk_status_error(404, "Not found", cls=NotFoundError),
+            ]
+        )
+
+        request = AlbumsAddAssetsDto(albumIds=[uuid4(), uuid4()], assetIds=[uuid4()])
+        result = await add_assets_to_albums(request, client=mock_client)
+
+        assert result.success is False
+        from routers.immich_models import BulkIdErrorReason
+
+        assert result.error == BulkIdErrorReason.duplicate
+
+    @pytest.mark.anyio
+    async def test_add_assets_to_albums_partial_failure(self):
+        """One success + one failure returns success=False with the failure's error."""
+        mock_client = Mock()
+        mock_client.albums.assets_associations.add = AsyncMock(
+            side_effect=[
+                None,
+                make_sdk_status_error(404, "Not found", cls=NotFoundError),
+            ]
+        )
+
+        request = AlbumsAddAssetsDto(albumIds=[uuid4(), uuid4()], assetIds=[uuid4()])
+        result = await add_assets_to_albums(request, client=mock_client)
+
+        assert result.success is False
+        from routers.immich_models import BulkIdErrorReason
+
+        assert result.error == BulkIdErrorReason.not_found

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -11,7 +11,6 @@ from fastapi.responses import JSONResponse
 from uuid import UUID, uuid4
 import base64
 
-from gumnut import GumnutError
 from socketio.exceptions import SocketIOError
 
 from services.websockets import WebSocketEvent
@@ -472,10 +471,15 @@ class TestUploadAsset:
 
     @pytest.mark.anyio
     async def test_upload_asset_api_error(self, mock_current_user):
-        """Test upload asset with API error."""
+        """An auth error during upload is mapped to 401 via map_gumnut_error."""
+        from gumnut import AuthenticationError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
         mock_client.assets.with_raw_response.create = AsyncMock(
-            side_effect=Exception("401 Invalid API key")
+            side_effect=make_sdk_status_error(
+                401, "Invalid API key", cls=AuthenticationError
+            )
         )
 
         request = _make_mock_request()
@@ -1016,14 +1020,16 @@ class TestDeleteAssets:
     @pytest.mark.anyio
     async def test_delete_assets_partial_failure(self):
         """Test deletion with some assets not found."""
-        # Setup - create mock client
+        from gumnut import NotFoundError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
 
-        # First delete succeeds, second fails with 404
+        # First delete succeeds, second fails with NotFoundError (already gone).
         mock_client.assets.delete = AsyncMock(
             side_effect=[
-                None,  # Success
-                GumnutError("404 Not found"),  # Failure
+                None,
+                make_sdk_status_error(404, "Not found", cls=NotFoundError),
             ]
         )
 
@@ -1031,13 +1037,56 @@ class TestDeleteAssets:
         request = AssetBulkDeleteDto(ids=asset_ids, force=False)
         current_user_id = uuid4()
 
-        # Execute
         with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
             result = await delete_assets(
                 request, client=mock_client, current_user_id=current_user_id
             )
 
-        # Assert - should still return 204 even with partial failures
+        # Per-item errors are logged and skipped; bulk endpoint still returns 204.
+        assert result.status_code == 204
+        assert mock_client.assets.delete.call_count == 2
+
+    @pytest.mark.anyio
+    async def test_delete_assets_non_404_does_not_abort_batch(self):
+        """A 5xx upstream error on one item must not abort the batch."""
+        from tests.conftest import make_sdk_status_error
+
+        mock_client = Mock()
+        mock_client.assets.delete = AsyncMock(
+            side_effect=[None, make_sdk_status_error(500, "boom")]
+        )
+
+        asset_ids = [uuid4(), uuid4()]
+        request = AssetBulkDeleteDto(ids=asset_ids, force=False)
+        current_user_id = uuid4()
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            result = await delete_assets(
+                request, client=mock_client, current_user_id=current_user_id
+            )
+
+        assert result.status_code == 204
+        assert mock_client.assets.delete.call_count == 2
+
+    @pytest.mark.anyio
+    async def test_delete_assets_connection_error_does_not_abort_batch(self):
+        """A transport error on one item must not abort the batch."""
+        from tests.conftest import make_sdk_connection_error
+
+        mock_client = Mock()
+        mock_client.assets.delete = AsyncMock(
+            side_effect=[None, make_sdk_connection_error("DELETE")]
+        )
+
+        asset_ids = [uuid4(), uuid4()]
+        request = AssetBulkDeleteDto(ids=asset_ids, force=False)
+        current_user_id = uuid4()
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            result = await delete_assets(
+                request, client=mock_client, current_user_id=current_user_id
+            )
+
         assert result.status_code == 204
         assert mock_client.assets.delete.call_count == 2
 
@@ -1151,17 +1200,16 @@ class TestGetAssetStatistics:
         assert result.videos == 0
 
     @pytest.mark.anyio
-    async def test_get_asset_statistics_gumnut_error(self):
-        """Test handling of Gumnut API errors."""
-        # Setup - create mock client
+    async def test_get_asset_statistics_propagates_sdk_error(self):
+        """SDK errors bubble up to the global GumnutError handler."""
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
-        mock_client.assets.list.side_effect = Exception("API Error")
+        mock_client.assets.list.side_effect = make_sdk_status_error(500, "boom")
 
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(APIStatusError):
             await get_asset_statistics(client=mock_client)
-
-        assert exc_info.value.status_code == 500
 
 
 class TestGetRandom:
@@ -1245,19 +1293,22 @@ class TestGetAssetInfo:
         mock_client.assets.retrieve.assert_called_once()
 
     @pytest.mark.anyio
-    async def test_get_asset_info_not_found(self, sample_uuid, mock_current_user):
-        """Test handling of asset not found."""
-        # Setup - create mock client
-        mock_client = Mock()
-        mock_client.assets.retrieve = AsyncMock(side_effect=Exception("404 Not found"))
+    async def test_get_asset_info_not_found_propagates(
+        self, sample_uuid, mock_current_user
+    ):
+        """A NotFoundError on retrieve bubbles up to the global handler."""
+        from gumnut import NotFoundError
+        from tests.conftest import make_sdk_status_error
 
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        mock_client = Mock()
+        mock_client.assets.retrieve = AsyncMock(
+            side_effect=make_sdk_status_error(404, "Not found", cls=NotFoundError)
+        )
+
+        with pytest.raises(NotFoundError):
             await get_asset_info(
                 sample_uuid, client=mock_client, current_user=mock_current_user
             )
-
-        assert exc_info.value.status_code == 404
 
 
 def _make_mock_asset_with_urls(variant_map: dict[str, dict[str, str]]):
@@ -1350,15 +1401,18 @@ class TestViewAsset:
         )
 
     @pytest.mark.anyio
-    async def test_view_asset_not_found(self, sample_uuid):
-        """Test handling of asset not found during view."""
+    async def test_view_asset_not_found_propagates(self, sample_uuid):
+        """A NotFoundError on retrieve bubbles up to the global handler."""
+        from gumnut import NotFoundError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
-        mock_client.assets.retrieve = AsyncMock(side_effect=Exception("404 Not found"))
+        mock_client.assets.retrieve = AsyncMock(
+            side_effect=make_sdk_status_error(404, "Not found", cls=NotFoundError)
+        )
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(NotFoundError):
             await view_asset(sample_uuid, client=mock_client)
-
-        assert exc_info.value.status_code == 404
 
     @pytest.mark.anyio
     async def test_view_asset_missing_variant(self, sample_uuid):

--- a/tests/unit/api/test_faces.py
+++ b/tests/unit/api/test_faces.py
@@ -201,20 +201,17 @@ class TestGetFaces:
         assert result[0].id == face_uuid
 
     @pytest.mark.anyio
-    async def test_sdk_error_mapped_to_http_exception(self):
-        """Test that SDK errors from faces.list are mapped via map_gumnut_error."""
-        from fastapi import HTTPException
+    async def test_sdk_error_propagates(self):
+        """SDK errors bubble up; the global GumnutError handler maps them."""
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
 
         asset_uuid = uuid4()
-
         mock_client = Mock()
-        mock_client.faces.list = Mock(side_effect=Exception("Something went wrong"))
+        mock_client.faces.list = Mock(side_effect=make_sdk_status_error(500, "boom"))
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(APIStatusError):
             await get_faces(id=asset_uuid, client=mock_client)
-
-        assert exc_info.value.status_code == 500
-        assert "Failed to fetch faces" in exc_info.value.detail
 
 
 class TestDeleteFace:
@@ -248,22 +245,20 @@ class TestDeleteFace:
         mock_client.faces.delete.assert_called_once_with(gumnut_face_id)
 
     @pytest.mark.anyio
-    async def test_sdk_error_mapped_to_http_exception(self):
-        """Test that SDK errors are mapped via map_gumnut_error."""
-        from fastapi import HTTPException
+    async def test_sdk_error_propagates(self):
+        """SDK errors bubble up; the global GumnutError handler maps them."""
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
 
         face_uuid = uuid4()
         mock_client = Mock()
         mock_client.faces.delete = AsyncMock(
-            side_effect=Exception("Something went wrong")
+            side_effect=make_sdk_status_error(500, "boom")
         )
 
         request = AssetFaceDeleteDto(force=False)
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(APIStatusError):
             await delete_face(id=face_uuid, request=request, client=mock_client)
-
-        assert exc_info.value.status_code == 500
-        assert "Failed to delete face" in exc_info.value.detail
 
 
 class TestReassignFace:
@@ -296,23 +291,21 @@ class TestReassignFace:
         assert result.id == str(safe_uuid_from_person_id(gumnut_person_id))
 
     @pytest.mark.anyio
-    async def test_sdk_error_mapped_to_http_exception(self):
-        """Test that SDK errors are mapped via map_gumnut_error."""
-        from fastapi import HTTPException
+    async def test_sdk_error_propagates(self):
+        """SDK errors bubble up; the global GumnutError handler maps them."""
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
 
         face_uuid = uuid4()
         person_uuid = uuid4()
 
         mock_client = Mock()
         mock_client.faces.update = AsyncMock(
-            side_effect=Exception("Something went wrong")
+            side_effect=make_sdk_status_error(500, "boom")
         )
 
         request = FaceDto(id=person_uuid)
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(APIStatusError):
             await reassign_faces_by_id(
                 id=face_uuid, request=request, client=mock_client
             )
-
-        assert exc_info.value.status_code == 500
-        assert "Failed to reassign face" in exc_info.value.detail

--- a/tests/unit/api/test_people.py
+++ b/tests/unit/api/test_people.py
@@ -83,37 +83,36 @@ class TestCreatePerson:
         )
 
     @pytest.mark.anyio
-    async def test_create_person_api_error(self):
-        """Test person creation with API error."""
-        # Setup - mock only the Gumnut client
+    async def test_create_person_propagates_auth_error(self):
+        """Auth errors bubble up as AuthenticationError."""
+        from gumnut import AuthenticationError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
         mock_client.people.create = AsyncMock(
-            side_effect=Exception("401 Invalid API key")
+            side_effect=make_sdk_status_error(
+                401, "Invalid API key", cls=AuthenticationError
+            )
         )
 
         request = PersonCreateDto(name="John Doe")
-
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(AuthenticationError):
             await create_person(request, client=mock_client)
-
-        assert exc_info.value.status_code == 401
 
     @pytest.mark.anyio
-    async def test_create_person_general_error(self):
-        """Test person creation with general error."""
-        # Setup - mock only the Gumnut client
+    async def test_create_person_propagates_5xx(self):
+        """Generic SDK errors bubble up to the global GumnutError handler."""
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
-        mock_client.people.create = AsyncMock(side_effect=Exception("Unknown error"))
+        mock_client.people.create = AsyncMock(
+            side_effect=make_sdk_status_error(500, "Unknown error")
+        )
 
         request = PersonCreateDto(name="John Doe")
-
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(APIStatusError):
             await create_person(request, client=mock_client)
-
-        assert exc_info.value.status_code == 500
-        assert "Failed to create person" in str(exc_info.value.detail)
 
 
 class TestUpdatePeople:
@@ -149,14 +148,16 @@ class TestUpdatePeople:
     @pytest.mark.anyio
     async def test_update_people_mixed_results(self):
         """Test bulk people update with some failures."""
-        # Setup - mock only the Gumnut client
+        from gumnut import NotFoundError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
 
         # First update succeeds, second fails
         mock_client.people.update = AsyncMock(
             side_effect=[
-                None,  # Success
-                Exception("404 Person not found"),  # Failure
+                None,
+                make_sdk_status_error(404, "Person not found", cls=NotFoundError),
             ]
         )
 
@@ -209,6 +210,62 @@ class TestUpdatePeople:
         # Check that only non-None fields were passed
         assert mock_client.people.update.call_count == 2
 
+    @pytest.mark.anyio
+    async def test_update_people_connection_error_does_not_abort_batch(self):
+        """A transport error on one item must not abort the bulk operation."""
+        from tests.conftest import make_sdk_connection_error
+
+        mock_client = Mock()
+        mock_client.people.update = AsyncMock(
+            side_effect=[None, make_sdk_connection_error("PUT")]
+        )
+
+        person_id1 = str(uuid4())
+        person_id2 = str(uuid4())
+        request = PeopleUpdateDto(
+            people=[
+                PeopleUpdateItem(id=person_id1, name="Good"),
+                PeopleUpdateItem(id=person_id2, name="Bad"),
+            ]
+        )
+
+        result = await update_people(request, client=mock_client)
+
+        assert len(result) == 2
+        assert result[0].success is True
+        assert result[0].id == person_id1
+        assert result[1].success is False
+        assert result[1].id == person_id2
+        assert result[1].error == Error1.unknown
+
+    @pytest.mark.anyio
+    async def test_update_people_malformed_uuid_does_not_abort_batch(self):
+        """A malformed UUID in one item must not abort the bulk operation.
+
+        Immich's `PeopleUpdateItem.id` is typed as `str` (the OpenAPI spec
+        switches between str and UUID for people ids), so `UUID(...)` can
+        raise `ValueError` here even when other items in the batch are
+        well-formed.
+        """
+        mock_client = Mock()
+        mock_client.people.update = AsyncMock(return_value=None)
+
+        valid_id = str(uuid4())
+        person_updates = [
+            PeopleUpdateItem(id="not-a-uuid", name="Bad"),
+            PeopleUpdateItem(id=valid_id, name="Good"),
+        ]
+        request = PeopleUpdateDto(people=person_updates)
+
+        result = await update_people(request, client=mock_client)
+
+        assert len(result) == 2
+        assert result[0].success is False
+        assert result[0].id == "not-a-uuid"
+        assert result[0].error == Error1.unknown
+        assert result[1].success is True
+        assert result[1].id == valid_id
+
 
 class TestUpdatePerson:
     """Test the update_person endpoint."""
@@ -236,20 +293,20 @@ class TestUpdatePerson:
 
     @pytest.mark.anyio
     async def test_update_person_not_found(self, sample_uuid):
-        """Test updating non-existent person."""
-        # Setup - mock only the Gumnut client
+        """A NotFoundError on update bubbles up to the global handler."""
+        from gumnut import NotFoundError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
         mock_client.people.update = AsyncMock(
-            side_effect=Exception("404 Person not found")
+            side_effect=make_sdk_status_error(
+                404, "Person not found", cls=NotFoundError
+            )
         )
 
         request = PersonUpdateDto(name="Updated Name")
-
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(NotFoundError):
             await update_person(sample_uuid, request, client=mock_client)
-
-        assert exc_info.value.status_code == 404  # Now properly mapped as 404
 
     @pytest.mark.anyio
     async def test_update_person_with_feature_face_asset_id(
@@ -449,18 +506,16 @@ class TestGetAllPeople:
         assert result.hasNextPage is False
 
     @pytest.mark.anyio
-    async def test_get_all_people_gumnut_error(self):
-        """Test handling of Gumnut API errors."""
-        # Setup - mock only the Gumnut client
+    async def test_get_all_people_propagates_sdk_error(self):
+        """SDK errors bubble up to the global GumnutError handler."""
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
-        mock_client.people.list.side_effect = Exception("API Error")
+        mock_client.people.list.side_effect = make_sdk_status_error(500, "boom")
 
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(APIStatusError):
             await call_get_all_people(client=mock_client)
-
-        assert exc_info.value.status_code == 500
-        assert "Failed to fetch people" in str(exc_info.value.detail)
 
 
 def _make_person(
@@ -691,40 +746,38 @@ class TestDeletePeople:
         assert mock_client.people.delete.call_count == 2
 
     @pytest.mark.anyio
-    async def test_delete_people_not_found(self):
-        """Test deletion with person not found."""
-        # Setup - mock only the Gumnut client
+    async def test_delete_people_not_found_propagates(self):
+        """A NotFoundError on delete bubbles up to the global handler."""
+        from gumnut import NotFoundError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
         mock_client.people.delete = AsyncMock(
-            side_effect=Exception("404 Person not found")
+            side_effect=make_sdk_status_error(
+                404, "Person not found", cls=NotFoundError
+            )
         )
 
-        person_ids = [uuid4()]
-        request = BulkIdsDto(ids=person_ids)
-
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        request = BulkIdsDto(ids=[uuid4()])
+        with pytest.raises(NotFoundError):
             await delete_people(request, client=mock_client)
-
-        assert exc_info.value.status_code == 404
 
     @pytest.mark.anyio
-    async def test_delete_people_api_error(self):
-        """Test deletion with API error."""
-        # Setup - mock only the Gumnut client
+    async def test_delete_people_propagates_auth_error(self):
+        """Auth errors bubble up to the global handler."""
+        from gumnut import AuthenticationError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
         mock_client.people.delete = AsyncMock(
-            side_effect=Exception("401 Invalid API key")
+            side_effect=make_sdk_status_error(
+                401, "Invalid API key", cls=AuthenticationError
+            )
         )
 
-        person_ids = [uuid4()]
-        request = BulkIdsDto(ids=person_ids)
-
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        request = BulkIdsDto(ids=[uuid4()])
+        with pytest.raises(AuthenticationError):
             await delete_people(request, client=mock_client)
-
-        assert exc_info.value.status_code == 401
 
 
 class TestGetThumbnail:
@@ -760,7 +813,7 @@ class TestGetThumbnail:
             await get_thumbnail(sample_uuid, client=mock_client)
 
         assert exc_info.value.status_code == 404
-        assert "Person or thumbnail not found" in str(exc_info.value.detail)
+        assert "Person thumbnail not available" in str(exc_info.value.detail)
 
     @pytest.mark.anyio
     async def test_get_thumbnail_no_thumbnail_key(
@@ -780,20 +833,23 @@ class TestGetThumbnail:
             await get_thumbnail(sample_uuid, client=mock_client)
 
         assert exc_info.value.status_code == 404
-        assert "Person or thumbnail not found" in str(exc_info.value.detail)
+        assert "Person thumbnail not available" in str(exc_info.value.detail)
 
     @pytest.mark.anyio
     async def test_get_thumbnail_person_not_found(self, sample_uuid):
-        """Test thumbnail retrieval when person doesn't exist."""
+        """A NotFoundError bubbles up to the global handler."""
+        from gumnut import NotFoundError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
         mock_client.people.retrieve = AsyncMock(
-            side_effect=Exception("404 Person not found")
+            side_effect=make_sdk_status_error(
+                404, "Person not found", cls=NotFoundError
+            )
         )
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(NotFoundError):
             await get_thumbnail(sample_uuid, client=mock_client)
-
-        assert exc_info.value.status_code == 404
 
 
 class TestGetPerson:
@@ -817,34 +873,36 @@ class TestGetPerson:
         mock_client.people.retrieve.assert_called_once()
 
     @pytest.mark.anyio
-    async def test_get_person_not_found(self, sample_uuid):
-        """Test person retrieval when person doesn't exist."""
-        # Setup - mock only the Gumnut client
+    async def test_get_person_not_found_propagates(self, sample_uuid):
+        """A NotFoundError on retrieve bubbles up to the global handler."""
+        from gumnut import NotFoundError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
         mock_client.people.retrieve = AsyncMock(
-            side_effect=Exception("404 Person not found")
+            side_effect=make_sdk_status_error(
+                404, "Person not found", cls=NotFoundError
+            )
         )
 
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(NotFoundError):
             await get_person(sample_uuid, client=mock_client)
-
-        assert exc_info.value.status_code == 404
 
     @pytest.mark.anyio
-    async def test_get_person_api_error(self, sample_uuid):
-        """Test person retrieval with API error."""
-        # Setup - mock only the Gumnut client
+    async def test_get_person_propagates_auth_error(self, sample_uuid):
+        """Auth errors bubble up to the global handler."""
+        from gumnut import AuthenticationError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
         mock_client.people.retrieve = AsyncMock(
-            side_effect=Exception("401 Invalid API key")
+            side_effect=make_sdk_status_error(
+                401, "Invalid API key", cls=AuthenticationError
+            )
         )
 
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(AuthenticationError):
             await get_person(sample_uuid, client=mock_client)
-
-        assert exc_info.value.status_code == 401
 
 
 class TestGetPersonStatistics:
@@ -899,17 +957,18 @@ class TestGetPersonStatistics:
         assert result.assets == 0
 
     @pytest.mark.anyio
-    async def test_get_person_statistics_not_found(self, sample_uuid):
-        """Test person statistics when person doesn't exist."""
-        # Setup - mock only the Gumnut client
+    async def test_get_person_statistics_not_found_propagates(self, sample_uuid):
+        """A NotFoundError on assets.list bubbles up to the global handler."""
+        from gumnut import NotFoundError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
-        mock_client.assets.list.side_effect = Exception("404 Person not found")
+        mock_client.assets.list.side_effect = make_sdk_status_error(
+            404, "Person not found", cls=NotFoundError
+        )
 
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(NotFoundError):
             await get_person_statistics(sample_uuid, client=mock_client)
-
-        assert exc_info.value.status_code == 404
 
 
 class TestDeletePerson:
@@ -930,34 +989,36 @@ class TestDeletePerson:
         mock_client.people.delete.assert_called_once()
 
     @pytest.mark.anyio
-    async def test_delete_person_not_found(self, sample_uuid):
-        """Test deletion of non-existent person."""
-        # Setup - mock only the Gumnut client
+    async def test_delete_person_not_found_propagates(self, sample_uuid):
+        """A NotFoundError on delete bubbles up to the global handler."""
+        from gumnut import NotFoundError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
         mock_client.people.delete = AsyncMock(
-            side_effect=Exception("404 Person not found")
+            side_effect=make_sdk_status_error(
+                404, "Person not found", cls=NotFoundError
+            )
         )
 
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(NotFoundError):
             await delete_person(sample_uuid, client=mock_client)
-
-        assert exc_info.value.status_code == 404
 
     @pytest.mark.anyio
-    async def test_delete_person_api_error(self, sample_uuid):
-        """Test deletion with API error."""
-        # Setup - mock only the Gumnut client
+    async def test_delete_person_propagates_auth_error(self, sample_uuid):
+        """Auth errors bubble up to the global handler."""
+        from gumnut import AuthenticationError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
         mock_client.people.delete = AsyncMock(
-            side_effect=Exception("401 Invalid API key")
+            side_effect=make_sdk_status_error(
+                401, "Invalid API key", cls=AuthenticationError
+            )
         )
 
-        # Execute & Assert
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(AuthenticationError):
             await delete_person(sample_uuid, client=mock_client)
-
-        assert exc_info.value.status_code == 401
 
 
 class TestMergePerson:
@@ -1066,20 +1127,21 @@ class TestReassignFaces:
         source_uuid = uuid4()  # body personId = source
         asset_uuid = uuid4()
 
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
+
         mock_client = Mock()
         mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
         mock_client.faces.list = Mock(
-            side_effect=Exception("500 Internal Server Error")
+            side_effect=make_sdk_status_error(500, "Internal Server Error")
         )
 
         request = AssetFaceUpdateDto(
             data=[AssetFaceUpdateItem(assetId=asset_uuid, personId=source_uuid)]
         )
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(APIStatusError):
             await reassign_faces(target_uuid, request, client=mock_client)
-
-        assert exc_info.value.status_code == 500
 
     @pytest.mark.anyio
     async def test_reassign_faces_multiple_faces_on_asset(

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -113,22 +113,20 @@ class TestSearchPerson:
         assert result == []
 
     @pytest.mark.anyio
-    async def test_sdk_error_mapped_to_http_exception(self):
-        """Test that SDK errors are mapped via map_gumnut_error."""
-        from fastapi import HTTPException
+    async def test_sdk_error_propagates(self):
+        """SDK errors bubble up; the global GumnutError handler maps them."""
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
 
         mock_client = Mock()
-        mock_client.people.list = Mock(side_effect=Exception("Something went wrong"))
+        mock_client.people.list = Mock(side_effect=make_sdk_status_error(500, "boom"))
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(APIStatusError):
             await search_person(
                 name="Test",
                 withHidden=None,  # type: ignore[arg-type]
                 client=mock_client,
             )
-
-        assert exc_info.value.status_code == 500
-        assert "Failed to search people" in exc_info.value.detail
 
 
 class TestSearchStatistics:
@@ -170,21 +168,19 @@ class TestSearchStatistics:
         assert result.total == 0
 
     @pytest.mark.anyio
-    async def test_sdk_error_mapped_to_http_exception(self):
-        """Test that SDK errors are mapped via map_gumnut_error."""
-        from fastapi import HTTPException
+    async def test_sdk_error_propagates(self):
+        """SDK errors bubble up; the global GumnutError handler maps them."""
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
 
         mock_client = Mock()
         mock_client.assets.counts = AsyncMock(
-            side_effect=Exception("Something went wrong")
+            side_effect=make_sdk_status_error(500, "boom")
         )
 
         request = StatisticsSearchDto()
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(APIStatusError):
             await search_asset_statistics(request=request, client=mock_client)
-
-        assert exc_info.value.status_code == 500
-        assert "Failed to get search statistics" in exc_info.value.detail
 
 
 class TestSearchMetadata:
@@ -299,21 +295,19 @@ class TestSearchMetadata:
         assert result.assets.items[0].originalFileName == "sunset.jpg"
 
     @pytest.mark.anyio
-    async def test_sdk_error_mapped_to_http_exception(self, mock_current_user):
-        """Test that SDK errors are mapped via map_gumnut_error."""
-        from fastapi import HTTPException
+    async def test_sdk_error_propagates(self, mock_current_user):
+        """SDK errors bubble up; the global GumnutError handler maps them."""
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
 
         mock_client = Mock()
         mock_client.search.search = AsyncMock(
-            side_effect=Exception("Something went wrong")
+            side_effect=make_sdk_status_error(500, "boom")
         )
 
         request = MetadataSearchDto()
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(APIStatusError):
             await search_assets(
                 request=request, client=mock_client, current_user=mock_current_user
             )
-
-        assert exc_info.value.status_code == 500
-        assert "Failed to search assets by metadata" in exc_info.value.detail

--- a/tests/unit/api/test_timeline.py
+++ b/tests/unit/api/test_timeline.py
@@ -2,7 +2,6 @@
 
 import pytest
 from unittest.mock import AsyncMock, Mock, patch
-from fastapi import HTTPException
 from uuid import uuid4
 from datetime import datetime, timezone, timedelta
 
@@ -267,29 +266,34 @@ class TestGetTimeBuckets:
         assert result == []
 
     @pytest.mark.anyio
-    async def test_get_time_buckets_gumnut_error(self):
-        """Test handling of Gumnut API errors."""
-        mock_client = Mock()
-        mock_client.assets.counts = AsyncMock(side_effect=Exception("API Error"))
+    async def test_get_time_buckets_propagates_sdk_error(self):
+        """SDK errors bubble up; the global GumnutError handler maps them."""
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
 
-        with pytest.raises(HTTPException) as exc_info:
-            await call_get_time_buckets(client=mock_client)
-
-        assert exc_info.value.status_code == 500
-        assert "Failed to fetch timeline buckets" in str(exc_info.value.detail)
-
-    @pytest.mark.anyio
-    async def test_get_time_buckets_auth_error(self):
-        """Test handling of authentication errors."""
         mock_client = Mock()
         mock_client.assets.counts = AsyncMock(
-            side_effect=Exception("401 Invalid API key")
+            side_effect=make_sdk_status_error(500, "boom")
         )
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(APIStatusError):
             await call_get_time_buckets(client=mock_client)
 
-        assert exc_info.value.status_code == 401
+    @pytest.mark.anyio
+    async def test_get_time_buckets_propagates_auth_error(self):
+        """Authentication errors bubble up as AuthenticationError."""
+        from gumnut import AuthenticationError
+        from tests.conftest import make_sdk_status_error
+
+        mock_client = Mock()
+        mock_client.assets.counts = AsyncMock(
+            side_effect=make_sdk_status_error(
+                401, "Invalid API key", cls=AuthenticationError
+            )
+        )
+
+        with pytest.raises(AuthenticationError):
+            await call_get_time_buckets(client=mock_client)
 
     @pytest.mark.anyio
     async def test_get_time_buckets_normalizes_to_month_start(self):
@@ -525,31 +529,34 @@ class TestGetTimeBucket:
             )
 
     @pytest.mark.anyio
-    async def test_get_time_bucket_gumnut_error(self):
-        """Test handling of Gumnut API errors."""
-        mock_client = Mock()
-        mock_client.assets.list.side_effect = Exception("API Error")
+    async def test_get_time_bucket_propagates_sdk_error(self):
+        """SDK errors bubble up; the global GumnutError handler maps them."""
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
 
-        with pytest.raises(HTTPException) as exc_info:
+        mock_client = Mock()
+        mock_client.assets.list.side_effect = make_sdk_status_error(500, "boom")
+
+        with pytest.raises(APIStatusError):
             await call_get_time_bucket(
                 timeBucket="2024-01-01T00:00:00", client=mock_client
             )
-
-        assert exc_info.value.status_code == 500
-        assert "Failed to fetch timeline bucket" in str(exc_info.value.detail)
 
     @pytest.mark.anyio
-    async def test_get_time_bucket_auth_error(self):
-        """Test handling of authentication errors."""
-        mock_client = Mock()
-        mock_client.assets.list.side_effect = Exception("401 Invalid API key")
+    async def test_get_time_bucket_propagates_auth_error(self):
+        """Authentication errors bubble up as AuthenticationError."""
+        from gumnut import AuthenticationError
+        from tests.conftest import make_sdk_status_error
 
-        with pytest.raises(HTTPException) as exc_info:
+        mock_client = Mock()
+        mock_client.assets.list.side_effect = make_sdk_status_error(
+            401, "Invalid API key", cls=AuthenticationError
+        )
+
+        with pytest.raises(AuthenticationError):
             await call_get_time_bucket(
                 timeBucket="2024-01-01T00:00:00", client=mock_client
             )
-
-        assert exc_info.value.status_code == 401
 
     @pytest.mark.anyio
     async def test_get_time_bucket_timezone_offsets(self, mock_sync_cursor_page):

--- a/tests/unit/config/test_exceptions.py
+++ b/tests/unit/config/test_exceptions.py
@@ -1,0 +1,175 @@
+"""
+Tests for the global GumnutError exception handler.
+
+These exercise the handler through a minimal FastAPI app + TestClient so
+the full request/response/handler pipeline is verified — not just the
+handler function in isolation.
+"""
+
+import logging
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from gumnut import (
+    APIResponseValidationError,
+    AuthenticationError,
+    BadRequestError,
+    GumnutError,
+    InternalServerError,
+    NotFoundError,
+    PermissionDeniedError,
+    RateLimitError,
+)
+
+from config.exceptions import configure_exception_handlers
+from tests.conftest import make_sdk_status_error
+
+
+def _make_app(raise_exception: Exception) -> FastAPI:
+    """Build a tiny FastAPI app whose `/boom` route raises the given exception."""
+    app = FastAPI()
+    configure_exception_handlers(app)
+
+    @app.get("/boom")
+    async def boom() -> None:
+        raise raise_exception
+
+    return app
+
+
+def _client(exc: Exception) -> TestClient:
+    return TestClient(_make_app(exc), raise_server_exceptions=False)
+
+
+class TestGumnutErrorHandler:
+    @pytest.mark.parametrize(
+        ("cls", "status_code"),
+        [
+            (NotFoundError, 404),
+            (AuthenticationError, 401),
+            (PermissionDeniedError, 403),
+            (BadRequestError, 400),
+        ],
+    )
+    def test_typed_status_errors_pass_through_status_code(self, cls, status_code):
+        err = make_sdk_status_error(status_code, "upstream said no", cls=cls)
+        response = _client(err).get("/boom")
+
+        assert response.status_code == status_code
+        body = response.json()
+        assert body["statusCode"] == status_code
+        assert body["message"]
+        assert body["error"]
+
+    def test_extracts_detail_from_body(self):
+        err = make_sdk_status_error(
+            401,
+            "raw",
+            body={"detail": "JWT has expired"},
+            cls=AuthenticationError,
+        )
+        response = _client(err).get("/boom")
+
+        assert response.status_code == 401
+        assert response.json()["message"] == "JWT has expired"
+
+    def test_internal_server_error_uses_actual_status_code(self):
+        # The Stainless-generated InternalServerError carries the real upstream
+        # code in .status_code (no Literal override).
+        err = make_sdk_status_error(503, "upstream down", cls=InternalServerError)
+        response = _client(err).get("/boom")
+
+        assert response.status_code == 503
+        assert response.json()["statusCode"] == 503
+
+    def test_rate_limit_error_maps_to_502(self, caplog: pytest.LogCaptureFixture):
+        err = make_sdk_status_error(429, "Too many requests", cls=RateLimitError)
+        caplog.set_level(logging.INFO, logger="routers.utils.error_mapping")
+
+        response = _client(err).get("/boom")
+
+        assert response.status_code == 502
+        assert response.json()["message"] == "Upstream temporarily unavailable"
+
+        # Logged at WARNING (under 429 policy), not at the 502 client-facing code.
+        rate_limit_records = [
+            r for r in caplog.records if "rate-limited request" in r.getMessage()
+        ]
+        assert rate_limit_records
+        assert rate_limit_records[-1].levelno == logging.WARNING
+
+    def test_api_response_validation_error_maps_to_502(self):
+        # APIResponseValidationError requires (response, body, message=...)
+        import httpx
+
+        request = httpx.Request("GET", "http://test.local/")
+        response = httpx.Response(200, request=request)
+        err = APIResponseValidationError(response, body=None, message="bad schema")
+
+        client_response = _client(err).get("/boom")
+        assert client_response.status_code == 502
+        assert client_response.json()["message"] == "Upstream returned invalid response"
+
+    def test_api_response_validation_error_logs_at_error_even_when_upstream_2xx(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """Schema mismatches are always actionable — log at the 502 client-facing
+        severity, not the upstream 2xx (which would demote to INFO)."""
+        import httpx
+
+        request = httpx.Request("GET", "http://test.local/")
+        response = httpx.Response(200, request=request)
+        err = APIResponseValidationError(response, body=None, message="bad schema")
+        caplog.set_level(logging.INFO, logger="routers.utils.error_mapping")
+
+        _client(err).get("/boom")
+
+        records = [r for r in caplog.records if "invalid response" in r.getMessage()]
+        assert records
+        assert records[-1].levelno == logging.ERROR
+
+    def test_api_connection_error_maps_to_502(self):
+        from tests.conftest import make_sdk_connection_error
+
+        response = _client(make_sdk_connection_error()).get("/boom")
+
+        assert response.status_code == 502
+        assert response.json()["message"] == "Upstream unreachable"
+
+    def test_generic_gumnut_error_maps_to_500(self):
+        err = GumnutError("something internal blew up")
+        response = _client(err).get("/boom")
+
+        assert response.status_code == 500
+        assert response.json()["message"] == "Internal error"
+
+    def test_response_shape_matches_immich_format(self):
+        err = make_sdk_status_error(404, "Not found", cls=NotFoundError)
+        response = _client(err).get("/boom")
+
+        body = response.json()
+        assert set(body.keys()) == {"message", "statusCode", "error"}
+        assert body["error"] == "Not Found"
+
+    def test_404_logs_at_info_level(self, caplog: pytest.LogCaptureFixture):
+        """Per the upstream policy, 404 is INFO (not WARNING) — these are noisy
+        and not actionable."""
+        err = make_sdk_status_error(404, "Not found", cls=NotFoundError)
+        caplog.set_level(logging.INFO, logger="routers.utils.error_mapping")
+
+        _client(err).get("/boom")
+
+        records = [r for r in caplog.records if getattr(r, "status_code", None) == 404]
+        assert records
+        assert records[-1].levelno == logging.INFO
+
+    def test_5xx_logs_at_error_level(self, caplog: pytest.LogCaptureFixture):
+        err = make_sdk_status_error(503, "Down", cls=InternalServerError)
+        caplog.set_level(logging.INFO, logger="routers.utils.error_mapping")
+
+        _client(err).get("/boom")
+
+        records = [r for r in caplog.records if getattr(r, "status_code", None) == 503]
+        assert records
+        assert records[-1].levelno == logging.ERROR

--- a/tests/unit/utils/test_error_mapping.py
+++ b/tests/unit/utils/test_error_mapping.py
@@ -2,310 +2,291 @@
 Tests for error mapping utilities.
 """
 
+import logging
+
 import pytest
 from fastapi import HTTPException
+from gumnut import (
+    AuthenticationError,
+    BadRequestError,
+    NotFoundError,
+    PermissionDeniedError,
+)
 
-from routers.utils.error_mapping import check_for_error_by_code, map_gumnut_error
+import routers.utils.error_mapping as error_mapping_module
+from routers.utils.error_mapping import (
+    log_upstream_response,
+    map_gumnut_error,
+    upstream_status_log_level,
+)
+from tests.conftest import make_sdk_status_error
 
 
-class TestCheckForErrorByCode:
-    """Test the check_for_error_by_code function."""
+class TestUpstreamStatusLogLevel:
+    """Test centralized status -> log level policy for upstream responses."""
 
-    def test_check_error_with_status_code_attribute(self):
-        """Test checking error when exception has status_code attribute."""
+    @pytest.mark.parametrize(
+        ("status_code", "expected_level"),
+        [
+            (400, logging.WARNING),
+            (401, logging.WARNING),
+            (403, logging.WARNING),
+            (404, logging.INFO),
+            (422, logging.WARNING),
+            (429, logging.WARNING),
+            (500, logging.ERROR),
+            (503, logging.ERROR),
+        ],
+    )
+    def test_upstream_status_log_level_policy(self, status_code, expected_level):
+        assert upstream_status_log_level(status_code) == expected_level
 
-        class MockSDKError(Exception):
-            def __init__(self, message, status_code):
-                super().__init__(message)
-                self.status_code = status_code
 
-        # Test 404 error
-        error_404 = MockSDKError("Not found", 404)
-        assert check_for_error_by_code(error_404, 404) is True
-        assert check_for_error_by_code(error_404, 401) is False
-        assert check_for_error_by_code(error_404, 500) is False
+class TestLogUpstreamResponse:
+    """Test shared upstream logging helper behavior."""
 
-        # Test 401 error
-        error_401 = MockSDKError("Unauthorized", 401)
-        assert check_for_error_by_code(error_401, 401) is True
-        assert check_for_error_by_code(error_401, 404) is False
-        assert check_for_error_by_code(error_401, 403) is False
+    def test_helper_fields_override_conflicting_extra(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        caplog.set_level(logging.INFO, logger="routers.utils.error_mapping")
 
-        # Test 403 error
-        error_403 = MockSDKError("Forbidden", 403)
-        assert check_for_error_by_code(error_403, 403) is True
-        assert check_for_error_by_code(error_403, 401) is False
-        assert check_for_error_by_code(error_403, 404) is False
+        log_upstream_response(
+            error_mapping_module.logger,
+            context="authoritative-context",
+            status_code=404,
+            message="upstream response",
+            extra={
+                "context": "caller-context",
+                "status_code": 999,
+                "custom_field": "kept",
+            },
+        )
 
-    def test_check_error_with_string_status_code(self):
-        """Test checking error when status_code is a string."""
+        matching_records = [
+            record
+            for record in caplog.records
+            if record.getMessage() == "upstream response"
+        ]
+        assert matching_records
 
-        class MockSDKError(Exception):
-            def __init__(self, message, status_code):
-                super().__init__(message)
-                self.status_code = status_code
+        record = matching_records[-1]
+        assert getattr(record, "context", None) == "authoritative-context"
+        assert getattr(record, "status_code", None) == 404
+        assert getattr(record, "custom_field", None) == "kept"
 
-        # Test string status code
-        error_str = MockSDKError("Not found", "404")
-        assert check_for_error_by_code(error_str, 404) is True
-        assert check_for_error_by_code(error_str, 401) is False
+    def test_helper_propagates_exc_info(self, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.INFO, logger="routers.utils.error_mapping")
 
-    def test_check_error_without_status_code_attribute(self):
-        """Test checking error when exception doesn't have status_code attribute."""
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            log_upstream_response(
+                error_mapping_module.logger,
+                context="ctx",
+                status_code=500,
+                message="upstream traceback",
+                exc_info=True,
+            )
 
-        # Regular exception without status_code
-        regular_error = Exception("Some error message")
-        assert check_for_error_by_code(regular_error, 404) is False
-        assert check_for_error_by_code(regular_error, 401) is False
-        assert check_for_error_by_code(regular_error, 500) is False
+        matching_records = [
+            record
+            for record in caplog.records
+            if record.getMessage() == "upstream traceback"
+        ]
+        assert matching_records
 
-        # ValueError without status_code
-        value_error = ValueError("Invalid value")
-        assert check_for_error_by_code(value_error, 400) is False
-
-    def test_check_error_with_none_status_code(self):
-        """Test checking error when status_code is None."""
-
-        class MockSDKError(Exception):
-            def __init__(self, message):
-                super().__init__(message)
-                self.status_code = None
-
-        error_none = MockSDKError("Error with None status")
-        # This should raise an error when trying to int(None)
-        with pytest.raises((TypeError, ValueError)):
-            check_for_error_by_code(error_none, 404)
+        record = matching_records[-1]
+        assert record.exc_info is not None
+        assert record.exc_info[0] is ValueError
 
 
 class TestMapGumnutError:
-    """Test the map_gumnut_error function."""
+    """Test the map_gumnut_error function for typed SDK exceptions."""
 
-    def test_map_error_with_status_code_attribute(self):
-        """Test mapping error when exception has status_code attribute."""
+    @pytest.mark.parametrize(
+        ("cls", "status_code"),
+        [
+            (NotFoundError, 404),
+            (AuthenticationError, 401),
+            (PermissionDeniedError, 403),
+            (BadRequestError, 400),
+        ],
+    )
+    def test_typed_status_errors_map_to_their_status(self, cls, status_code):
+        err = make_sdk_status_error(status_code, "upstream said no", cls=cls)
+        result = map_gumnut_error(err, "Failed to fetch resource")
 
-        class MockSDKError(Exception):
-            def __init__(self, message, status_code):
-                super().__init__(message)
-                self.status_code = status_code
-
-        # Test 404 error - context is not included, just the error message
-        error_404 = MockSDKError("Resource not found", 404)
-        result = map_gumnut_error(error_404, "Failed to fetch resource")
         assert isinstance(result, HTTPException)
-        assert result.status_code == 404
-        assert result.detail == "Resource not found"
+        assert result.status_code == status_code
+        # No body → falls back to e.message
+        assert result.detail == "upstream said no"
 
-        # Test 401 error
-        error_401 = MockSDKError("Invalid credentials", 401)
-        result = map_gumnut_error(error_401, "Failed to authenticate")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 401
-        assert result.detail == "Invalid credentials"
-
-        # Test 403 error
-        error_403 = MockSDKError("Access denied", 403)
-        result = map_gumnut_error(error_403, "Failed to access resource")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 403
-        assert result.detail == "Access denied"
-
-    def test_map_error_with_string_patterns(self):
-        """Test mapping error using string pattern matching fallback."""
-
-        # Test 404 string patterns
-        error_404_1 = Exception("404 Not found")
-        result = map_gumnut_error(error_404_1, "Failed to fetch")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 404
-        assert result.detail == "Failed to fetch: Not found"
-
-        error_404_2 = Exception("Resource Not found")
-        result = map_gumnut_error(error_404_2, "Failed to fetch")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 404
-        assert result.detail == "Failed to fetch: Not found"
-
-        error_404_3 = Exception("asset not found")
-        result = map_gumnut_error(error_404_3, "Failed to fetch")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 404
-        assert result.detail == "Failed to fetch: Not found"
-
-    def test_map_error_401_patterns(self):
-        """Test mapping 401 error patterns."""
-
-        # Test 401 string patterns
-        error_401_1 = Exception("401 Unauthorized")
-        result = map_gumnut_error(error_401_1, "Failed to authenticate")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 401
-        assert result.detail == "Failed to authenticate: Invalid API key"
-
-        error_401_2 = Exception("Invalid API key provided")
-        result = map_gumnut_error(error_401_2, "Failed to authenticate")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 401
-        assert result.detail == "Failed to authenticate: Invalid API key"
-
-        error_401_3 = Exception("Unauthorized access")
-        result = map_gumnut_error(error_401_3, "Failed to authenticate")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 401
-        assert result.detail == "Failed to authenticate: Invalid API key"
-
-    def test_map_error_403_patterns(self):
-        """Test mapping 403 error patterns."""
-
-        # Test 403 string patterns
-        error_403_1 = Exception("403 Forbidden")
-        result = map_gumnut_error(error_403_1, "Failed to access")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 403
-        assert result.detail == "Failed to access: Access denied"
-
-        error_403_2 = Exception("Access Forbidden")
-        result = map_gumnut_error(error_403_2, "Failed to access")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 403
-        assert result.detail == "Failed to access: Access denied"
-
-    def test_map_error_400_patterns(self):
-        """Test mapping 400 error patterns."""
-
-        # Test 400 string patterns
-        error_400_1 = Exception("400 Bad request")
-        result = map_gumnut_error(error_400_1, "Failed to process")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 400
-        assert result.detail == "Failed to process: Bad request"
-
-        error_400_2 = Exception("Invalid Bad request format")
-        result = map_gumnut_error(error_400_2, "Failed to process")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 400
-        assert result.detail == "Failed to process: Bad request"
-
-    def test_map_error_fallback_to_500(self):
-        """Test mapping unknown errors falls back to 500."""
-
-        # Test unknown error
-        unknown_error = Exception("Some unknown error")
-        result = map_gumnut_error(unknown_error, "Failed to process")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 500
-        assert result.detail == "Failed to process: Some unknown error"
-
-        # Test empty error message
-        empty_error = Exception("")
-        result = map_gumnut_error(empty_error, "Failed to process")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 500
-        assert result.detail == "Failed to process: "
-
-    def test_map_error_with_different_contexts(self):
-        """Test mapping errors with different context messages."""
-
-        error = Exception("404 Not found")
-
-        # Test different contexts
-        result1 = map_gumnut_error(error, "Failed to fetch album")
-        assert result1.detail == "Failed to fetch album: Not found"
-
-        result2 = map_gumnut_error(error, "Failed to fetch asset")
-        assert result2.detail == "Failed to fetch asset: Not found"
-
-        result3 = map_gumnut_error(error, "Failed to fetch person")
-        assert result3.detail == "Failed to fetch person: Not found"
-
-    def test_map_error_case_insensitive_patterns(self):
-        """Test that string pattern matching is case insensitive where appropriate."""
-
-        # Test lowercase patterns
-        error_bad_request = Exception("bad request")
-        result = map_gumnut_error(error_bad_request, "Failed to process")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 400
-
-        error_forbidden = Exception("forbidden")
-        result = map_gumnut_error(error_forbidden, "Failed to access")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 403
-
-        error_unauthorized = Exception("unauthorized")
-        result = map_gumnut_error(error_unauthorized, "Failed to authenticate")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 401
-
-    def test_map_error_priority_status_code_over_string(self):
-        """Test that status_code attribute takes priority over string matching."""
-
-        class MockSDKError(Exception):
-            def __init__(self, message, status_code):
-                super().__init__(message)
-                self.status_code = status_code
-
-        # Error has status_code 500 but message contains "404"
-        error = MockSDKError("404 Not found in server error", 500)
-        result = map_gumnut_error(error, "Failed to process")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 500  # Should use status_code, not string pattern
-        assert result.detail == "404 Not found in server error"
-
-        # Error has status_code 401 but message contains "403"
-        error = MockSDKError("403 Forbidden but auth issue", 401)
-        result = map_gumnut_error(error, "Failed to authenticate")
-        assert isinstance(result, HTTPException)
-        assert result.status_code == 401  # Should use status_code, not string pattern
-
-    def test_map_error_extracts_message_from_body(self):
-        """Test that clean messages are extracted from SDK exception body attribute."""
-
-        class MockSDKErrorWithBody(Exception):
-            def __init__(self, message, status_code, body):
-                super().__init__(message)
-                self.status_code = status_code
-                self.body = body
-
-        # Test extracting 'detail' from body (like Gumnut SDK responses)
-        error_with_detail = MockSDKErrorWithBody(
-            "Error code: 401 - {'detail': 'JWT has expired'}",
+    def test_extracts_detail_from_body_dict(self):
+        err = make_sdk_status_error(
             401,
-            {"detail": "JWT has expired"},
+            "raw error",
+            body={"detail": "JWT has expired"},
+            cls=AuthenticationError,
         )
-        result = map_gumnut_error(error_with_detail, "Failed to fetch user details")
-        assert isinstance(result, HTTPException)
+        result = map_gumnut_error(err, "Failed to fetch user details")
+
         assert result.status_code == 401
         assert result.detail == "JWT has expired"
 
-        # Test extracting 'message' from body
-        error_with_message = MockSDKErrorWithBody(
-            "Error code: 404 - {'message': 'Asset not found'}",
+    def test_extracts_message_from_body_when_no_detail(self):
+        err = make_sdk_status_error(
             404,
-            {"message": "Asset not found"},
+            "raw",
+            body={"message": "Asset not found"},
+            cls=NotFoundError,
         )
-        result = map_gumnut_error(error_with_message, "Failed to fetch asset")
-        assert isinstance(result, HTTPException)
+        result = map_gumnut_error(err, "Failed to fetch asset")
+
         assert result.status_code == 404
         assert result.detail == "Asset not found"
 
-        # Test extracting 'error' from body
-        error_with_error = MockSDKErrorWithBody(
-            "Error code: 403 - {'error': 'Access denied'}",
+    def test_extracts_error_from_body_when_no_detail_or_message(self):
+        err = make_sdk_status_error(
             403,
-            {"error": "Access denied"},
+            "raw",
+            body={"error": "Access denied"},
+            cls=PermissionDeniedError,
         )
-        result = map_gumnut_error(error_with_error, "Failed to access resource")
-        assert isinstance(result, HTTPException)
+        result = map_gumnut_error(err, "Failed to access resource")
+
         assert result.status_code == 403
         assert result.detail == "Access denied"
 
-        # Test fallback when body is not a dict
-        error_without_dict_body = MockSDKErrorWithBody(
-            "Plain error message",
+    def test_falls_back_to_message_when_body_not_dict(self):
+        err = make_sdk_status_error(
             500,
-            "not a dict",
+            "Plain error message",
+            body="not a dict",
         )
-        result = map_gumnut_error(error_without_dict_body, "Failed to process")
-        assert isinstance(result, HTTPException)
+        result = map_gumnut_error(err, "Failed to process")
+
         assert result.status_code == 500
         assert result.detail == "Plain error message"
+
+    @pytest.mark.parametrize(
+        ("status_code", "expected_level"),
+        [
+            (401, logging.WARNING),
+            (403, logging.WARNING),
+            (404, logging.INFO),
+            (422, logging.WARNING),
+            (429, logging.WARNING),
+            (500, logging.ERROR),
+        ],
+    )
+    def test_logs_with_status_policy(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        status_code: int,
+        expected_level: int,
+    ):
+        """Status-based log level should follow upstream response policy."""
+        caplog.set_level(logging.INFO, logger="routers.utils.error_mapping")
+
+        result = map_gumnut_error(
+            make_sdk_status_error(status_code, "Upstream request failed"),
+            "Failed to upload asset",
+        )
+
+        assert result.status_code == status_code
+
+        status_records = [
+            record
+            for record in caplog.records
+            if getattr(record, "status_code", None) == status_code
+        ]
+        assert status_records
+        assert status_records[-1].levelno == expected_level
+
+    def test_propagates_extra_to_log_record(self, caplog: pytest.LogCaptureFixture):
+        """Caller-supplied extra fields should land on the upstream log record."""
+        caplog.set_level(logging.INFO, logger="routers.utils.error_mapping")
+
+        map_gumnut_error(
+            make_sdk_status_error(500, "Upstream request failed"),
+            "Failed to upload asset",
+            extra={"upload_filename": "img.jpg", "device_asset_id": "abc"},
+        )
+
+        matching_records = [
+            record
+            for record in caplog.records
+            if getattr(record, "upload_filename", None) == "img.jpg"
+        ]
+        assert matching_records
+        assert getattr(matching_records[-1], "device_asset_id", None) == "abc"
+
+    def test_rate_limit_error_maps_to_502_and_logs_warning(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """RateLimitError should be mapped to 502 and logged at WARNING."""
+
+        # Patch the imported reference so isinstance() inside map_gumnut_error
+        # matches our fake class (otherwise we'd need the real RateLimitError
+        # constructor, which requires a real httpx.Response).
+        class FakeRateLimitError(Exception):
+            pass
+
+        monkeypatch.setattr(error_mapping_module, "RateLimitError", FakeRateLimitError)
+        caplog.set_level(logging.INFO, logger="routers.utils.error_mapping")
+
+        result = error_mapping_module.map_gumnut_error(
+            FakeRateLimitError("429 Too many requests"),
+            "Failed to upload asset",
+        )
+
+        assert result.status_code == 502
+        assert (
+            result.detail == "Failed to upload asset: Upstream temporarily unavailable"
+        )
+
+        matching_records = [
+            record
+            for record in caplog.records
+            if "rate-limited request" in record.getMessage()
+        ]
+        assert matching_records
+        assert matching_records[-1].levelno == logging.WARNING
+
+    def test_non_sdk_exception_maps_to_500(self, caplog: pytest.LogCaptureFixture):
+        """A plain Exception (e.g. programmer error) should map to 500."""
+        caplog.set_level(logging.INFO, logger="routers.utils.error_mapping")
+
+        result = map_gumnut_error(
+            ValueError("Some unknown error"),
+            "Failed to process",
+        )
+
+        assert isinstance(result, HTTPException)
+        assert result.status_code == 500
+        assert "Some unknown error" in result.detail
+
+    def test_helper_fields_override_caller_extra_in_map_gumnut_error(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """Caller `extra` cannot override authoritative context/status_code."""
+        caplog.set_level(logging.INFO, logger="routers.utils.error_mapping")
+
+        map_gumnut_error(
+            make_sdk_status_error(404, "Not found", cls=NotFoundError),
+            "Failed to fetch resource",
+            extra={"context": "spoof", "status_code": 999, "custom_field": "kept"},
+        )
+
+        records = [
+            r
+            for r in caplog.records
+            if getattr(r, "context", None) == "Failed to fetch resource"
+        ]
+        assert records
+        assert getattr(records[-1], "status_code", None) == 404
+        assert getattr(records[-1], "custom_field", None) == "kept"


### PR DESCRIPTION
Resolves GUM-619.

## Summary

Replaces ad-hoc per-route Gumnut SDK error handling — and a string-matching log severity scheme — with a typed boundary at the FastAPI layer. Three connected changes:

1. **Centralized upstream-status severity policy** in \`routers/utils/error_mapping.py\` (helpers \`upstream_status_log_level\` / \`log_upstream_response\`) so 404 logs at \`INFO\`, other 4xx at \`WARNING\`, and 5xx at \`ERROR\`. This is the original GUM-619 goal — drop the noise floor in Sentry by demoting expected upstream 4xxs.

2. **Global \`GumnutError\` exception handler** in \`config/exceptions.py\` (registered in \`main.py\`) that dispatches by \`isinstance\` against the typed Stainless SDK exception hierarchy:

   | SDK exception | Client status | Detail |
   |---------------|---------------|--------|
   | \`RateLimitError\` | 502 | \"Upstream temporarily unavailable\" |
   | \`APIStatusError\` subclasses (NotFoundError, AuthenticationError, …) | \`exc.status_code\` | from \`body.detail\` / \`body.message\` / \`body.error\` / \`exc.message\` |
   | \`APIResponseValidationError\` | 502 | \"Upstream returned invalid response\" — always logged at ERROR (schema mismatches are a contract bug regardless of upstream HTTP status) |
   | \`APIConnectionError\` / \`APITimeoutError\` | 502 | \"Upstream unreachable\" |
   | generic \`GumnutError\` | 500 | \"Internal error\" |

   This replaces the substring fallback in \`get_upstream_status_code\` (\`\"404\" in msg\`, \`\"not found\" in msg.lower()\`, etc.) which was effectively dead code — real SDK errors always expose \`.status_code\` via \`APIStatusError\`.

3. **Router simplification** — with the handler in place, ~40 \`try: … except Exception as e: raise map_gumnut_error(…) from e\` boilerplate blocks across \`albums\`, \`assets\`, \`faces\`, \`people\`, \`search\`, \`sync\`, \`timeline\`, and \`current_user\` are removed. SDK errors just bubble.

   Per-item bulk handlers (\`delete_assets\`, \`albums.add_assets_to_album\` / \`remove_asset_from_album\` / \`add_assets_to_albums\`, \`people.update_people\`) switch from substring-based dispatch to typed \`isinstance\` checks via a shared \`classify_bulk_item_error(exc, enum_cls)\` helper. \`ConflictError\` (409) replaces \`\"duplicate\" in str(e).lower()\` for album-asset adds. Each bulk handler also catches non-APIStatusError \`GumnutError\` (transport / schema-mismatch) per-item, so a transient connection blip mid-batch is recorded as \`unknown\` per item rather than aborting the whole bulk operation. \`update_people\` additionally catches \`ValueError\` for malformed UUID strings — Immich's \`PeopleUpdateItem.id\` is typed as \`str\`, so \`UUID(...)\` can raise.

   Redundant existence pre-checks (\`await client.albums.retrieve(…)\` immediately before \`delete\` / \`update\` / \`assets_associations.add\` / \`assets_associations.remove\`) are dropped — the actual op raises \`NotFoundError\` directly via the SDK, halving upstream round-trips and removing a TOCTOU window. The dead \`if not gumnut_person:\` branch in \`people.get_person\` is also removed.

   \`map_gumnut_error\` is retained — and simplified — for the upload paths (\`_upload_buffered\`, \`_upload_streaming\`) which still need to enrich the upstream log record with call-site context (filename, device IDs, \`exc_info=True\`).

## Shared helpers

- \`extract_detail_from_status_error(exc)\` — body-detail extraction shared between the global handler and \`map_gumnut_error\`.
- \`classify_bulk_item_error(exc, enum_cls)\` — \`APIStatusError\` → \`Error1\` / \`BulkIdErrorReason\` value, generic over the target enum.
- \`truncated_error_detail(exc)\` + \`ERROR_DETAIL_MAX_CHARS = 500\` — one source of truth for the log truncation policy.
- \`log_bulk_transport_error(...)\` — centralizes the 502 ERROR-level log + truncated \`error_detail\` for per-item bulk transport failures.

## Test coverage

- \`tests/unit/utils/test_error_mapping.py\` — \`upstream_status_log_level\` policy, \`log_upstream_response\` (extra-override + exc_info propagation), \`map_gumnut_error\` (typed status mapping, body-detail extraction, log-level policy, extra propagation, RateLimitError → 502, non-SDK exception → 500).
- \`tests/unit/config/test_exceptions.py\` — exercises the global handler end-to-end via a \`TestClient\` (typed status passthrough, body-detail extraction, RateLimitError → 502, \`APIResponseValidationError\` / \`APIConnectionError\` → 502, generic \`GumnutError\` → 500, Immich response shape, log-level policy).
- Router unit tests across \`test_albums\`, \`test_assets\`, \`test_faces\`, \`test_people\`, \`test_search\`, \`test_timeline\` use real SDK exception types via new \`make_sdk_status_error()\` and \`make_sdk_connection_error()\` helpers in \`tests/conftest.py\`, instead of \`Exception(\"404 Not found\")\` mocks that were testing the removed substring fallback.
- New per-item tests for \`ConflictError\` → \`duplicate\`, transient \`GumnutError\` → \`unknown\`, malformed UUID resilience, and partial-failure semantics across bulk endpoints.

## Documentation

\`docs/architecture/adapter-architecture.md\` and \`docs/references/code-practices.md\` updated to describe the new handler dispatch table, \`classify_bulk_item_error\`, and the \`ConflictError\` → duplicate flow.

## Verification

- \`uv run ruff check\` ✅
- \`uv run ruff format --check\` ✅
- \`uv run pytest\` ✅ (715 passed)

Replaces #137.