### PR TITLE
Use bulk SDK calls for single-album add/remove (GUM-650)

### DIFF
--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -317,7 +317,12 @@ Immich clients have no HTTP 429 handling — a rate limit response causes sync f
 
 ### Per-item error handling
 
-Bulk operations (delete assets, update people, add assets to albums) process items individually and track per-item results. A failure on one item doesn't abort the entire operation — the adapter continues processing remaining items and returns a result array with success/error status per item. The shared `classify_bulk_item_error()` helper in `routers/utils/error_mapping.py` maps `APIStatusError` subclasses to the canonical `not_found` / `no_permission` / `unknown` buckets; per-endpoint nuances (e.g. `ConflictError` → `duplicate`) are layered on top.
+Bulk operations expose per-item results to Immich clients via `BulkIdResponseDto[]`, but use one of two implementation shapes depending on whether the upstream Gumnut endpoint is itself bulk-aware:
+
+1. **Single bulk SDK call** (e.g. single-album `add_assets_to_album` / `remove_asset_from_album`). The upstream accepts a list and either splits the result server-side (`add` returns `{added_assets, duplicate_assets}`) or silently skips missing IDs (`remove` returns 204). The adapter maps the response body into per-item results on success; on a bulk error, the whole batch failed (the upstream validates before any DB write), so every requested asset is annotated with the same classified error.
+2. **Per-item fan-out** (e.g. `delete_assets`, `update_people`, multi-album `add_assets_to_albums`). The upstream operates one entity at a time; the adapter loops and tracks per-item results, continuing past per-item failures.
+
+Both shapes use `classify_bulk_item_error()` in `routers/utils/error_mapping.py` to map `APIStatusError` subclasses to the canonical `not_found` / `no_permission` / `unknown` buckets. Per-endpoint nuances are layered on top — e.g. multi-album `add_assets_to_albums` still catches `ConflictError` → `duplicate` from a per-album call, though that catch is effectively dead today since the upstream returns 200 with `duplicate_assets` rather than 409 (tracked for cleanup).
 
 ## Endpoint Implementation Status
 

--- a/routers/api/albums.py
+++ b/routers/api/albums.py
@@ -1,9 +1,14 @@
+import logging
 from typing import Annotated, List
 from uuid import UUID
