### PR TITLE
Extract log_bulk_status_error helper and extend map_gumnut_error coverage

### DIFF
--- a/config/exceptions.py
+++ b/config/exceptions.py
@@ -15,6 +15,7 @@ from gumnut import (
 )
 
 from routers.utils.error_mapping import (
+    ERROR_DETAIL_MAX_CHARS,
     extract_detail_from_status_error,
     log_upstream_response,
     logger,
@@ -81,7 +82,7 @@ async def _gumnut_error_handler(request: Request, exc: GumnutError) -> JSONRespo
 
     if isinstance(exc, APIStatusError):
         detail = extract_detail_from_status_error(exc)
-        log_extra: dict[str, Any] = {"error_detail": detail[:500]}
+        log_extra: dict[str, Any] = {"error_detail": detail[:ERROR_DETAIL_MAX_CHARS]}
         log_upstream_response(
             logger,
             context=context,

--- a/routers/api/albums.py
+++ b/routers/api/albums.py
@@ -7,6 +7,7 @@ from gumnut import APIStatusError, AsyncGumnut, ConflictError, GumnutError
 
 from routers.utils.error_mapping import (
     classify_bulk_item_error,
+    log_bulk_status_error,
     log_bulk_transport_error,
 )
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
@@ -191,6 +192,13 @@ async def add_assets_to_album(
                     error=classify_bulk_item_error(asset_error, Error1),
                 )
             )
+            log_bulk_status_error(
+                logger,
+                context="add_assets_to_album",
+                exc=asset_error,
+                message=f"Failed to add asset {asset_uuid_str} to album {id}",
+                extra={"asset_id": asset_uuid_str, "album_id": str(id)},
+            )
         except GumnutError as asset_error:
             response.append(
                 BulkIdResponseDto(
@@ -267,6 +275,13 @@ async def remove_asset_from_album(
                     error=classify_bulk_item_error(asset_error, Error1),
                 )
             )
+            log_bulk_status_error(
+                logger,
+                context="remove_asset_from_album",
+                exc=asset_error,
+                message=f"Failed to remove asset {asset_uuid_str} from album {id}",
+                extra={"asset_id": asset_uuid_str, "album_id": str(id)},
+            )
         except GumnutError as asset_error:
             response.append(
                 BulkIdResponseDto(
@@ -329,6 +344,13 @@ async def add_assets_to_albums(
         except APIStatusError as album_error:
             if first_error is None:
                 first_error = classify_bulk_item_error(album_error, BulkIdErrorReason)
+            log_bulk_status_error(
+                logger,
+                context="add_assets_to_albums",
+                exc=album_error,
+                message=f"Failed to add assets to album {album_uuid}",
+                extra={"album_id": str(album_uuid)},
+            )
         except GumnutError as album_error:
             if first_error is None:
                 first_error = BulkIdErrorReason.unknown

--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -25,10 +25,9 @@ from config.settings import Settings, get_settings
 from routers.utils.cdn_client import DEFAULT_FORWARDED_HEADERS, stream_from_cdn
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
 from routers.utils.error_mapping import (
+    log_bulk_status_error,
     log_bulk_transport_error,
-    log_upstream_response,
     map_gumnut_error,
-    truncated_error_detail,
 )
 from routers.utils.current_user import get_current_user, get_current_user_id
 from pydantic import ValidationError
@@ -622,28 +621,26 @@ async def delete_assets(
 
         except NotFoundError as asset_error:
             # Asset is already gone; expected during sync, log and continue.
-            log_upstream_response(
+            log_bulk_status_error(
                 logger,
                 context="delete_assets",
-                status_code=404,
+                exc=asset_error,
                 message=f"Asset {asset_uuid} not found during deletion",
                 extra={
                     "asset_id": str(asset_uuid),
                     "gumnut_id": str(gumnut_asset_id),
-                    "error_detail": truncated_error_detail(asset_error),
                 },
             )
         except APIStatusError as asset_error:
             # Don't abort bulk delete on individual upstream errors.
-            log_upstream_response(
+            log_bulk_status_error(
                 logger,
                 context="delete_assets",
-                status_code=asset_error.status_code,
+                exc=asset_error,
                 message=f"Failed to delete asset {asset_uuid}",
                 extra={
                     "asset_id": str(asset_uuid),
                     "gumnut_id": str(gumnut_asset_id),
-                    "error_detail": truncated_error_detail(asset_error),
                 },
             )
         except GumnutError as asset_error:

--- a/routers/api/people.py
+++ b/routers/api/people.py
@@ -10,6 +10,7 @@ from gumnut.types import PersonResponse
 from routers.utils.cdn_client import stream_from_cdn
 from routers.utils.error_mapping import (
     classify_bulk_item_error,
+    log_bulk_status_error,
     log_bulk_transport_error,
     log_upstream_response,
 )
@@ -178,10 +179,10 @@ async def update_people(
                     error=classify_bulk_item_error(person_error, Error1),
                 )
             )
-            log_upstream_response(
+            log_bulk_status_error(
                 logger,
                 context="update_people",
-                status_code=person_error.status_code,
+                exc=person_error,
                 message=f"Failed bulk person update for {person_item.id}: {person_error}",
                 extra={"person_id": person_item.id},
             )

--- a/routers/utils/error_mapping.py
+++ b/routers/utils/error_mapping.py
@@ -16,6 +16,8 @@ from typing import Any, TypeVar
 
 from fastapi import HTTPException, status
 from gumnut import (
+    APIConnectionError,
+    APIResponseValidationError,
     APIStatusError,
     AuthenticationError,
     GumnutError,
@@ -90,6 +92,32 @@ def log_bulk_transport_error(
         context=context,
         status_code=status.HTTP_502_BAD_GATEWAY,
         message=f"Transport error in {context}",
+        extra=log_extra,
+    )
+
+
+def log_bulk_status_error(
+    logger_obj: logging.Logger,
+    *,
+    context: str,
+    exc: APIStatusError,
+    message: str,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Log a per-item upstream HTTP error from a bulk endpoint.
+
+    Sibling of `log_bulk_transport_error` for the `APIStatusError` arm of a
+    per-item try/except. Uses `exc.status_code` for severity dispatch and
+    folds truncated `error_detail` into the log record so every bulk endpoint
+    emits the same field set.
+    """
+    log_extra: dict[str, Any] = dict(extra or {})
+    log_extra["error_detail"] = truncated_error_detail(exc)
+    log_upstream_response(
+        logger_obj,
+        context=context,
+        status_code=exc.status_code,
+        message=message,
         extra=log_extra,
     )
 
@@ -193,6 +221,36 @@ def map_gumnut_error(
             exc_info=exc_info,
         )
         return HTTPException(status_code=e.status_code, detail=detail)
+
+    if isinstance(e, APIResponseValidationError):
+        # Schema mismatch is a contract bug — log at 502 ERROR severity, not
+        # the upstream 2xx (which would demote to INFO).
+        log_upstream_response(
+            logger,
+            context=context,
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            message=f"Gumnut SDK returned invalid response in {context}: {e.message}",
+            extra=extra,
+            exc_info=exc_info,
+        )
+        return HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"{context}: Upstream returned invalid response",
+        )
+
+    if isinstance(e, APIConnectionError):
+        log_upstream_response(
+            logger,
+            context=context,
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            message=f"Gumnut SDK connection error in {context}: {e.message}",
+            extra=extra,
+            exc_info=exc_info,
+        )
+        return HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"{context}: Upstream unreachable",
+        )
 
     # Non-SDK exception (transport error, programmer error, etc.) — map to 500.
     log_upstream_response(

--- a/services/streaming_upload.py
+++ b/services/streaming_upload.py
@@ -25,7 +25,7 @@ import httpx
 import sentry_sdk
 from fastapi import HTTPException, Request, status
 
-from routers.utils.error_mapping import log_upstream_response
+from routers.utils.error_mapping import ERROR_DETAIL_MAX_CHARS, log_upstream_response
 from routers.utils.gumnut_client import set_refreshed_token
 from services.streaming_form_parser import StreamingFormParser
 from services.streaming_pipe import StreamingPipe
@@ -267,7 +267,7 @@ class StreamingUploadPipeline:
                 message=f"photos-api upload error for {filename}",
                 extra={
                     "upload_filename": filename,
-                    "error_detail": detail[:500],
+                    "error_detail": detail[:ERROR_DETAIL_MAX_CHARS],
                 },
             )
 

--- a/tests/unit/utils/test_error_mapping.py
+++ b/tests/unit/utils/test_error_mapping.py
@@ -4,9 +4,11 @@ Tests for error mapping utilities.
 
 import logging
 
+import httpx
 import pytest
 from fastapi import HTTPException
 from gumnut import (
+    APIResponseValidationError,
     AuthenticationError,
     BadRequestError,
     NotFoundError,
@@ -15,11 +17,13 @@ from gumnut import (
 
 import routers.utils.error_mapping as error_mapping_module
 from routers.utils.error_mapping import (
+    ERROR_DETAIL_MAX_CHARS,
+    log_bulk_status_error,
     log_upstream_response,
     map_gumnut_error,
     upstream_status_log_level,
 )
-from tests.conftest import make_sdk_status_error
+from tests.conftest import make_sdk_connection_error, make_sdk_status_error
 
 
 class TestUpstreamStatusLogLevel:
@@ -290,3 +294,105 @@ class TestMapGumnutError:
         assert records
         assert getattr(records[-1], "status_code", None) == 404
         assert getattr(records[-1], "custom_field", None) == "kept"
+
+    def test_response_validation_error_maps_to_502_and_logs_error(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """APIResponseValidationError → 502 ERROR, regardless of upstream status."""
+        caplog.set_level(logging.INFO, logger="routers.utils.error_mapping")
+
+        request = httpx.Request("GET", "http://test.local/")
+        # Schema mismatch on a 200 — the upstream HTTP status is fine; the bug
+        # is in the body. Severity must come from the 502 we surface, not 200.
+        response = httpx.Response(200, request=request)
+        err = APIResponseValidationError(response, body=None, message="bad schema")
+
+        result = map_gumnut_error(err, "Failed to upload asset")
+
+        assert result.status_code == 502
+        assert (
+            result.detail
+            == "Failed to upload asset: Upstream returned invalid response"
+        )
+
+        matching = [
+            r
+            for r in caplog.records
+            if getattr(r, "context", None) == "Failed to upload asset"
+        ]
+        assert matching
+        assert matching[-1].levelno == logging.ERROR
+        assert getattr(matching[-1], "status_code", None) == 502
+
+    def test_connection_error_maps_to_502_and_logs_error(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """APIConnectionError → 502 ERROR with `Upstream unreachable` detail."""
+        caplog.set_level(logging.INFO, logger="routers.utils.error_mapping")
+
+        result = map_gumnut_error(
+            make_sdk_connection_error(),
+            "Failed to upload asset",
+        )
+
+        assert result.status_code == 502
+        assert result.detail == "Failed to upload asset: Upstream unreachable"
+
+        matching = [
+            r
+            for r in caplog.records
+            if getattr(r, "context", None) == "Failed to upload asset"
+        ]
+        assert matching
+        assert matching[-1].levelno == logging.ERROR
+
+
+class TestLogBulkStatusError:
+    """Test the per-item bulk-endpoint status-error log helper."""
+
+    def test_uses_status_code_for_severity_and_includes_truncated_detail(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """404 → INFO, error_detail folded into the record and truncated."""
+        caplog.set_level(logging.INFO, logger="routers.utils.error_mapping")
+
+        long_msg = "x" * (ERROR_DETAIL_MAX_CHARS + 50)
+        log_bulk_status_error(
+            error_mapping_module.logger,
+            context="delete_assets",
+            exc=make_sdk_status_error(404, long_msg, cls=NotFoundError),
+            message="Asset not found during deletion",
+            extra={"asset_id": "abc"},
+        )
+
+        matching = [
+            r
+            for r in caplog.records
+            if r.getMessage() == "Asset not found during deletion"
+        ]
+        assert matching
+        record = matching[-1]
+        assert record.levelno == logging.INFO
+        assert getattr(record, "context", None) == "delete_assets"
+        assert getattr(record, "status_code", None) == 404
+        assert getattr(record, "asset_id", None) == "abc"
+        assert len(getattr(record, "error_detail", "")) == ERROR_DETAIL_MAX_CHARS
+
+    def test_500_status_logs_at_error(self, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.INFO, logger="routers.utils.error_mapping")
+
+        log_bulk_status_error(
+            error_mapping_module.logger,
+            context="add_assets_to_album",
+            exc=make_sdk_status_error(500, "boom"),
+            message="Failed to add asset",
+        )
+
+        matching = [
+            r for r in caplog.records if r.getMessage() == "Failed to add asset"
+        ]
+        assert matching
+        assert matching[-1].levelno == logging.ERROR


### PR DESCRIPTION
Follow-up to GUM-619 / #139. Three small cleanups on top of the global SDK error handler.

## 1. `log_bulk_status_error()` helper

Sibling of `log_bulk_transport_error` for the `APIStatusError` arm of bulk per-item try/except blocks. Uses `exc.status_code` for severity dispatch and folds truncated `error_detail` into the log record so callers don't repeat the `log_upstream_response(... extra={"error_detail": truncated_error_detail(exc)})` boilerplate.

Adopted in:
- `albums.add_assets_to_album` (previously logged nothing on the `APIStatusError` arm)
- `albums.remove_asset_from_album` (previously logged nothing)
- `albums.add_assets_to_albums` (previously logged nothing)
- `assets.delete_assets`
- `people.update_people`

## 2. `map_gumnut_error()` covers `APIResponseValidationError` and `APIConnectionError`

The global handler in `config/exceptions.py` already dispatched these to 502, but the upload paths (`services/streaming_upload.py`) which still call `map_gumnut_error` directly were falling through to the generic 500 arm. Both now map to 502 with the same detail / log severity as the global handler.

`APIResponseValidationError` specifically logs at 502 ERROR regardless of the upstream HTTP status, since a schema mismatch is a contract bug not an upstream outage.

## 3. `ERROR_DETAIL_MAX_CHARS` constant

Replaces hardcoded `[:500]` / `500` in `config/exceptions.py` and `services/streaming_upload.py` — one source of truth, matching the existing usage in `truncated_error_detail`.

## Test coverage

- `TestLogBulkStatusError` — status-based severity dispatch, truncated `error_detail` in log record, caller `extra` propagation.
- `TestMapGumnutError::test_response_validation_error_maps_to_502_and_logs_error` — 502 + ERROR severity even when upstream HTTP status is 200.
- `TestMapGumnutError::test_connection_error_maps_to_502_and_logs_error` — 502 + ERROR severity with `Upstream unreachable` detail.

## Test plan

- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run pyright` (0 errors)
- [x] `uv run pytest` (719 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)