### PR TITLE
Implement people merge endpoint (GUM-553)

### DIFF
--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Immich Adapter Architecture"
-last-updated: 2026-03-19
+last-updated: 2026-04-28
 ---
 
 # Immich Adapter Architecture

--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -329,7 +329,7 @@ The adapter implements a subset of Immich's API surface. Unimplemented endpoints
 |------|-----------|-------|
 | Assets | Upload, download (original + thumbnail), delete, bulk delete, existence check, statistics | Streaming downloads via `StreamingResponse` |
 | Albums | CRUD, add/remove assets, statistics | User sharing not supported (returns 501) |
-| People | CRUD, list with pagination/sort/filter, thumbnails, statistics | Merge is a stub |
+| People | CRUD, list with pagination/sort/filter, thumbnails, statistics, merge | |
 | Faces | List, delete, reassign | Create is a stub |
 | Timeline | Time buckets (monthly), bucket contents | Date-range filtering with timezone handling |
 | Search | Smart search, metadata search, person search, statistics | Places, suggestions, explore are stubs |

--- a/docs/design-docs/immich-adapter-gap-analysis.md
+++ b/docs/design-docs/immich-adapter-gap-analysis.md
@@ -2,7 +2,7 @@
 title: "Immich Adapter Gap Analysis"
 status: active
 created: 2026-04-15
-last-updated: 2026-04-21
+last-updated: 2026-04-28
 ---
 
 # Immich Adapter Gap Analysis