-import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
-from gumnut import APIStatusError, AsyncGumnut, ConflictError, GumnutError
+from gumnut import (
+    APIStatusError,
+    AsyncGumnut,
+    ConflictError,
+    GumnutError,
+)
 
 from routers.utils.error_mapping import (
     classify_bulk_item_error,
@@ -35,6 +40,7 @@ from routers.utils.album_conversion import convert_gumnut_album_to_immich
 from pydantic.json_schema import SkipJsonSchema
 
 logger = logging.getLogger(__name__)
+
 
 router = APIRouter(
     prefix="/api/albums",
@@ -167,44 +173,67 @@ async def add_assets_to_album(
     """
 
     gumnut_album_id = uuid_to_gumnut_album_id(id)
+    album_id_str = str(id)
+    asset_uuids = list(request.ids)
+    gumnut_asset_ids = [
+        uuid_to_gumnut_asset_id(asset_uuid) for asset_uuid in asset_uuids
+    ]
 
-    response = []
-    for asset_uuid in request.ids:
+    # The upstream POST /api/albums/{album_id}/assets accepts the full asset_id
+    # list and returns added/duplicate split server-side, so the happy path is a
+    # single round-trip. The upstream 404s the entire batch when any asset is
+    # missing or in a different library (no partial commit), so a bulk failure
+    # means the whole batch failed — mark every requested asset with the
+    # classified error rather than retrying per-item.
+    try:
+        bulk_response = await client.albums.assets_associations.add(
+            gumnut_album_id, asset_ids=gumnut_asset_ids
+        )
+    except APIStatusError as bulk_error:
+        error = classify_bulk_item_error(bulk_error, Error1)
+        return [
+            BulkIdResponseDto(id=str(asset_uuid), success=False, error=error)
+            for asset_uuid in asset_uuids
+        ]
+    except GumnutError as bulk_error:
+        log_bulk_transport_error(
+            logger,
+            context="add_assets_to_album",
+            exc=bulk_error,
+            extra={"album_id": album_id_str, "asset_count": len(asset_uuids)},
+        )
+        return [
+            BulkIdResponseDto(id=str(asset_uuid), success=False, error=Error1.unknown)
+            for asset_uuid in asset_uuids
+        ]
+
+    added = set(bulk_response.added_assets)
+    duplicate = set(bulk_response.duplicate_assets)
+    results: list[BulkIdResponseDto] = []
+    for gumnut_asset_id, asset_uuid in zip(gumnut_asset_ids, asset_uuids):
         asset_uuid_str = str(asset_uuid)
-        try:
-            gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
-            await client.albums.assets_associations.add(
-                gumnut_album_id, asset_ids=[gumnut_asset_id]
-            )
-            response.append(BulkIdResponseDto(id=asset_uuid_str, success=True))
-        except ConflictError:
-            response.append(
+        if gumnut_asset_id in added:
+            results.append(BulkIdResponseDto(id=asset_uuid_str, success=True))
+        elif gumnut_asset_id in duplicate:
+            results.append(
                 BulkIdResponseDto(
                     id=asset_uuid_str, success=False, error=Error1.duplicate
                 )
             )
-        except APIStatusError as asset_error:
-            response.append(
-                BulkIdResponseDto(
-                    id=asset_uuid_str,
-                    success=False,
-                    error=classify_bulk_item_error(asset_error, Error1),
-                )
+        else:
+            # Shouldn't happen with the current photos-api implementation, but
+            # surface drift via a warning + unknown rather than silently
+            # succeeding.
+            logger.warning(
+                "Asset missing from add_assets bulk response",
+                extra={"album_id": album_id_str, "asset_id": asset_uuid_str},
             )
-        except GumnutError as asset_error:
-            response.append(
+            results.append(
                 BulkIdResponseDto(
                     id=asset_uuid_str, success=False, error=Error1.unknown
                 )
             )
-            log_bulk_transport_error(
-                logger,
-                context="add_assets_to_album",
-                exc=asset_error,
-                extra={"asset_id": asset_uuid_str, "album_id": str(id)},
-            )
-
-    return response
+    return results
 
 
 @router.patch("/{id}")
@@ -249,38 +278,42 @@ async def remove_asset_from_album(
     """
 
     gumnut_album_id = uuid_to_gumnut_album_id(id)
+    album_id_str = str(id)
+    asset_uuids = list(request.ids)
+    gumnut_asset_ids = [
+        uuid_to_gumnut_asset_id(asset_uuid) for asset_uuid in asset_uuids
+    ]
 
-    response = []
-    for asset_uuid in request.ids:
-        asset_uuid_str = str(asset_uuid)
-        try:
-            gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
-            await client.albums.assets_associations.remove(
-                gumnut_album_id, asset_ids=[gumnut_asset_id]
-            )
-            response.append(BulkIdResponseDto(id=asset_uuid_str, success=True))
-        except APIStatusError as asset_error:
-            response.append(
-                BulkIdResponseDto(
-                    id=asset_uuid_str,
-                    success=False,
-                    error=classify_bulk_item_error(asset_error, Error1),
-                )
-            )
-        except GumnutError as asset_error:
-            response.append(
-                BulkIdResponseDto(
-                    id=asset_uuid_str, success=False, error=Error1.unknown
-                )
-            )
-            log_bulk_transport_error(
-                logger,
-                context="remove_asset_from_album",
-                exc=asset_error,
-                extra={"asset_id": asset_uuid_str, "album_id": str(id)},
-            )
+    # The upstream DELETE /api/albums/{album_id}/assets accepts the full
+    # asset_id list, silently skips missing IDs, and returns 204. A single
+    # round-trip covers all assets — we surface batch-level errors (e.g. the
+    # album itself is missing) by mapping the same error onto every entry.
+    try:
+        await client.albums.assets_associations.remove(
+            gumnut_album_id, asset_ids=gumnut_asset_ids
+        )
+    except APIStatusError as bulk_error:
+        error = classify_bulk_item_error(bulk_error, Error1)
+        return [
+            BulkIdResponseDto(id=str(asset_uuid), success=False, error=error)
+            for asset_uuid in asset_uuids
+        ]
+    except GumnutError as bulk_error:
+        log_bulk_transport_error(
+            logger,
+            context="remove_asset_from_album",
+            exc=bulk_error,
+            extra={"album_id": album_id_str, "asset_count": len(asset_uuids)},
+        )
+        return [
+            BulkIdResponseDto(id=str(asset_uuid), success=False, error=Error1.unknown)
+            for asset_uuid in asset_uuids
+        ]
 
-    return response
+    return [
+        BulkIdResponseDto(id=str(asset_uuid), success=True)
+        for asset_uuid in asset_uuids
+    ]
 
 
 @router.delete("/{id}", status_code=204)

--- a/routers/api/albums.py
+++ b/routers/api/albums.py
@@ -357,6 +357,10 @@ async def add_assets_to_albums(
             )
             successful_operations += 1
         except ConflictError:
+            # Dead branch under the current upstream: photos-api returns 200
+            # with duplicate_assets populated rather than 409. Kept for
+            # forward-compat; tracked for cleanup alongside the bulk-call
+            # rewrite of this endpoint.
             if first_error is None:
                 first_error = BulkIdErrorReason.duplicate
         except APIStatusError as album_error:

--- a/routers/api/albums.py
+++ b/routers/api/albums.py
@@ -173,18 +173,10 @@ async def add_assets_to_album(
     """
 
     gumnut_album_id = uuid_to_gumnut_album_id(id)
-    album_id_str = str(id)
-    asset_uuids = list(request.ids)
-    gumnut_asset_ids = [
-        uuid_to_gumnut_asset_id(asset_uuid) for asset_uuid in asset_uuids
-    ]
+    gumnut_asset_ids = [uuid_to_gumnut_asset_id(uuid) for uuid in request.ids]
 
-    # The upstream POST /api/albums/{album_id}/assets accepts the full asset_id
-    # list and returns added/duplicate split server-side, so the happy path is a
-    # single round-trip. The upstream 404s the entire batch when any asset is
-    # missing or in a different library (no partial commit), so a bulk failure
-    # means the whole batch failed — mark every requested asset with the
-    # classified error rather than retrying per-item.
+    # Upstream validates membership before any DB write — a bulk error means no
+    # partial commit, so mark every requested asset failed.
     try:
         bulk_response = await client.albums.assets_associations.add(
             gumnut_album_id, asset_ids=gumnut_asset_ids
@@ -192,25 +184,25 @@ async def add_assets_to_album(
     except APIStatusError as bulk_error:
         error = classify_bulk_item_error(bulk_error, Error1)
         return [
-            BulkIdResponseDto(id=str(asset_uuid), success=False, error=error)
-            for asset_uuid in asset_uuids
+            BulkIdResponseDto(id=str(uuid), success=False, error=error)
+            for uuid in request.ids
         ]
     except GumnutError as bulk_error:
         log_bulk_transport_error(
             logger,
             context="add_assets_to_album",
             exc=bulk_error,
-            extra={"album_id": album_id_str, "asset_count": len(asset_uuids)},
+            extra={"album_id": str(id), "asset_count": len(request.ids)},
         )
         return [
-            BulkIdResponseDto(id=str(asset_uuid), success=False, error=Error1.unknown)
-            for asset_uuid in asset_uuids
+            BulkIdResponseDto(id=str(uuid), success=False, error=Error1.unknown)
+            for uuid in request.ids
         ]
 
     added = set(bulk_response.added_assets)
     duplicate = set(bulk_response.duplicate_assets)
     results: list[BulkIdResponseDto] = []
-    for gumnut_asset_id, asset_uuid in zip(gumnut_asset_ids, asset_uuids):
+    for gumnut_asset_id, asset_uuid in zip(gumnut_asset_ids, request.ids):
         asset_uuid_str = str(asset_uuid)
         if gumnut_asset_id in added:
             results.append(BulkIdResponseDto(id=asset_uuid_str, success=True))
@@ -221,12 +213,11 @@ async def add_assets_to_album(
                 )
             )
         else:
-            # Shouldn't happen with the current photos-api implementation, but
-            # surface drift via a warning + unknown rather than silently
-            # succeeding.
+            # Shouldn't happen with the current photos-api contract — surface
+            # drift via a warning + unknown rather than silently succeeding.
             logger.warning(
                 "Asset missing from add_assets bulk response",
-                extra={"album_id": album_id_str, "asset_id": asset_uuid_str},
+                extra={"album_id": str(id), "asset_id": asset_uuid_str},
             )
             results.append(
                 BulkIdResponseDto(
@@ -278,16 +269,11 @@ async def remove_asset_from_album(
     """
 
     gumnut_album_id = uuid_to_gumnut_album_id(id)
-    album_id_str = str(id)
-    asset_uuids = list(request.ids)
-    gumnut_asset_ids = [
-        uuid_to_gumnut_asset_id(asset_uuid) for asset_uuid in asset_uuids
-    ]
+    gumnut_asset_ids = [uuid_to_gumnut_asset_id(uuid) for uuid in request.ids]
 
-    # The upstream DELETE /api/albums/{album_id}/assets accepts the full
-    # asset_id list, silently skips missing IDs, and returns 204. A single
-    # round-trip covers all assets — we surface batch-level errors (e.g. the
-    # album itself is missing) by mapping the same error onto every entry.
+    # Upstream silently skips missing assets and 204s on success — only
+    # batch-level errors (e.g. album missing) reach the except branches, and
+    # they map the same error onto every entry.
     try:
         await client.albums.assets_associations.remove(
             gumnut_album_id, asset_ids=gumnut_asset_ids
@@ -295,25 +281,22 @@ async def remove_asset_from_album(
     except APIStatusError as bulk_error:
         error = classify_bulk_item_error(bulk_error, Error1)
         return [
-            BulkIdResponseDto(id=str(asset_uuid), success=False, error=error)
-            for asset_uuid in asset_uuids
+            BulkIdResponseDto(id=str(uuid), success=False, error=error)
+            for uuid in request.ids
         ]
     except GumnutError as bulk_error:
         log_bulk_transport_error(
             logger,
             context="remove_asset_from_album",
             exc=bulk_error,
-            extra={"album_id": album_id_str, "asset_count": len(asset_uuids)},
+            extra={"album_id": str(id), "asset_count": len(request.ids)},
         )
         return [
-            BulkIdResponseDto(id=str(asset_uuid), success=False, error=Error1.unknown)
-            for asset_uuid in asset_uuids
+            BulkIdResponseDto(id=str(uuid), success=False, error=Error1.unknown)
+            for uuid in request.ids
         ]
 
-    return [
-        BulkIdResponseDto(id=str(asset_uuid), success=True)
-        for asset_uuid in asset_uuids
-    ]
+    return [BulkIdResponseDto(id=str(uuid), success=True) for uuid in request.ids]
 
 
 @router.delete("/{id}", status_code=204)
@@ -357,10 +340,7 @@ async def add_assets_to_albums(
             )
             successful_operations += 1
         except ConflictError:
-            # Dead branch under the current upstream: photos-api returns 200
-            # with duplicate_assets populated rather than 409. Kept for
-            # forward-compat; tracked for cleanup alongside the bulk-call
-            # rewrite of this endpoint.
+            # Dead branch: upstream returns 200 with duplicate_assets, never 409.
             if first_error is None:
                 first_error = BulkIdErrorReason.duplicate
         except APIStatusError as album_error:

--- a/tests/unit/api/test_albums.py
+++ b/tests/unit/api/test_albums.py
@@ -1,5 +1,7 @@
 """Tests for albums.py endpoints."""
 
+import logging
+
 import pytest
 from unittest.mock import AsyncMock, Mock
 from gumnut import NotFoundError
@@ -559,6 +561,39 @@ class TestAddAssetsToAlbum:
         assert all(item.success is False for item in result)
         assert all(item.error == Error1.unknown for item in result)
         assert mock_client.albums.assets_associations.add.call_count == 1
+
+    @pytest.mark.anyio
+    async def test_add_assets_missing_from_response_marked_unknown(
+        self, sample_uuid, caplog
+    ):
+        """An asset_id absent from both added and duplicate sets is marked unknown.
+
+        Defensive against drift in the upstream response shape — if photos-api
+        ever introduces a third bucket (e.g. `not_found_assets`), assets falling
+        into it surface as unknown + warning instead of silently succeeding.
+        """
+        present = uuid4()
+        missing = uuid4()
+        present_gid = uuid_to_gumnut_asset_id(present)
+
+        mock_client = Mock()
+        mock_client.albums.assets_associations.add = AsyncMock(
+            return_value=_add_response(added=[present_gid])
+        )
+
+        request = BulkIdsDto(ids=[present, missing])
+        with caplog.at_level(logging.WARNING):
+            result = await add_assets_to_album(sample_uuid, request, client=mock_client)
+
+        assert result[0].id == str(present)
+        assert result[0].success is True
+        assert result[1].id == str(missing)
+        assert result[1].success is False
+        assert result[1].error == Error1.unknown
+        assert any(
+            "missing from add_assets bulk response" in record.message
+            for record in caplog.records
+        )
 
 
 class TestUpdateAlbum:

--- a/tests/unit/api/test_albums.py
+++ b/tests/unit/api/test_albums.py
@@ -3,9 +3,10 @@
 import pytest
 from unittest.mock import AsyncMock, Mock
 from gumnut import NotFoundError
+from gumnut.types.albums import AssetsAssociationAddResponse
 from uuid import uuid4
 
-from tests.conftest import make_sdk_status_error
+from tests.conftest import make_sdk_connection_error, make_sdk_status_error
 from routers.api.albums import (
     get_all_albums,
     get_album_statistics,
@@ -29,6 +30,15 @@ from routers.utils.gumnut_id_conversion import (
     uuid_to_gumnut_asset_id,
     safe_uuid_from_asset_id,
 )
+
+
+def _add_response(
+    added: list[str] | None = None, duplicate: list[str] | None = None
+) -> AssetsAssociationAddResponse:
+    return AssetsAssociationAddResponse(
+        added_assets=added or [],
+        duplicate_assets=duplicate or [],
+    )
 
 
 class TestGetAllAlbums:
@@ -443,47 +453,80 @@ class TestAddAssetsToAlbum:
 
     @pytest.mark.anyio
     async def test_add_assets_success(self, sample_uuid):
-        """Test successful addition of assets to album."""
-        mock_client = Mock()
-        mock_client.albums.assets_associations.add = AsyncMock(return_value=None)
-
+        """A single bulk call adds every asset and returns success per asset."""
         asset_id1 = uuid4()
         asset_id2 = uuid4()
-        request = BulkIdsDto(ids=[asset_id1, asset_id2])
+        gumnut_id1 = uuid_to_gumnut_asset_id(asset_id1)
+        gumnut_id2 = uuid_to_gumnut_asset_id(asset_id2)
 
+        mock_client = Mock()
+        mock_client.albums.assets_associations.add = AsyncMock(
+            return_value=_add_response(added=[gumnut_id1, gumnut_id2])
+        )
+
+        request = BulkIdsDto(ids=[asset_id1, asset_id2])
+        result = await add_assets_to_album(sample_uuid, request, client=mock_client)
+
+        assert [item.id for item in result] == [str(asset_id1), str(asset_id2)]
+        assert all(item.success is True for item in result)
+        # The endpoint should make a single bulk call, not one per asset.
+        mock_client.albums.assets_associations.add.assert_called_once_with(
+            uuid_to_gumnut_album_id(sample_uuid),
+            asset_ids=[gumnut_id1, gumnut_id2],
+        )
+
+    @pytest.mark.anyio
+    async def test_add_assets_duplicates_from_response(self, sample_uuid):
+        """Duplicates are read from the response body, not inferred from a 409."""
+        new_asset = uuid4()
+        dup_asset = uuid4()
+        new_gid = uuid_to_gumnut_asset_id(new_asset)
+        dup_gid = uuid_to_gumnut_asset_id(dup_asset)
+
+        mock_client = Mock()
+        mock_client.albums.assets_associations.add = AsyncMock(
+            return_value=_add_response(added=[new_gid], duplicate=[dup_gid])
+        )
+
+        request = BulkIdsDto(ids=[new_asset, dup_asset])
         result = await add_assets_to_album(sample_uuid, request, client=mock_client)
 
         assert len(result) == 2
-        assert all(item.success is True for item in result)
-        assert result[0].id == str(asset_id1)
-        assert result[1].id == str(asset_id2)
-        assert mock_client.albums.assets_associations.add.call_count == 2
+        assert result[0].id == str(new_asset)
+        assert result[0].success is True
+        assert result[1].id == str(dup_asset)
+        assert result[1].success is False
+        assert result[1].error == Error1.duplicate
 
     @pytest.mark.anyio
-    async def test_add_assets_not_found(self, mock_gumnut_client, sample_uuid):
-        """A NotFoundError on the per-asset add is captured as Error1.not_found."""
-        request = BulkIdsDto(ids=[uuid4()])
-        mock_gumnut_client.albums.assets_associations.add = AsyncMock(
+    async def test_add_assets_not_found_marks_all(self, sample_uuid):
+        """A 404 on the bulk call marks every requested asset as not_found.
+
+        Upstream validates membership before any DB write, so a 404 means the
+        whole batch failed — no per-item retry, no partial commit to recover.
+        """
+        mock_client = Mock()
+        mock_client.albums.assets_associations.add = AsyncMock(
             side_effect=make_sdk_status_error(404, "Not found", cls=NotFoundError)
         )
 
-        result = await add_assets_to_album(
-            sample_uuid, request, client=mock_gumnut_client
-        )
+        asset_id1 = uuid4()
+        asset_id2 = uuid4()
+        request = BulkIdsDto(ids=[asset_id1, asset_id2])
 
-        assert len(result) == 1
-        assert result[0].success is False
-        assert result[0].error == Error1.not_found
+        result = await add_assets_to_album(sample_uuid, request, client=mock_client)
+
+        assert [item.id for item in result] == [str(asset_id1), str(asset_id2)]
+        assert all(item.success is False for item in result)
+        assert all(item.error == Error1.not_found for item in result)
+        assert mock_client.albums.assets_associations.add.call_count == 1
 
     @pytest.mark.anyio
-    async def test_add_assets_mixed_results(self, sample_uuid):
-        """Per-asset NotFoundError is captured as Error1.not_found, others as unknown."""
+    async def test_add_assets_other_api_status_error_marks_all(self, sample_uuid):
+        """A non-404 4xx/5xx on the bulk call marks every requested asset with the same error."""
         mock_client = Mock()
         mock_client.albums.assets_associations.add = AsyncMock(
-            side_effect=[
-                None,
-                make_sdk_status_error(404, "Asset not found", cls=NotFoundError),
-            ]
+            side_effect=make_sdk_status_error(500, "boom")
         )
 
         asset_id1 = uuid4()
@@ -492,29 +535,30 @@ class TestAddAssetsToAlbum:
 
         result = await add_assets_to_album(sample_uuid, request, client=mock_client)
 
-        assert len(result) == 2
-        assert result[0].success is True
-        assert result[0].id == str(asset_id1)
-        assert result[1].success is False
-        assert result[1].id == str(asset_id2)
-        assert result[1].error == Error1.not_found
+        assert [item.id for item in result] == [str(asset_id1), str(asset_id2)]
+        assert all(item.success is False for item in result)
+        assert all(item.error == Error1.unknown for item in result)
+        # Should not retry per-item for non-404 errors.
+        assert mock_client.albums.assets_associations.add.call_count == 1
 
     @pytest.mark.anyio
-    async def test_add_assets_duplicate(self, sample_uuid):
-        """A ConflictError from the SDK is mapped to Error1.duplicate."""
-        from gumnut import ConflictError
-
+    async def test_add_assets_transport_error_marks_all(self, sample_uuid):
+        """An SDK transport error on the bulk call marks every asset as unknown."""
         mock_client = Mock()
         mock_client.albums.assets_associations.add = AsyncMock(
-            side_effect=make_sdk_status_error(409, "duplicate", cls=ConflictError)
+            side_effect=make_sdk_connection_error()
         )
 
-        request = BulkIdsDto(ids=[uuid4()])
+        asset_id1 = uuid4()
+        asset_id2 = uuid4()
+        request = BulkIdsDto(ids=[asset_id1, asset_id2])
+
         result = await add_assets_to_album(sample_uuid, request, client=mock_client)
 
-        assert len(result) == 1
-        assert result[0].success is False
-        assert result[0].error == Error1.duplicate
+        assert [item.id for item in result] == [str(asset_id1), str(asset_id2)]
+        assert all(item.success is False for item in result)
+        assert all(item.error == Error1.unknown for item in result)
+        assert mock_client.albums.assets_associations.add.call_count == 1
 
 
 class TestUpdateAlbum:
@@ -591,43 +635,50 @@ class TestRemoveAssetFromAlbum:
 
     @pytest.mark.anyio
     async def test_remove_assets_success(self, sample_uuid):
-        """Test successful removal of assets from album."""
+        """A single bulk call removes every asset and returns success per asset."""
+        asset_id1 = uuid4()
+        asset_id2 = uuid4()
+        gumnut_id1 = uuid_to_gumnut_asset_id(asset_id1)
+        gumnut_id2 = uuid_to_gumnut_asset_id(asset_id2)
+
         mock_client = Mock()
         mock_client.albums.assets_associations.remove = AsyncMock(return_value=None)
 
-        asset_id1 = uuid4()
-        asset_id2 = uuid4()
         request = BulkIdsDto(ids=[asset_id1, asset_id2])
-
         result = await remove_asset_from_album(sample_uuid, request, client=mock_client)
 
-        assert len(result) == 2
+        assert [item.id for item in result] == [str(asset_id1), str(asset_id2)]
         assert all(item.success is True for item in result)
-        assert result[0].id == str(asset_id1)
-        assert result[1].id == str(asset_id2)
-        assert mock_client.albums.assets_associations.remove.call_count == 2
+        # The endpoint should make a single bulk call, not one per asset.
+        mock_client.albums.assets_associations.remove.assert_called_once_with(
+            uuid_to_gumnut_album_id(sample_uuid),
+            asset_ids=[gumnut_id1, gumnut_id2],
+        )
 
     @pytest.mark.anyio
-    async def test_remove_assets_not_found(self, sample_uuid):
-        """A NotFoundError on a per-asset remove is captured as Error1.not_found."""
+    async def test_remove_assets_album_not_found_marks_all(self, sample_uuid):
+        """A 404 on the bulk call (album missing) marks every asset as not_found."""
         mock_client = Mock()
         mock_client.albums.assets_associations.remove = AsyncMock(
             side_effect=make_sdk_status_error(404, "Not found", cls=NotFoundError)
         )
 
-        request = BulkIdsDto(ids=[uuid4()])
+        asset_id1 = uuid4()
+        asset_id2 = uuid4()
+        request = BulkIdsDto(ids=[asset_id1, asset_id2])
+
         result = await remove_asset_from_album(sample_uuid, request, client=mock_client)
 
-        assert len(result) == 1
-        assert result[0].success is False
-        assert result[0].error == Error1.not_found
+        assert [item.id for item in result] == [str(asset_id1), str(asset_id2)]
+        assert all(item.success is False for item in result)
+        assert all(item.error == Error1.not_found for item in result)
 
     @pytest.mark.anyio
-    async def test_remove_assets_mixed_results(self, sample_uuid):
-        """One success + one APIStatusError failure returns mixed per-item results."""
+    async def test_remove_assets_other_error_marks_all(self, sample_uuid):
+        """A non-404 4xx/5xx marks every asset with the classified error."""
         mock_client = Mock()
         mock_client.albums.assets_associations.remove = AsyncMock(
-            side_effect=[None, make_sdk_status_error(500, "boom")]
+            side_effect=make_sdk_status_error(500, "boom")
         )
 
         asset_id1 = uuid4()
@@ -636,12 +687,27 @@ class TestRemoveAssetFromAlbum:
 
         result = await remove_asset_from_album(sample_uuid, request, client=mock_client)
 
-        assert len(result) == 2
-        assert result[0].success is True
-        assert result[0].id == str(asset_id1)
-        assert result[1].success is False
-        assert result[1].id == str(asset_id2)
-        assert result[1].error == Error1.unknown
+        assert all(item.success is False for item in result)
+        assert all(item.error == Error1.unknown for item in result)
+        assert mock_client.albums.assets_associations.remove.call_count == 1
+
+    @pytest.mark.anyio
+    async def test_remove_assets_transport_error_marks_all(self, sample_uuid):
+        """An SDK transport error on the bulk call marks every asset as unknown."""
+        mock_client = Mock()
+        mock_client.albums.assets_associations.remove = AsyncMock(
+            side_effect=make_sdk_connection_error()
+        )
+
+        asset_id1 = uuid4()
+        asset_id2 = uuid4()
+        request = BulkIdsDto(ids=[asset_id1, asset_id2])
+
+        result = await remove_asset_from_album(sample_uuid, request, client=mock_client)
+
+        assert all(item.success is False for item in result)
+        assert all(item.error == Error1.unknown for item in result)
+        assert mock_client.albums.assets_associations.remove.call_count == 1
 
 
 class TestDeleteAlbum:

--- a/tests/unit/api/test_albums.py
+++ b/tests/unit/api/test_albums.py
@@ -471,7 +471,6 @@ class TestAddAssetsToAlbum:
 
         assert [item.id for item in result] == [str(asset_id1), str(asset_id2)]
         assert all(item.success is True for item in result)
-        # The endpoint should make a single bulk call, not one per asset.
         mock_client.albums.assets_associations.add.assert_called_once_with(
             uuid_to_gumnut_album_id(sample_uuid),
             asset_ids=[gumnut_id1, gumnut_id2],
@@ -479,7 +478,7 @@ class TestAddAssetsToAlbum:
 
     @pytest.mark.anyio
     async def test_add_assets_duplicates_from_response(self, sample_uuid):
-        """Duplicates are read from the response body, not inferred from a 409."""
+        """Duplicates are read from the response body."""
         new_asset = uuid4()
         dup_asset = uuid4()
         new_gid = uuid_to_gumnut_asset_id(new_asset)
@@ -540,7 +539,6 @@ class TestAddAssetsToAlbum:
         assert [item.id for item in result] == [str(asset_id1), str(asset_id2)]
         assert all(item.success is False for item in result)
         assert all(item.error == Error1.unknown for item in result)
-        # Should not retry per-item for non-404 errors.
         assert mock_client.albums.assets_associations.add.call_count == 1
 
     @pytest.mark.anyio
@@ -684,7 +682,6 @@ class TestRemoveAssetFromAlbum:
 
         assert [item.id for item in result] == [str(asset_id1), str(asset_id2)]
         assert all(item.success is True for item in result)
-        # The endpoint should make a single bulk call, not one per asset.
         mock_client.albums.assets_associations.remove.assert_called_once_with(
             uuid_to_gumnut_album_id(sample_uuid),
             asset_ids=[gumnut_id1, gumnut_id2],


### PR DESCRIPTION
Resolves [GUM-650](https://linear.app/gumnut-ai/issue/GUM-650). Replaces #143 with a clean rewrite from main.

## Summary

The single-album endpoints (`PUT`/`DELETE /api/albums/{id}/assets`) were fanning out one SDK call per asset. The SDK and upstream `/api/albums/{album_id}/assets` already accept a list of `asset_ids` and split added/duplicate server-side, so a single bulk call replaces the per-asset loop.

## Changes

- **`add_assets_to_album`**: one bulk SDK call. Map per-asset response from the `{added_assets, duplicate_assets}` body. On any bulk error (including a 404 from a missing/wrong-library asset), mark every requested asset with the classified error — the upstream validates before any DB write, so a 404 means the whole batch failed and there is nothing to recover per-item.
- **`remove_asset_from_album`**: one bulk SDK call. The upstream silently skips missing IDs and returns 204, so per-asset `not_found` errors aren't reachable; batch-level errors map to every entry.
- **Multi-album `add_assets_to_albums`**: unchanged (still sequential per-album fan-out, same as pre-PR).

## Latent bug fix (side effect)

The prior per-item code caught `ConflictError` to map duplicates to `error=duplicate`, but the upstream returns 200 with `duplicate_assets` populated (not 409), so the catch never fired and duplicates were silently reported as `success=True`. Reading the response body fixes this.

## Follow-ups

- [GUM-667](https://linear.app/gumnut-ai/issue/GUM-667) — make upstream `add_assets_to_album` silently skip missing assets and return them in a `not_found_assets` response field. Once that lands, the "mark all as not_found on bulk error" branch in this PR can be replaced with structured per-asset classification.
- [GUM-668](https://linear.app/gumnut-ai/issue/GUM-668) — parallelize the remaining per-item fan-out endpoints in the adapter (`delete_assets`, `update_people`, `delete_people`, `reassign_faces`, multi-album `add_assets_to_albums`) with a shared bounded-concurrency utility.
- [GUM-669](https://linear.app/gumnut-ai/issue/GUM-669) — cap `asset_ids` length on the upstream album add/remove bulk endpoints to avoid hitting the Postgres bind-param limit (32,767) at extreme batch sizes.
- [GUM-670](https://linear.app/gumnut-ai/issue/GUM-670) — chunk `asset_ids` in the adapter before calling the SDK so a power user adding ≥30k photos in one click doesn't trigger a 5xx. Blocked on GUM-669.

## Tests

- 36 album tests pass (`uv run pytest tests/unit/api/test_albums.py`)
- New tests cover: single-call assertion, response-body duplicate detection, 404 marks all as `not_found`, other-status-error fan-out (4xx/5xx), transport-error fan-out for both add/remove
- Removed: dead `ConflictError`-based duplicate test for `add_assets_to_album`

## Validation

- `uv run ruff format` / `ruff check` (clean)
- `uv run pyright` (clean)
- `uv run pytest` (all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)