--- a/docs/design-docs/immich-adapter-gap-analysis.md
+++ b/docs/design-docs/immich-adapter-gap-analysis.md
@@ -437,7 +437,7 @@ Person merge is listed as a stub in the adapter architecture doc.
 
 **Effort**: **S** — Implement merge as: for each source person, list all faces (paginate fully via the SDK's async iterator) → reassign each to the target person → delete the source person only after all reassignments succeed. Partial failure handling: if a reassignment fails mid-merge, the source person should not be deleted (faces would be orphaned).
 
-**Recommendation**: **Closed** (GUM-553) — implemented in `merge_person` (`routers/api/people.py`): per-source face reassignment via `faces.list` → `faces.update` → `people.delete`, with the source only deleted after all faces succeed and per-item failures returned as `BulkIdResponseDto` so a single bad source can't abort the batch. Self-merge requests are rejected with 400.
+**Recommendation**: **Closed** (GUM-553) — implemented in `merge_person` (`routers/api/people.py`) as a thin pass-through to `client.people.merge`, which atomically reassigns all faces, deletes the sources, and recalculates the primary's centroid embedding. Self-merge is rejected client-side with 400 to keep the Immich error shape stable; empty `ids` is a no-op.
 
 ---
 

--- a/docs/design-docs/immich-adapter-gap-analysis.md
+++ b/docs/design-docs/immich-adapter-gap-analysis.md
@@ -437,7 +437,7 @@ Person merge is listed as a stub in the adapter architecture doc.
 
 **Effort**: **S** — Implement merge as: for each source person, list all faces (paginate fully via the SDK's async iterator) → reassign each to the target person → delete the source person only after all reassignments succeed. Partial failure handling: if a reassignment fails mid-merge, the source person should not be deleted (faces would be orphaned).
 
-**Recommendation**: **Close** — Important for people management UX, small effort, no backend work needed.
+**Recommendation**: **Closed** (GUM-553) — implemented in `merge_person` (`routers/api/people.py`): per-source face reassignment via `faces.list` → `faces.update` → `people.delete`, with the source only deleted after all faces succeed and per-item failures returned as `BulkIdResponseDto` so a single bad source can't abort the batch. Self-merge requests are rejected with 400.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.14"
 dependencies = [
     "cryptography>=46.0.0",
     "fastapi[standard]>=0.135.2",
-    "gumnut-sdk>=0.74.0",
+    "gumnut-sdk>=0.76.0",
     "pydantic-settings>=2.10.1",
     "pytest>=8.4.2",
     "python-socketio>=5.13.0",

--- a/routers/api/people.py
+++ b/routers/api/people.py
@@ -375,19 +375,10 @@ async def merge_person(
     request: MergePersonDto,
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
 ) -> List[BulkIdResponseDto]:
-    """Merge one or more source people into the target person at ``{id}``.
-
-    Delegates to the Gumnut ``people.merge`` endpoint, which atomically
-    reassigns every face from the sources to the target, deletes the
-    sources, and recalculates the target's centroid embedding. The merge is
-    all-or-nothing on the server, so the per-source result list is either
-    fully success or the upstream error is surfaced.
-    """
-    # Empty ids is a no-op for callers; the upstream would 422.
+    """Merge one or more source people into the target person at ``{id}``."""
     if not request.ids:
         return []
 
-    # Self-merge is rejected client-side so Immich gets a stable 400 shape.
     if id in request.ids:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/routers/api/people.py
+++ b/routers/api/people.py
@@ -1,8 +1,10 @@
+import asyncio
+import logging
 from typing import List
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from fastapi.responses import StreamingResponse
-from uuid import UUID
-import logging
 
 from gumnut import APIStatusError, AsyncGumnut, GumnutError
 from gumnut.types import PersonResponse
@@ -380,9 +382,6 @@ async def merge_person(
     delete the source. The source is only deleted after **all** of its faces
     have been successfully reassigned — a partial reassignment leaves the
     source intact so its remaining faces aren't orphaned.
-
-    A failure on one source doesn't abort the batch; results are returned
-    per-source.
     """
     if id in request.ids:
         raise HTTPException(
@@ -392,7 +391,7 @@ async def merge_person(
 
     gumnut_target_person_id = uuid_to_gumnut_person_id(id)
 
-    # Validate target upfront — let GumnutError bubble to the global handler.
+    # Validate target before mutating any sources.
     await client.people.retrieve(gumnut_target_person_id)
 
     results: List[BulkIdResponseDto] = []
@@ -402,13 +401,17 @@ async def merge_person(
         try:
             gumnut_source_person_id = uuid_to_gumnut_person_id(source_uuid)
 
-            # Materialize faces before mutating, mirroring reassign_faces —
-            # avoids any cursor/listing interaction with the in-flight updates.
+            # Materialize the face list before mutating to avoid any cursor /
+            # listing interaction with the in-flight updates.
             faces = [
                 f async for f in client.faces.list(person_id=gumnut_source_person_id)
             ]
-            for face in faces:
-                await client.faces.update(face.id, person_id=gumnut_target_person_id)
+            await asyncio.gather(
+                *(
+                    client.faces.update(face.id, person_id=gumnut_target_person_id)
+                    for face in faces
+                )
+            )
 
             await client.people.delete(gumnut_source_person_id)
 

--- a/routers/api/people.py
+++ b/routers/api/people.py
@@ -369,13 +369,87 @@ async def delete_person(
 
 
 @router.post("/{id}/merge")
-async def merge_person(id: UUID, request: MergePersonDto) -> List[BulkIdResponseDto]:
-    """
-    Merge a person with one or more other people.
-    Not supported by Gumnut, so this is a stub implementation that returns an empty list.
-    """
+async def merge_person(
+    id: UUID,
+    request: MergePersonDto,
+    client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
+) -> List[BulkIdResponseDto]:
+    """Merge one or more source people into the target person at ``{id}``.
 
-    return []
+    For each source person: list its faces, reassign each to the target, then
+    delete the source. The source is only deleted after **all** of its faces
+    have been successfully reassigned — a partial reassignment leaves the
+    source intact so its remaining faces aren't orphaned.
+
+    A failure on one source doesn't abort the batch; results are returned
+    per-source.
+    """
+    if id in request.ids:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot merge a person into themselves",
+        )
+
+    gumnut_target_person_id = uuid_to_gumnut_person_id(id)
+
+    # Validate target upfront — let GumnutError bubble to the global handler.
+    await client.people.retrieve(gumnut_target_person_id)
+
+    results: List[BulkIdResponseDto] = []
+
+    for source_uuid in request.ids:
+        source_id_str = str(source_uuid)
+        try:
+            gumnut_source_person_id = uuid_to_gumnut_person_id(source_uuid)
+
+            # Materialize faces before mutating, mirroring reassign_faces —
+            # avoids any cursor/listing interaction with the in-flight updates.
+            faces = [
+                f async for f in client.faces.list(person_id=gumnut_source_person_id)
+            ]
+            for face in faces:
+                await client.faces.update(face.id, person_id=gumnut_target_person_id)
+
+            await client.people.delete(gumnut_source_person_id)
+
+            results.append(
+                BulkIdResponseDto(id=source_id_str, success=True, error=None)
+            )
+        except APIStatusError as merge_error:
+            results.append(
+                BulkIdResponseDto(
+                    id=source_id_str,
+                    success=False,
+                    error=classify_bulk_item_error(merge_error, Error1),
+                )
+            )
+            log_upstream_response(
+                logger,
+                context="merge_person",
+                status_code=merge_error.status_code,
+                message=(
+                    f"Failed merging person {source_id_str} into {id}: {merge_error}"
+                ),
+                extra={
+                    "source_person_id": source_id_str,
+                    "target_person_id": str(id),
+                },
+            )
+        except GumnutError as merge_error:
+            results.append(
+                BulkIdResponseDto(id=source_id_str, success=False, error=Error1.unknown)
+            )
+            log_bulk_transport_error(
+                logger,
+                context="merge_person",
+                exc=merge_error,
+                extra={
+                    "source_person_id": source_id_str,
+                    "target_person_id": str(id),
+                },
+            )
+
+    return results
 
 
 @router.put("/{id}/reassign")

--- a/routers/api/people.py
+++ b/routers/api/people.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from typing import List
 from uuid import UUID
@@ -378,81 +377,34 @@ async def merge_person(
 ) -> List[BulkIdResponseDto]:
     """Merge one or more source people into the target person at ``{id}``.
 
-    For each source person: list its faces, reassign each to the target, then
-    delete the source. The source is only deleted after **all** of its faces
-    have been successfully reassigned — a partial reassignment leaves the
-    source intact so its remaining faces aren't orphaned.
+    Delegates to the Gumnut ``people.merge`` endpoint, which atomically
+    reassigns every face from the sources to the target, deletes the
+    sources, and recalculates the target's centroid embedding. The merge is
+    all-or-nothing on the server, so the per-source result list is either
+    fully success or the upstream error is surfaced.
     """
+    # Empty ids is a no-op for callers; the upstream would 422.
+    if not request.ids:
+        return []
+
+    # Self-merge is rejected client-side so Immich gets a stable 400 shape.
     if id in request.ids:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Cannot merge a person into themselves",
         )
 
-    gumnut_target_person_id = uuid_to_gumnut_person_id(id)
+    await client.people.merge(
+        uuid_to_gumnut_person_id(id),
+        source_person_ids=[
+            uuid_to_gumnut_person_id(source_uuid) for source_uuid in request.ids
+        ],
+    )
 
-    # Validate target before mutating any sources.
-    await client.people.retrieve(gumnut_target_person_id)
-
-    results: List[BulkIdResponseDto] = []
-
-    for source_uuid in request.ids:
-        source_id_str = str(source_uuid)
-        try:
-            gumnut_source_person_id = uuid_to_gumnut_person_id(source_uuid)
-
-            # Materialize the face list before mutating to avoid any cursor /
-            # listing interaction with the in-flight updates.
-            faces = [
-                f async for f in client.faces.list(person_id=gumnut_source_person_id)
-            ]
-            await asyncio.gather(
-                *(
-                    client.faces.update(face.id, person_id=gumnut_target_person_id)
-                    for face in faces
-                )
-            )
-
-            await client.people.delete(gumnut_source_person_id)
-
-            results.append(
-                BulkIdResponseDto(id=source_id_str, success=True, error=None)
-            )
-        except APIStatusError as merge_error:
-            results.append(
-                BulkIdResponseDto(
-                    id=source_id_str,
-                    success=False,
-                    error=classify_bulk_item_error(merge_error, Error1),
-                )
-            )
-            log_upstream_response(
-                logger,
-                context="merge_person",
-                status_code=merge_error.status_code,
-                message=(
-                    f"Failed merging person {source_id_str} into {id}: {merge_error}"
-                ),
-                extra={
-                    "source_person_id": source_id_str,
-                    "target_person_id": str(id),
-                },
-            )
-        except GumnutError as merge_error:
-            results.append(
-                BulkIdResponseDto(id=source_id_str, success=False, error=Error1.unknown)
-            )
-            log_bulk_transport_error(
-                logger,
-                context="merge_person",
-                exc=merge_error,
-                extra={
-                    "source_person_id": source_id_str,
-                    "target_person_id": str(id),
-                },
-            )
-
-    return results
+    return [
+        BulkIdResponseDto(id=str(source_uuid), success=True, error=None)
+        for source_uuid in request.ids
+    ]
 
 
 @router.put("/{id}/reassign")

--- a/tests/integration/test_sync_stream_http_e2e.py
+++ b/tests/integration/test_sync_stream_http_e2e.py
@@ -19,7 +19,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 from gumnut.types.album_response import AlbumResponse
-from gumnut.types.asset_response import AssetResponse, Metadata
+from gumnut.types.asset_response import AssetResponse
+from gumnut.types.metadata_response import MetadataResponse
 from gumnut.types.face_response import FaceResponse
 from gumnut.types.person_response import PersonResponse
 from gumnut.types.user_response import UserResponse
@@ -172,7 +173,7 @@ def parse_datetime(dt_str: str) -> datetime:
 
 
 def create_asset_response(
-    asset_data: dict, metadata: Metadata | None = None
+    asset_data: dict, metadata: MetadataResponse | None = None
 ) -> AssetResponse:
     """Create an AssetResponse from test data."""
     return AssetResponse(
@@ -192,9 +193,9 @@ def create_asset_response(
     )
 
 
-def create_metadata_response(asset_id: str, metadata_data: dict) -> Metadata:
-    """Create a Metadata object from test data."""
-    return Metadata(
+def create_metadata_response(asset_id: str, metadata_data: dict) -> MetadataResponse:
+    """Create a MetadataResponse object from test data."""
+    return MetadataResponse(
         asset_id=asset_id,
         created_at=datetime.now(timezone.utc),
         updated_at=datetime.now(timezone.utc),

--- a/tests/unit/api/test_people.py
+++ b/tests/unit/api/test_people.py
@@ -1025,36 +1025,23 @@ class TestMergePerson:
     """Test the merge_person endpoint."""
 
     @pytest.mark.anyio
-    async def test_merge_person_empty_ids(self, sample_uuid, sample_gumnut_person):
-        """Empty ids list still validates the target but returns no results."""
+    async def test_merge_person_empty_ids(self, sample_uuid):
+        """Empty ids list short-circuits without an upstream call."""
         mock_client = Mock()
-        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
-        mock_client.faces.list = Mock()
-        mock_client.faces.update = AsyncMock()
-        mock_client.people.delete = AsyncMock()
+        mock_client.people.merge = AsyncMock()
 
         request = MergePersonDto(ids=[])
 
         result = await merge_person(sample_uuid, request, client=mock_client)
 
         assert result == []
-        mock_client.people.retrieve.assert_called_once_with(
-            uuid_to_gumnut_person_id(sample_uuid)
-        )
-        mock_client.faces.list.assert_not_called()
-        mock_client.faces.update.assert_not_called()
-        mock_client.people.delete.assert_not_called()
+        mock_client.people.merge.assert_not_called()
 
     @pytest.mark.anyio
-    async def test_merge_person_self_merge_rejected(
-        self, sample_uuid, sample_gumnut_person
-    ):
-        """Including the target id in the source list returns 400."""
+    async def test_merge_person_self_merge_rejected(self, sample_uuid):
+        """Including the target id in the source list returns 400 before any upstream call."""
         mock_client = Mock()
-        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
-        mock_client.faces.list = Mock()
-        mock_client.faces.update = AsyncMock()
-        mock_client.people.delete = AsyncMock()
+        mock_client.people.merge = AsyncMock()
 
         request = MergePersonDto(ids=[uuid4(), sample_uuid])
 
@@ -1062,29 +1049,18 @@ class TestMergePerson:
             await merge_person(sample_uuid, request, client=mock_client)
 
         assert exc_info.value.status_code == 400
-        # Target should not be retrieved when the request is rejected upfront
-        mock_client.people.retrieve.assert_not_called()
-        mock_client.faces.update.assert_not_called()
-        mock_client.people.delete.assert_not_called()
+        mock_client.people.merge.assert_not_called()
 
     @pytest.mark.anyio
     async def test_merge_person_single_source_success(
-        self, sample_uuid, sample_gumnut_person, mock_sync_cursor_page
+        self, sample_uuid, sample_gumnut_person
     ):
-        """A single source person is merged: faces reassigned, source deleted."""
+        """A single source: one upstream merge call, all-success result."""
         target_uuid = sample_uuid
         source_uuid = uuid4()
 
-        mock_face_1 = Mock(id="face_aaa")
-        mock_face_2 = Mock(id="face_bbb")
-
         mock_client = Mock()
-        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
-        mock_client.faces.list = Mock(
-            return_value=mock_sync_cursor_page([mock_face_1, mock_face_2])
-        )
-        mock_client.faces.update = AsyncMock()
-        mock_client.people.delete = AsyncMock()
+        mock_client.people.merge = AsyncMock(return_value=sample_gumnut_person)
 
         request = MergePersonDto(ids=[source_uuid])
 
@@ -1095,39 +1071,22 @@ class TestMergePerson:
         assert result[0].success is True
         assert result[0].error is None
 
-        mock_client.faces.list.assert_called_once_with(
-            person_id=uuid_to_gumnut_person_id(source_uuid)
-        )
-        assert mock_client.faces.update.call_count == 2
-        mock_client.faces.update.assert_any_call(
-            "face_aaa", person_id=uuid_to_gumnut_person_id(target_uuid)
-        )
-        mock_client.faces.update.assert_any_call(
-            "face_bbb", person_id=uuid_to_gumnut_person_id(target_uuid)
-        )
-        mock_client.people.delete.assert_called_once_with(
-            uuid_to_gumnut_person_id(source_uuid)
+        mock_client.people.merge.assert_called_once_with(
+            uuid_to_gumnut_person_id(target_uuid),
+            source_person_ids=[uuid_to_gumnut_person_id(source_uuid)],
         )
 
     @pytest.mark.anyio
     async def test_merge_person_multiple_sources_success(
-        self, sample_uuid, sample_gumnut_person, mock_sync_cursor_page
+        self, sample_uuid, sample_gumnut_person
     ):
-        """Multiple sources are each merged into the target."""
+        """Multiple sources go through a single atomic upstream merge call."""
         target_uuid = sample_uuid
         source_1 = uuid4()
         source_2 = uuid4()
 
         mock_client = Mock()
-        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
-        mock_client.faces.list = Mock(
-            side_effect=[
-                mock_sync_cursor_page([Mock(id="face_a")]),
-                mock_sync_cursor_page([Mock(id="face_b")]),
-            ]
-        )
-        mock_client.faces.update = AsyncMock()
-        mock_client.people.delete = AsyncMock()
+        mock_client.people.merge = AsyncMock(return_value=sample_gumnut_person)
 
         request = MergePersonDto(ids=[source_1, source_2])
 
@@ -1135,165 +1094,33 @@ class TestMergePerson:
 
         assert len(result) == 2
         assert all(r.success for r in result)
-        assert {r.id for r in result} == {str(source_1), str(source_2)}
+        assert [r.id for r in result] == [str(source_1), str(source_2)]
 
-        # Each source listed independently
-        list_calls = mock_client.faces.list.call_args_list
-        assert list_calls[0][1]["person_id"] == uuid_to_gumnut_person_id(source_1)
-        assert list_calls[1][1]["person_id"] == uuid_to_gumnut_person_id(source_2)
-
-        # Both sources deleted
-        assert mock_client.people.delete.call_count == 2
-        mock_client.people.delete.assert_any_call(uuid_to_gumnut_person_id(source_1))
-        mock_client.people.delete.assert_any_call(uuid_to_gumnut_person_id(source_2))
-
-    @pytest.mark.anyio
-    async def test_merge_person_source_with_no_faces_still_deletes(
-        self, sample_uuid, sample_gumnut_person, mock_sync_cursor_page
-    ):
-        """A source with no faces is still deleted (nothing to reassign)."""
-        target_uuid = sample_uuid
-        source_uuid = uuid4()
-
-        mock_client = Mock()
-        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
-        mock_client.faces.list = Mock(return_value=mock_sync_cursor_page([]))
-        mock_client.faces.update = AsyncMock()
-        mock_client.people.delete = AsyncMock()
-
-        request = MergePersonDto(ids=[source_uuid])
-
-        result = await merge_person(target_uuid, request, client=mock_client)
-
-        assert result[0].success is True
-        mock_client.faces.update.assert_not_called()
-        mock_client.people.delete.assert_called_once_with(
-            uuid_to_gumnut_person_id(source_uuid)
+        mock_client.people.merge.assert_called_once_with(
+            uuid_to_gumnut_person_id(target_uuid),
+            source_person_ids=[
+                uuid_to_gumnut_person_id(source_1),
+                uuid_to_gumnut_person_id(source_2),
+            ],
         )
 
     @pytest.mark.anyio
-    async def test_merge_person_target_not_found_bubbles(self, sample_uuid):
-        """If the target person doesn't exist, the upstream NotFoundError bubbles."""
+    async def test_merge_person_upstream_error_bubbles(self, sample_uuid):
+        """Upstream errors bubble to the global GumnutError handler — merge is atomic."""
         from gumnut import NotFoundError
         from tests.conftest import make_sdk_status_error
 
         mock_client = Mock()
-        mock_client.people.retrieve = AsyncMock(
+        mock_client.people.merge = AsyncMock(
             side_effect=make_sdk_status_error(
                 404, "Person not found", cls=NotFoundError
             )
         )
 
-        request = MergePersonDto(ids=[uuid4()])
+        request = MergePersonDto(ids=[uuid4(), uuid4()])
 
         with pytest.raises(NotFoundError):
             await merge_person(sample_uuid, request, client=mock_client)
-
-    @pytest.mark.anyio
-    async def test_merge_person_source_not_found_per_item(
-        self, sample_uuid, sample_gumnut_person, mock_sync_cursor_page
-    ):
-        """A missing source maps to a per-item not_found result; batch continues."""
-        from gumnut import NotFoundError
-        from tests.conftest import make_sdk_status_error
-
-        target_uuid = sample_uuid
-        good_source = uuid4()
-        missing_source = uuid4()
-
-        mock_client = Mock()
-        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
-        # First source: lists faces fine. Second source: lookup raises NotFoundError.
-        mock_client.faces.list = Mock(
-            side_effect=[
-                mock_sync_cursor_page([Mock(id="face_a")]),
-                make_sdk_status_error(404, "Not found", cls=NotFoundError),
-            ]
-        )
-        mock_client.faces.update = AsyncMock()
-        mock_client.people.delete = AsyncMock()
-
-        request = MergePersonDto(ids=[good_source, missing_source])
-
-        result = await merge_person(target_uuid, request, client=mock_client)
-
-        by_id = {r.id: r for r in result}
-        assert by_id[str(good_source)].success is True
-        assert by_id[str(missing_source)].success is False
-        assert by_id[str(missing_source)].error == Error1.not_found
-
-        # Only the good source should have been deleted
-        mock_client.people.delete.assert_called_once_with(
-            uuid_to_gumnut_person_id(good_source)
-        )
-
-    @pytest.mark.anyio
-    async def test_merge_person_face_update_failure_does_not_delete_source(
-        self, sample_uuid, sample_gumnut_person, mock_sync_cursor_page
-    ):
-        """If a face reassignment fails, the source must NOT be deleted."""
-        from tests.conftest import make_sdk_status_error
-
-        target_uuid = sample_uuid
-        source_uuid = uuid4()
-
-        mock_face = Mock(id="face_xyz")
-
-        mock_client = Mock()
-        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
-        mock_client.faces.list = Mock(return_value=mock_sync_cursor_page([mock_face]))
-        mock_client.faces.update = AsyncMock(
-            side_effect=make_sdk_status_error(500, "Internal error")
-        )
-        mock_client.people.delete = AsyncMock()
-
-        request = MergePersonDto(ids=[source_uuid])
-
-        result = await merge_person(target_uuid, request, client=mock_client)
-
-        assert len(result) == 1
-        assert result[0].id == str(source_uuid)
-        assert result[0].success is False
-        assert result[0].error == Error1.unknown
-        # Source must remain intact when a reassignment fails mid-merge.
-        mock_client.people.delete.assert_not_called()
-
-    @pytest.mark.anyio
-    async def test_merge_person_transport_error_per_item(
-        self, sample_uuid, sample_gumnut_person, mock_sync_cursor_page
-    ):
-        """Non-APIStatusError GumnutError on a source maps to unknown; batch continues."""
-        from tests.conftest import make_sdk_connection_error
-
-        target_uuid = sample_uuid
-        flaky_source = uuid4()
-        good_source = uuid4()
-
-        mock_client = Mock()
-        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
-        # First source: transport error. Second source: succeeds.
-        mock_client.faces.list = Mock(
-            side_effect=[
-                make_sdk_connection_error(),
-                mock_sync_cursor_page([Mock(id="face_ok")]),
-            ]
-        )
-        mock_client.faces.update = AsyncMock()
-        mock_client.people.delete = AsyncMock()
-
-        request = MergePersonDto(ids=[flaky_source, good_source])
-
-        result = await merge_person(target_uuid, request, client=mock_client)
-
-        by_id = {r.id: r for r in result}
-        assert by_id[str(flaky_source)].success is False
-        assert by_id[str(flaky_source)].error == Error1.unknown
-        assert by_id[str(good_source)].success is True
-
-        # Flaky source must not be deleted.
-        mock_client.people.delete.assert_called_once_with(
-            uuid_to_gumnut_person_id(good_source)
-        )
 
 
 class TestReassignFaces:

--- a/tests/unit/api/test_people.py
+++ b/tests/unit/api/test_people.py
@@ -1025,16 +1025,275 @@ class TestMergePerson:
     """Test the merge_person endpoint."""
 
     @pytest.mark.anyio
-    async def test_merge_person_stub(self, sample_uuid):
-        """Test merge person stub implementation."""
-        # Setup
-        request = MergePersonDto(ids=[uuid4(), uuid4()])
+    async def test_merge_person_empty_ids(self, sample_uuid, sample_gumnut_person):
+        """Empty ids list still validates the target but returns no results."""
+        mock_client = Mock()
+        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
+        mock_client.faces.list = Mock()
+        mock_client.faces.update = AsyncMock()
+        mock_client.people.delete = AsyncMock()
 
-        # Execute
-        result = await merge_person(sample_uuid, request)
+        request = MergePersonDto(ids=[])
 
-        # Assert
-        assert result == []  # Stub implementation returns empty list
+        result = await merge_person(sample_uuid, request, client=mock_client)
+
+        assert result == []
+        mock_client.people.retrieve.assert_called_once_with(
+            uuid_to_gumnut_person_id(sample_uuid)
+        )
+        mock_client.faces.list.assert_not_called()
+        mock_client.faces.update.assert_not_called()
+        mock_client.people.delete.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_merge_person_self_merge_rejected(
+        self, sample_uuid, sample_gumnut_person
+    ):
+        """Including the target id in the source list returns 400."""
+        mock_client = Mock()
+        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
+        mock_client.faces.list = Mock()
+        mock_client.faces.update = AsyncMock()
+        mock_client.people.delete = AsyncMock()
+
+        request = MergePersonDto(ids=[uuid4(), sample_uuid])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await merge_person(sample_uuid, request, client=mock_client)
+
+        assert exc_info.value.status_code == 400
+        # Target should not be retrieved when the request is rejected upfront
+        mock_client.people.retrieve.assert_not_called()
+        mock_client.faces.update.assert_not_called()
+        mock_client.people.delete.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_merge_person_single_source_success(
+        self, sample_uuid, sample_gumnut_person, mock_sync_cursor_page
+    ):
+        """A single source person is merged: faces reassigned, source deleted."""
+        target_uuid = sample_uuid
+        source_uuid = uuid4()
+
+        mock_face_1 = Mock(id="face_aaa")
+        mock_face_2 = Mock(id="face_bbb")
+
+        mock_client = Mock()
+        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
+        mock_client.faces.list = Mock(
+            return_value=mock_sync_cursor_page([mock_face_1, mock_face_2])
+        )
+        mock_client.faces.update = AsyncMock()
+        mock_client.people.delete = AsyncMock()
+
+        request = MergePersonDto(ids=[source_uuid])
+
+        result = await merge_person(target_uuid, request, client=mock_client)
+
+        assert len(result) == 1
+        assert result[0].id == str(source_uuid)
+        assert result[0].success is True
+        assert result[0].error is None
+
+        mock_client.faces.list.assert_called_once_with(
+            person_id=uuid_to_gumnut_person_id(source_uuid)
+        )
+        assert mock_client.faces.update.call_count == 2
+        mock_client.faces.update.assert_any_call(
+            "face_aaa", person_id=uuid_to_gumnut_person_id(target_uuid)
+        )
+        mock_client.faces.update.assert_any_call(
+            "face_bbb", person_id=uuid_to_gumnut_person_id(target_uuid)
+        )
+        mock_client.people.delete.assert_called_once_with(
+            uuid_to_gumnut_person_id(source_uuid)
+        )
+
+    @pytest.mark.anyio
+    async def test_merge_person_multiple_sources_success(
+        self, sample_uuid, sample_gumnut_person, mock_sync_cursor_page
+    ):
+        """Multiple sources are each merged into the target."""
+        target_uuid = sample_uuid
+        source_1 = uuid4()
+        source_2 = uuid4()
+
+        mock_client = Mock()
+        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
+        mock_client.faces.list = Mock(
+            side_effect=[
+                mock_sync_cursor_page([Mock(id="face_a")]),
+                mock_sync_cursor_page([Mock(id="face_b")]),
+            ]
+        )
+        mock_client.faces.update = AsyncMock()
+        mock_client.people.delete = AsyncMock()
+
+        request = MergePersonDto(ids=[source_1, source_2])
+
+        result = await merge_person(target_uuid, request, client=mock_client)
+
+        assert len(result) == 2
+        assert all(r.success for r in result)
+        assert {r.id for r in result} == {str(source_1), str(source_2)}
+
+        # Each source listed independently
+        list_calls = mock_client.faces.list.call_args_list
+        assert list_calls[0][1]["person_id"] == uuid_to_gumnut_person_id(source_1)
+        assert list_calls[1][1]["person_id"] == uuid_to_gumnut_person_id(source_2)
+
+        # Both sources deleted
+        assert mock_client.people.delete.call_count == 2
+        mock_client.people.delete.assert_any_call(uuid_to_gumnut_person_id(source_1))
+        mock_client.people.delete.assert_any_call(uuid_to_gumnut_person_id(source_2))
+
+    @pytest.mark.anyio
+    async def test_merge_person_source_with_no_faces_still_deletes(
+        self, sample_uuid, sample_gumnut_person, mock_sync_cursor_page
+    ):
+        """A source with no faces is still deleted (nothing to reassign)."""
+        target_uuid = sample_uuid
+        source_uuid = uuid4()
+
+        mock_client = Mock()
+        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
+        mock_client.faces.list = Mock(return_value=mock_sync_cursor_page([]))
+        mock_client.faces.update = AsyncMock()
+        mock_client.people.delete = AsyncMock()
+
+        request = MergePersonDto(ids=[source_uuid])
+
+        result = await merge_person(target_uuid, request, client=mock_client)
+
+        assert result[0].success is True
+        mock_client.faces.update.assert_not_called()
+        mock_client.people.delete.assert_called_once_with(
+            uuid_to_gumnut_person_id(source_uuid)
+        )
+
+    @pytest.mark.anyio
+    async def test_merge_person_target_not_found_bubbles(self, sample_uuid):
+        """If the target person doesn't exist, the upstream NotFoundError bubbles."""
+        from gumnut import NotFoundError
+        from tests.conftest import make_sdk_status_error
+
+        mock_client = Mock()
+        mock_client.people.retrieve = AsyncMock(
+            side_effect=make_sdk_status_error(
+                404, "Person not found", cls=NotFoundError
+            )
+        )
+
+        request = MergePersonDto(ids=[uuid4()])
+
+        with pytest.raises(NotFoundError):
+            await merge_person(sample_uuid, request, client=mock_client)
+
+    @pytest.mark.anyio
+    async def test_merge_person_source_not_found_per_item(
+        self, sample_uuid, sample_gumnut_person, mock_sync_cursor_page
+    ):
+        """A missing source maps to a per-item not_found result; batch continues."""
+        from gumnut import NotFoundError
+        from tests.conftest import make_sdk_status_error
+
+        target_uuid = sample_uuid
+        good_source = uuid4()
+        missing_source = uuid4()
+
+        mock_client = Mock()
+        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
+        # First source: lists faces fine. Second source: lookup raises NotFoundError.
+        mock_client.faces.list = Mock(
+            side_effect=[
+                mock_sync_cursor_page([Mock(id="face_a")]),
+                make_sdk_status_error(404, "Not found", cls=NotFoundError),
+            ]
+        )
+        mock_client.faces.update = AsyncMock()
+        mock_client.people.delete = AsyncMock()
+
+        request = MergePersonDto(ids=[good_source, missing_source])
+
+        result = await merge_person(target_uuid, request, client=mock_client)
+
+        by_id = {r.id: r for r in result}
+        assert by_id[str(good_source)].success is True
+        assert by_id[str(missing_source)].success is False
+        assert by_id[str(missing_source)].error == Error1.not_found
+
+        # Only the good source should have been deleted
+        mock_client.people.delete.assert_called_once_with(
+            uuid_to_gumnut_person_id(good_source)
+        )
+
+    @pytest.mark.anyio
+    async def test_merge_person_face_update_failure_does_not_delete_source(
+        self, sample_uuid, sample_gumnut_person, mock_sync_cursor_page
+    ):
+        """If a face reassignment fails, the source must NOT be deleted."""
+        from tests.conftest import make_sdk_status_error
+
+        target_uuid = sample_uuid
+        source_uuid = uuid4()
+
+        mock_face = Mock(id="face_xyz")
+
+        mock_client = Mock()
+        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
+        mock_client.faces.list = Mock(return_value=mock_sync_cursor_page([mock_face]))
+        mock_client.faces.update = AsyncMock(
+            side_effect=make_sdk_status_error(500, "Internal error")
+        )
+        mock_client.people.delete = AsyncMock()
+
+        request = MergePersonDto(ids=[source_uuid])
+
+        result = await merge_person(target_uuid, request, client=mock_client)
+
+        assert len(result) == 1
+        assert result[0].id == str(source_uuid)
+        assert result[0].success is False
+        assert result[0].error == Error1.unknown
+        # Source must remain intact when a reassignment fails mid-merge.
+        mock_client.people.delete.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_merge_person_transport_error_per_item(
+        self, sample_uuid, sample_gumnut_person, mock_sync_cursor_page
+    ):
+        """Non-APIStatusError GumnutError on a source maps to unknown; batch continues."""
+        from tests.conftest import make_sdk_connection_error
+
+        target_uuid = sample_uuid
+        flaky_source = uuid4()
+        good_source = uuid4()
+
+        mock_client = Mock()
+        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
+        # First source: transport error. Second source: succeeds.
+        mock_client.faces.list = Mock(
+            side_effect=[
+                make_sdk_connection_error(),
+                mock_sync_cursor_page([Mock(id="face_ok")]),
+            ]
+        )
+        mock_client.faces.update = AsyncMock()
+        mock_client.people.delete = AsyncMock()
+
+        request = MergePersonDto(ids=[flaky_source, good_source])
+
+        result = await merge_person(target_uuid, request, client=mock_client)
+
+        by_id = {r.id: r for r in result}
+        assert by_id[str(flaky_source)].success is False
+        assert by_id[str(flaky_source)].error == Error1.unknown
+        assert by_id[str(good_source)].success is True
+
+        # Flaky source must not be deleted.
+        mock_client.people.delete.assert_called_once_with(
+            uuid_to_gumnut_person_id(good_source)
+        )
 
 
 class TestReassignFaces:

--- a/tests/unit/api/test_people.py
+++ b/tests/unit/api/test_people.py
@@ -1106,7 +1106,7 @@ class TestMergePerson:
 
     @pytest.mark.anyio
     async def test_merge_person_upstream_error_bubbles(self, sample_uuid):
-        """Upstream errors bubble to the global GumnutError handler — merge is atomic."""
+        """Upstream errors bubble to the global GumnutError handler."""
         from gumnut import NotFoundError
         from tests.conftest import make_sdk_status_error
 
@@ -1117,7 +1117,7 @@ class TestMergePerson:
             )
         )
 
-        request = MergePersonDto(ids=[uuid4(), uuid4()])
+        request = MergePersonDto(ids=[uuid4()])
 
         with pytest.raises(NotFoundError):
             await merge_person(sample_uuid, request, client=mock_client)

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-04-10T20:02:23.848635Z"
+exclude-newer = "2026-04-14T22:41:48.422071Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -305,7 +305,7 @@ wheels = [
 
 [[package]]
 name = "gumnut-sdk"
-version = "0.74.0"
+version = "0.76.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -315,9 +315,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/fc/c89473181ac0bf87734959ef69bf9210ab0b73d925ae1db2f0b976c99add/gumnut_sdk-0.74.0.tar.gz", hash = "sha256:07bb47d653f7f423bd3e63aadecaa39a1accc30863d8b1052c5017cf82651c18", size = 278319, upload-time = "2026-04-24T19:24:19.292Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/7b/d6c2675c6b42979ff2089f76bf12e16818a1fc133fd07e02743fea68d2b5/gumnut_sdk-0.76.0.tar.gz", hash = "sha256:58a34517ec72d6eb7416f4509c1377f2cb5351b520890feacc692f7733d7d2e6", size = 280071, upload-time = "2026-04-28T22:39:13.738Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/d8/3ba096a5a2850089aa23668e68d31d4da01765b43175a5fd135c17565322/gumnut_sdk-0.74.0-py3-none-any.whl", hash = "sha256:eabb3ae50e97d506747ede7472f8992efa377784617b64650b43037b339bb5f0", size = 149621, upload-time = "2026-04-24T19:24:17.858Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/49/2e61db06f522c089b898b71905f84f7c2f454f3831ce3436ecc9c2cf7719/gumnut_sdk-0.76.0-py3-none-any.whl", hash = "sha256:714cf84ff7e417026ede5139c12bce76f997e6ff28d21494f98a60060aaee161", size = 151923, upload-time = "2026-04-28T22:39:12.189Z" },
 ]
 
 [[package]]
@@ -409,7 +409,7 @@ dev = [
 requires-dist = [
     { name = "cryptography", specifier = ">=46.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.2" },
-    { name = "gumnut-sdk", specifier = ">=0.74.0" },
+    { name = "gumnut-sdk", specifier = ">=0.76.0" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "python-socketio", specifier = ">=5.13.0" },


### PR DESCRIPTION
## Summary
- Bump `gumnut-sdk` to `>=0.76.0` and replace the `merge_person` stub in `routers/api/people.py` with a thin pass-through to `client.people.merge`. The SDK endpoint atomically reassigns all faces from the sources to the target, deletes the source people, and recalculates the target's centroid embedding (the centroid recalc was missing from earlier client-side sketches of this work).
- Self-merge is rejected client-side with 400 to keep the Immich error shape stable. Empty `ids` short-circuits to `[]` without an upstream call. Upstream errors bubble through the global `GumnutError` handler. Because the server-side merge is all-or-nothing, the returned `BulkIdResponseDto` list is all-success on 200 — there's no partial-failure granularity to surface per source.
- Update `docs/architecture/adapter-architecture.md` (drop "Merge is a stub") and `docs/design-docs/immich-adapter-gap-analysis.md` §22 (Recommendation flipped to "Closed" with a pointer to the new handler).
- Drive-by from the SDK bump: 0.76.0 split `MetadataResponse` out of `asset_response`; updated the one integration test that imported the old `Metadata` name.

## Linear
https://linear.app/gumnut-ai/issue/GUM-553/implement-people-merge-endpoint

## Test plan
- [x] `uv run pytest` (722 passed)
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run pyright` (clean)
- [x] New unit tests cover: empty ids short-circuit (no upstream call), self-merge 400 (no upstream call), single-source success, multi-source success in one atomic upstream call, upstream `NotFoundError` bubbles through

🤖 Generated with [Claude Code](https://claude.com/claude-code)