### PR TITLE
GUM-635: Trash PR B: DELETE honors force + trash router + WebSocket events

### DIFF
--- a/docs/architecture/websocket-implementation.md
+++ b/docs/architecture/websocket-implementation.md
@@ -159,7 +159,9 @@ Starting with `on_upload_success`, but designed for future extension:
 |---|---|---|---|---|
 | `on_upload_success` | `AssetResponseDto` | Yes | Legacy | photos-api thumbnails are synchronous |
 | `AssetUploadReadyV1` | `SyncAssetV1` + `SyncAssetExifV1` | No | v2 sync | Emit alongside `on_upload_success` |
-| `on_asset_delete` | `string` (assetId) | Yes | Yes | photos-api deletion is synchronous |
+| `on_asset_delete` | `string` (assetId) | Yes | Yes | One per id; force=true permanent delete |
+| `on_asset_trash` | `string[]` (assetIds) | Yes | Yes | Batched per chunk; force=false soft delete |
+| `on_asset_restore` | `string[]` (assetIds) | Yes | Yes | Batched per chunk; restore from trash |
 | `on_session_delete` | `string` (sessionId) | Yes | No | Sessions managed by immich-adapter |
 | `on_server_version` | `ServerVersionResponseDto` | Yes | No | Sent on connect (existing) |
 
@@ -175,7 +177,6 @@ These events require features that don't exist in photos-api:
 
 | Event | Reason |
 |---|---|
-| `on_asset_trash` / `on_asset_restore` | photos-api hard-deletes (no soft-delete) |
 | `on_asset_update` | Assets are immutable after creation |
 | `on_asset_stack_update` | Stacks not implemented |
 | `on_asset_hidden` | Asset visibility not supported |
@@ -186,7 +187,7 @@ These events require features that don't exist in photos-api:
 ### Implementation Priority
 
 1. **`on_upload_success` + `AssetUploadReadyV1`** - Core upload feedback for web and mobile
-2. **`on_asset_delete`** - Timeline synchronization
+2. **`on_asset_delete` + `on_asset_trash` + `on_asset_restore`** - Timeline synchronization for hard-delete, soft-delete, and restore flows
 3. **`on_session_delete`** - Security critical; forces web logout when session deleted
 
 ### 3.3 Mobile v2 Sync Protocol
@@ -218,6 +219,8 @@ class WebSocketEvent(Enum):
     UPLOAD_SUCCESS = "on_upload_success"
     ASSET_UPLOAD_READY_V1 = "AssetUploadReadyV1"
     ASSET_DELETE = "on_asset_delete"
+    ASSET_TRASH = "on_asset_trash"
+    ASSET_RESTORE = "on_asset_restore"
     SESSION_DELETE = "on_session_delete"
     SERVER_VERSION = "on_server_version"
 
@@ -298,6 +301,8 @@ class WebSocketEvent(Enum):
     UPLOAD_SUCCESS = "on_upload_success"
     ASSET_UPLOAD_READY_V1 = "AssetUploadReadyV1"
     ASSET_DELETE = "on_asset_delete"
+    ASSET_TRASH = "on_asset_trash"
+    ASSET_RESTORE = "on_asset_restore"
     SESSION_DELETE = "on_session_delete"
     SERVER_VERSION = "on_server_version"
 
@@ -416,14 +421,14 @@ async def emit_event(event: WebSocketEvent, user_id: str, payload: EventPayload 
 ```python
 # In routers/api/assets.py (after upload completes)
 
-from routers.api.websockets import emit_event, WebSocketEvent
+from services.websockets import emit_user_event, WebSocketEvent
 
 @router.post("/assets")
 async def upload_asset(...):
     # ... upload logic ...
 
-    # Notify connected clients
-    await emit_event(WebSocketEvent.UPLOAD_SUCCESS, current_user.id, asset_response_dto)
+    # Fire-and-forget; SocketIOError is swallowed inside emit_user_event.
+    await emit_user_event(WebSocketEvent.UPLOAD_SUCCESS, current_user.id, asset_response_dto)
 
     return asset_response_dto
 ```
@@ -435,9 +440,9 @@ async def upload_asset(...):
 async def delete_assets(...):
     # ... delete logic ...
 
-    # Notify connected clients for each deleted asset
+    # No try/except needed — emit_user_event swallows SocketIOError centrally.
     for asset_id in deleted_asset_ids:
-        await emit_event(WebSocketEvent.ASSET_DELETE, current_user.id, asset_id)
+        await emit_user_event(WebSocketEvent.ASSET_DELETE, current_user.id, asset_id)
 ```
 
 ---
@@ -446,9 +451,9 @@ async def delete_assets(...):
 
 ### 5.1 Error Handling
 
-- If `emit_upload_success` is called for a user with no connected clients, it's a no-op (no error)
+- If `emit_user_event` is called for a user with no connected clients, it's a no-op (no error)
 - Session lookup failures during connect result in connection rejection
-- Emit failures should be logged but not block the upload response
+- **Emit failures are swallowed centrally**: `emit_user_event` and `emit_session_event` catch `SocketIOError` from the underlying transport, log at WARN with `exc_info=True`, and return normally. Callers must NOT wrap these in `try/except SocketIOError` — the fire-and-forget contract is type-level so emit failures cannot break the request paired with them. If a caller needs to handle other exception types (e.g., DTO conversion before the emit), it can still wrap the broader block in its own try/except.
 
 ### 5.2 Payload Serialization
 

--- a/docs/architecture/websocket-implementation.md
+++ b/docs/architecture/websocket-implementation.md
@@ -427,7 +427,6 @@ from services.websockets import emit_user_event, WebSocketEvent
 async def upload_asset(...):
     # ... upload logic ...
 
-    # Fire-and-forget; SocketIOError is swallowed inside emit_user_event.
     await emit_user_event(WebSocketEvent.UPLOAD_SUCCESS, current_user.id, asset_response_dto)
 
     return asset_response_dto
@@ -440,7 +439,6 @@ async def upload_asset(...):
 async def delete_assets(...):
     # ... delete logic ...
 
-    # No try/except needed — emit_user_event swallows SocketIOError centrally.
     for asset_id in deleted_asset_ids:
         await emit_user_event(WebSocketEvent.ASSET_DELETE, current_user.id, asset_id)
 ```

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -158,6 +158,10 @@ await client.delete("/api/assets", body={"ids": gumnut_ids}, cast_to=type(None))
 
 `AsyncGumnut` extends `AsyncAPIClient`, whose `.post()` / `.delete()` methods are public, route through the same JWT auth, retry, and response-hook plumbing as the typed methods, and surface the same `GumnutError` hierarchy. Don't import from `gumnut._types` — `cast_to=type(None)` works without it.
 
+### WebSocket Emission
+
+`emit_user_event` and `emit_session_event` (in `services/websockets.py`) are **fire-and-forget**: they catch `SocketIOError` from the underlying transport, log at WARN with `exc_info=True`, and return normally. **Do not wrap call sites in `try/except SocketIOError`** — the central swallow is the contract, and per-site catches are duplication. If the surrounding block needs to handle other exception types (e.g., DTO conversion before the emit, like `_emit_upload_events` in `routers/api/assets.py`), the broader try/except can stay; just don't add a separate `except SocketIOError` branch.
+
 ### Immich Client Error Handling
 
 - **Observed behavior:** Immich mobile and web clients have no HTTP 429 (rate limit) handling. A 429 causes sync failures, broken thumbnails, and upload errors with no automatic recovery.

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -147,6 +147,8 @@ for chunk in batched(asset_uuids, BULK_CHUNK_SIZE):
 
 Backend bulk endpoints are idempotent on already-transitioned rows (e.g., `trash_assets` skips already-trashed ids; `restore_assets` skips already-live ids). **Don't add per-id 404 / NotFoundError swallowing for these flows** — let bulk failures (validation, transport, 5xx) propagate to the global `GumnutError` handler. The per-id-loop-with-NotFoundError pattern shown above under *Gumnut SDK Errors* applies to single-asset endpoints (e.g., `client.assets.delete(asset_id)`), not to the bulk variants.
 
+Pin the no-swallow contract with a `test_*_propagates_sdk_error` test per bulk flow — mock the bulk call to raise via `make_sdk_status_error(500, ...)` and assert `pytest.raises(APIStatusError)`. Without this test, a future refactor that wraps the bulk call in `try/except` would silently regress the contract. See `tests/unit/api/test_assets.py::TestDeleteAssets::test_delete_assets_force_false_propagates_sdk_error` for the canonical shape.
+
 When the SDK doesn't yet expose a typed method for a backend endpoint (Stainless regenerates on a delay after each backend release), call the raw HTTP layer directly via `AsyncGumnut.post()` / `.delete()` with `cast_to=type(None)` for 204-returning endpoints:
 
 ```python

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -132,6 +132,30 @@ for asset_uuid in request.ids:
 
 Use `map_gumnut_error(e, context, extra=..., exc_info=True)` only when the call site needs to enrich the upstream log record with context the global handler can't see — most commonly the upload paths logging filename / device ids / tracebacks.
 
+### Bulk-ID Endpoints
+
+For backend endpoints that accept `{"ids": [...]}` (e.g., `POST /api/assets/trash`, `POST /api/assets/restore`, bulk `DELETE /api/assets`), chunk the request to stay under the backend's `MAX_BULK_GET_IDS=100` cap. Use the shared `BULK_CHUNK_SIZE` constant from `routers/utils/gumnut_client.py` and `itertools.batched`:
+
+```python
+from itertools import batched
+from routers.utils.gumnut_client import BULK_CHUNK_SIZE
+
+for chunk in batched(asset_uuids, BULK_CHUNK_SIZE):
+    gumnut_ids = [uuid_to_gumnut_asset_id(uid) for uid in chunk]
+    await client.post("/api/assets/trash", body={"ids": gumnut_ids}, cast_to=type(None))
+```
+
+Backend bulk endpoints are idempotent on already-transitioned rows (e.g., `trash_assets` skips already-trashed ids; `restore_assets` skips already-live ids). **Don't add per-id 404 / NotFoundError swallowing for these flows** — let bulk failures (validation, transport, 5xx) propagate to the global `GumnutError` handler. The per-id-loop-with-NotFoundError pattern shown above under *Gumnut SDK Errors* applies to single-asset endpoints (e.g., `client.assets.delete(asset_id)`), not to the bulk variants.
+
+When the SDK doesn't yet expose a typed method for a backend endpoint (Stainless regenerates on a delay after each backend release), call the raw HTTP layer directly via `AsyncGumnut.post()` / `.delete()` with `cast_to=type(None)` for 204-returning endpoints:
+
+```python
+await client.post("/api/assets/trash", body={"ids": gumnut_ids}, cast_to=type(None))
+await client.delete("/api/assets", body={"ids": gumnut_ids}, cast_to=type(None))
+```
+
+`AsyncGumnut` extends `AsyncAPIClient`, whose `.post()` / `.delete()` methods are public, route through the same JWT auth, retry, and response-hook plumbing as the typed methods, and surface the same `GumnutError` hierarchy. Don't import from `gumnut._types` — `cast_to=type(None)` works without it.
+
 ### Immich Client Error Handling
 
 - **Observed behavior:** Immich mobile and web clients have no HTTP 429 (rate limit) handling. A 429 causes sync failures, broken thumbnails, and upload errors with no automatic recovery.

--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -1,3 +1,4 @@
+from itertools import batched
 from typing import List, Literal, NamedTuple, cast
 from uuid import UUID, uuid4
 import base64
@@ -18,18 +19,13 @@ from fastapi import (
     status,
 )
 from fastapi.responses import JSONResponse, StreamingResponse
-from gumnut import APIStatusError, AsyncGumnut, GumnutError, NotFoundError
+from gumnut import AsyncGumnut
 from gumnut.types.asset_response import AssetResponse
 
 from config.settings import Settings, get_settings
 from routers.utils.cdn_client import DEFAULT_FORWARDED_HEADERS, stream_from_cdn
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
-from routers.utils.error_mapping import (
-    log_bulk_transport_error,
-    log_upstream_response,
-    map_gumnut_error,
-    truncated_error_detail,
-)
+from routers.utils.error_mapping import map_gumnut_error
 from routers.utils.current_user import get_current_user, get_current_user_id
 from pydantic import ValidationError
 from socketio.exceptions import SocketIOError
@@ -77,6 +73,11 @@ router = APIRouter(
     tags=["assets"],
     responses={404: {"description": "Not found"}},
 )
+
+
+# Backend caps bulk-id endpoints at MAX_BULK_GET_IDS=100 per request; chunk
+# requests larger than that to stay under the cap.
+_BULK_CHUNK_SIZE = 100
 
 
 AssetVariant = Literal["thumbnail", "preview", "fullsize", "original"]
@@ -595,70 +596,89 @@ async def delete_assets(
     current_user_id: UUID = Depends(get_current_user_id),
 ) -> Response:
     """
-    Delete multiple assets using the Gumnut SDK.
-    Deletes assets by their IDs. The force parameter is ignored as Gumnut handles deletion directly.
+    Delete multiple assets, branching on the Immich `force` flag.
+
+    - ``force=True`` permanently deletes via the backend's bulk
+      ``DELETE /api/assets`` endpoint. Emits one ``on_asset_delete`` per id —
+      Immich's wire shape is single-id-per-event for permanent deletes.
+    - ``force=False`` or absent (Immich's native default) soft-deletes via the
+      backend's ``POST /api/assets/trash`` endpoint. Emits a single batched
+      ``on_asset_trash`` event per chunk carrying the full id array.
+
+    The backend bulk endpoints are idempotent — already-trashed or already-purged
+    rows are skipped without erroring — so the previous per-id 404 swallowing
+    is not needed. Bulk failures (validation, transport, 5xx) propagate to the
+    client via the global ``GumnutError`` handler.
     """
+    if not request.ids:
+        return Response(status_code=204)
 
-    for asset_uuid in request.ids:
-        try:
-            gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
-            await client.assets.delete(gumnut_asset_id)
+    if request.force:
+        await _bulk_permanent_delete(client, request.ids, str(current_user_id))
+    else:
+        await _bulk_trash(client, request.ids, str(current_user_id))
 
+    return Response(status_code=204)
+
+
+async def _bulk_permanent_delete(
+    client: AsyncGumnut,
+    asset_uuids: list[UUID],
+    user_id: str,
+) -> None:
+    """Bulk hard-delete; emits one on_asset_delete per id."""
+    for chunk in batched(asset_uuids, _BULK_CHUNK_SIZE):
+        gumnut_ids = [uuid_to_gumnut_asset_id(uid) for uid in chunk]
+        await client.delete(
+            "/api/assets",
+            body={"ids": gumnut_ids},
+            cast_to=type(None),
+        )
+        for asset_uuid in chunk:
             try:
                 await emit_user_event(
                     WebSocketEvent.ASSET_DELETE,
-                    str(current_user_id),
+                    user_id,
                     str(asset_uuid),
                 )
             except SocketIOError as ws_error:
                 logger.warning(
-                    "Failed to emit WebSocket event after asset delete",
+                    "Failed to emit on_asset_delete after permanent delete",
                     extra={
                         "asset_id": str(asset_uuid),
-                        "gumnut_id": str(gumnut_asset_id),
                         "error": str(ws_error),
                     },
                 )
 
-        except NotFoundError as asset_error:
-            # Asset is already gone; expected during sync, log and continue.
-            log_upstream_response(
-                logger,
-                context="delete_assets",
-                status_code=404,
-                message=f"Asset {asset_uuid} not found during deletion",
-                extra={
-                    "asset_id": str(asset_uuid),
-                    "gumnut_id": str(gumnut_asset_id),
-                    "error_detail": truncated_error_detail(asset_error),
-                },
-            )
-        except APIStatusError as asset_error:
-            # Don't abort bulk delete on individual upstream errors.
-            log_upstream_response(
-                logger,
-                context="delete_assets",
-                status_code=asset_error.status_code,
-                message=f"Failed to delete asset {asset_uuid}",
-                extra={
-                    "asset_id": str(asset_uuid),
-                    "gumnut_id": str(gumnut_asset_id),
-                    "error_detail": truncated_error_detail(asset_error),
-                },
-            )
-        except GumnutError as asset_error:
-            # Immich expects best-effort partial deletion; record per-item.
-            log_bulk_transport_error(
-                logger,
-                context="delete_assets",
-                exc=asset_error,
-                extra={
-                    "asset_id": str(asset_uuid),
-                    "gumnut_id": str(gumnut_asset_id),
-                },
-            )
 
-    return Response(status_code=204)
+async def _bulk_trash(
+    client: AsyncGumnut,
+    asset_uuids: list[UUID],
+    user_id: str,
+) -> None:
+    """Bulk soft-delete; emits one batched on_asset_trash per chunk."""
+    for chunk in batched(asset_uuids, _BULK_CHUNK_SIZE):
+        gumnut_ids = [uuid_to_gumnut_asset_id(uid) for uid in chunk]
+        await client.post(
+            "/api/assets/trash",
+            body={"ids": gumnut_ids},
+            cast_to=type(None),
+        )
+        chunk_uuid_strs = [str(uid) for uid in chunk]
+        try:
+            await emit_user_event(
+                WebSocketEvent.ASSET_TRASH,
+                user_id,
+                chunk_uuid_strs,
+            )
+        except SocketIOError as ws_error:
+            logger.warning(
+                "Failed to emit on_asset_trash after soft delete",
+                extra={
+                    "asset_count": len(chunk_uuid_strs),
+                    "error": str(ws_error),
+                },
+            )
 
 
 @router.get("/device/{deviceId}", deprecated=True)

--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -24,7 +24,10 @@ from gumnut.types.asset_response import AssetResponse
 
 from config.settings import Settings, get_settings
 from routers.utils.cdn_client import DEFAULT_FORWARDED_HEADERS, stream_from_cdn
-from routers.utils.gumnut_client import get_authenticated_gumnut_client
+from routers.utils.gumnut_client import (
+    BULK_CHUNK_SIZE,
+    get_authenticated_gumnut_client,
+)
 from routers.utils.error_mapping import map_gumnut_error
 from routers.utils.current_user import get_current_user, get_current_user_id
 from pydantic import ValidationError
@@ -73,11 +76,6 @@ router = APIRouter(
     tags=["assets"],
     responses={404: {"description": "Not found"}},
 )
-
-
-# Backend caps bulk-id endpoints at MAX_BULK_GET_IDS=100 per request; chunk
-# requests larger than that to stay under the cap.
-_BULK_CHUNK_SIZE = 100
 
 
 AssetVariant = Literal["thumbnail", "preview", "fullsize", "original"]
@@ -627,7 +625,7 @@ async def _bulk_permanent_delete(
     user_id: str,
 ) -> None:
     """Bulk hard-delete; emits one on_asset_delete per id."""
-    for chunk in batched(asset_uuids, _BULK_CHUNK_SIZE):
+    for chunk in batched(asset_uuids, BULK_CHUNK_SIZE):
         gumnut_ids = [uuid_to_gumnut_asset_id(uid) for uid in chunk]
         await client.delete(
             "/api/assets",
@@ -657,7 +655,7 @@ async def _bulk_trash(
     user_id: str,
 ) -> None:
     """Bulk soft-delete; emits one batched on_asset_trash per chunk."""
-    for chunk in batched(asset_uuids, _BULK_CHUNK_SIZE):
+    for chunk in batched(asset_uuids, BULK_CHUNK_SIZE):
         gumnut_ids = [uuid_to_gumnut_asset_id(uid) for uid in chunk]
         await client.post(
             "/api/assets/trash",

--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -31,7 +31,6 @@ from routers.utils.gumnut_client import (
 from routers.utils.error_mapping import map_gumnut_error
 from routers.utils.current_user import get_current_user, get_current_user_id
 from pydantic import ValidationError
-from socketio.exceptions import SocketIOError
 
 from services.streaming_upload import StreamingUploadPipeline
 from services.websockets import emit_user_event, WebSocketEvent
@@ -633,20 +632,11 @@ async def _bulk_permanent_delete(
             cast_to=type(None),
         )
         for asset_uuid in chunk:
-            try:
-                await emit_user_event(
-                    WebSocketEvent.ASSET_DELETE,
-                    user_id,
-                    str(asset_uuid),
-                )
-            except SocketIOError as ws_error:
-                logger.warning(
-                    "Failed to emit on_asset_delete after permanent delete",
-                    extra={
-                        "asset_id": str(asset_uuid),
-                        "error": str(ws_error),
-                    },
-                )
+            await emit_user_event(
+                WebSocketEvent.ASSET_DELETE,
+                user_id,
+                str(asset_uuid),
+            )
 
 
 async def _bulk_trash(
@@ -663,20 +653,11 @@ async def _bulk_trash(
             cast_to=type(None),
         )
         chunk_uuid_strs = [str(uid) for uid in chunk]
-        try:
-            await emit_user_event(
-                WebSocketEvent.ASSET_TRASH,
-                user_id,
-                chunk_uuid_strs,
-            )
-        except SocketIOError as ws_error:
-            logger.warning(
-                "Failed to emit on_asset_trash after soft delete",
-                extra={
-                    "asset_count": len(chunk_uuid_strs),
-                    "error": str(ws_error),
-                },
-            )
+        await emit_user_event(
+            WebSocketEvent.ASSET_TRASH,
+            user_id,
+            chunk_uuid_strs,
+        )
 
 
 @router.get("/device/{deviceId}", deprecated=True)

--- a/routers/api/auth.py
+++ b/routers/api/auth.py
@@ -88,7 +88,6 @@ async def post_logout(
                 extra={"error": str(e)},
                 exc_info=True,
             )
-        # emit_session_event swallows SocketIOError internally — fire-and-forget.
         await emit_session_event(
             WebSocketEvent.SESSION_DELETE, session_token, session_token
         )

--- a/routers/api/auth.py
+++ b/routers/api/auth.py
@@ -20,7 +20,6 @@ from routers.utils.cookies import AuthType, ImmichCookie
 from routers.utils.gumnut_client import (
     get_authenticated_gumnut_client_optional,
 )
-from socketio.exceptions import SocketIOError
 
 from services.websockets import emit_session_event, WebSocketEvent
 from services.session_store import SessionStore, get_session_store
@@ -82,15 +81,6 @@ async def post_logout(
     if session_token:
         try:
             await session_store.delete(session_token)
-            # Emit WebSocket event to notify the session's client
-            await emit_session_event(
-                WebSocketEvent.SESSION_DELETE, session_token, session_token
-            )
-        except SocketIOError as ws_error:
-            logger.warning(
-                "Failed to emit WebSocket event after logout",
-                extra={"session_id": session_token, "error": str(ws_error)},
-            )
         except Exception as e:
             # Log but don't fail the logout - cookie clearing is more important
             logger.warning(
@@ -98,6 +88,10 @@ async def post_logout(
                 extra={"error": str(e)},
                 exc_info=True,
             )
+        # emit_session_event swallows SocketIOError internally — fire-and-forget.
+        await emit_session_event(
+            WebSocketEvent.SESSION_DELETE, session_token, session_token
+        )
 
     response.delete_cookie(ImmichCookie.ACCESS_TOKEN.value)
     response.delete_cookie(ImmichCookie.AUTH_TYPE.value)

--- a/routers/api/sessions.py
+++ b/routers/api/sessions.py
@@ -198,7 +198,6 @@ async def delete_session(
 
     await session_store.delete_by_id(session_token)
 
-    # emit_session_event swallows SocketIOError internally — fire-and-forget.
     await emit_session_event(
         WebSocketEvent.SESSION_DELETE, session_token, session_token
     )

--- a/routers/api/sessions.py
+++ b/routers/api/sessions.py
@@ -1,6 +1,6 @@
+import logging
 from typing import List
 from uuid import UUID
-import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
@@ -12,7 +12,6 @@ from routers.immich_models import (
 from routers.utils.current_user import get_current_user_id
 from services.websockets import emit_session_event, WebSocketEvent
 from services.session_store import Session, SessionStore, get_session_store
-from socketio.exceptions import SocketIOError
 
 logger = logging.getLogger(__name__)
 
@@ -199,16 +198,10 @@ async def delete_session(
 
     await session_store.delete_by_id(session_token)
 
-    # Emit WebSocket event to notify the deleted session's client
-    try:
-        await emit_session_event(
-            WebSocketEvent.SESSION_DELETE, session_token, session_token
-        )
-    except SocketIOError as ws_error:
-        logger.warning(
-            "Failed to emit WebSocket event after session delete",
-            extra={"session_id": session_token, "error": str(ws_error)},
-        )
+    # emit_session_event swallows SocketIOError internally — fire-and-forget.
+    await emit_session_event(
+        WebSocketEvent.SESSION_DELETE, session_token, session_token
+    )
 
     return None
 

--- a/routers/api/trash.py
+++ b/routers/api/trash.py
@@ -12,13 +12,11 @@ through ``AsyncGumnut.post`` / ``.delete`` directly. Errors propagate to the
 global ``GumnutError`` handler.
 """
 
-import logging
 from itertools import batched
 from uuid import UUID
 
 from fastapi import APIRouter, Depends
 from gumnut import AsyncGumnut
-from socketio.exceptions import SocketIOError
 
 from routers.immich_models import (
     BulkIdsDto,
@@ -34,8 +32,6 @@ from routers.utils.gumnut_id_conversion import (
     uuid_to_gumnut_asset_id,
 )
 from services.websockets import emit_user_event, WebSocketEvent
-
-logger = logging.getLogger(__name__)
 
 
 router = APIRouter(
@@ -55,7 +51,10 @@ async def empty_trash(
     Enumerates the caller's trashed ids, then issues bulk
     ``DELETE /api/assets`` calls in chunks. Emits one ``on_asset_delete`` per
     purged id, matching Immich's wire shape (single-id-per-event for permanent
-    deletes). Returns the total number of ids purged.
+    deletes). The returned count reflects the upfront enumerated id list;
+    between enumeration and the chunked deletes a concurrent request could
+    transition some ids, so the count can diverge slightly from rows actually
+    purged in this call. The bulk DELETE is idempotent on already-purged ids.
     """
     user_id = str(current_user_id)
     trashed_gumnut_ids = await _list_trashed_ids(client)
@@ -67,20 +66,11 @@ async def empty_trash(
         )
         for gumnut_id in chunk:
             asset_uuid = safe_uuid_from_asset_id(gumnut_id)
-            try:
-                await emit_user_event(
-                    WebSocketEvent.ASSET_DELETE,
-                    user_id,
-                    str(asset_uuid),
-                )
-            except SocketIOError as ws_error:
-                logger.warning(
-                    "Failed to emit on_asset_delete during empty_trash",
-                    extra={
-                        "asset_id": str(asset_uuid),
-                        "error": str(ws_error),
-                    },
-                )
+            await emit_user_event(
+                WebSocketEvent.ASSET_DELETE,
+                user_id,
+                str(asset_uuid),
+            )
     return TrashResponseDto(count=len(trashed_gumnut_ids))
 
 
@@ -93,8 +83,11 @@ async def restore_trash(
 
     Enumerates the caller's trashed ids, then issues bulk
     ``POST /api/assets/restore`` calls in chunks. Emits a single batched
-    ``on_asset_restore`` event per chunk carrying the chunk's id array, and
-    returns the total restored count.
+    ``on_asset_restore`` event per chunk carrying the chunk's id array. The
+    returned count reflects the upfront enumerated id list; concurrent
+    transitions between enumeration and the chunked restores can make it
+    diverge slightly from rows actually restored in this call. The backend's
+    restore endpoint is idempotent on already-live ids.
     """
     user_id = str(current_user_id)
     trashed_gumnut_ids = await _list_trashed_ids(client)
@@ -105,20 +98,11 @@ async def restore_trash(
             cast_to=type(None),
         )
         chunk_uuid_strs = [str(safe_uuid_from_asset_id(gid)) for gid in chunk]
-        try:
-            await emit_user_event(
-                WebSocketEvent.ASSET_RESTORE,
-                user_id,
-                chunk_uuid_strs,
-            )
-        except SocketIOError as ws_error:
-            logger.warning(
-                "Failed to emit on_asset_restore during restore_trash",
-                extra={
-                    "asset_count": len(chunk_uuid_strs),
-                    "error": str(ws_error),
-                },
-            )
+        await emit_user_event(
+            WebSocketEvent.ASSET_RESTORE,
+            user_id,
+            chunk_uuid_strs,
+        )
     return TrashResponseDto(count=len(trashed_gumnut_ids))
 
 
@@ -149,20 +133,11 @@ async def restore_assets(
             cast_to=type(None),
         )
         chunk_uuid_strs = [str(uid) for uid in chunk]
-        try:
-            await emit_user_event(
-                WebSocketEvent.ASSET_RESTORE,
-                user_id,
-                chunk_uuid_strs,
-            )
-        except SocketIOError as ws_error:
-            logger.warning(
-                "Failed to emit on_asset_restore during restore_assets",
-                extra={
-                    "asset_count": len(chunk_uuid_strs),
-                    "error": str(ws_error),
-                },
-            )
+        await emit_user_event(
+            WebSocketEvent.ASSET_RESTORE,
+            user_id,
+            chunk_uuid_strs,
+        )
     return TrashResponseDto(count=len(request.ids))
 
 

--- a/routers/api/trash.py
+++ b/routers/api/trash.py
@@ -1,8 +1,43 @@
-from fastapi import APIRouter
+"""Trash router — restore-by-ids, restore-all, and empty-trash flows.
+
+Backed by the photos-api trash primitives:
+
+- ``POST /api/assets/restore`` — bulk restore by ids (idempotent on already-live).
+- ``DELETE /api/assets`` (bulk body) — bulk permanent delete by ids.
+- ``GET /api/assets?state=trashed`` — paginated trashed listing for the
+  restore-all and empty-trash flows.
+
+The SDK does not expose typed methods for these endpoints yet, so calls go
+through ``AsyncGumnut.post`` / ``.delete`` directly. Errors propagate to the
+global ``GumnutError`` handler.
+"""
+
+import logging
+from itertools import batched
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from gumnut import AsyncGumnut
+from socketio.exceptions import SocketIOError
+
 from routers.immich_models import (
     BulkIdsDto,
     TrashResponseDto,
 )
+from routers.utils.current_user import get_current_user_id
+from routers.utils.gumnut_client import get_authenticated_gumnut_client
+from routers.utils.gumnut_id_conversion import (
+    safe_uuid_from_asset_id,
+    uuid_to_gumnut_asset_id,
+)
+from services.websockets import emit_user_event, WebSocketEvent
+
+logger = logging.getLogger(__name__)
+
+# Backend caps bulk-id endpoints at MAX_BULK_GET_IDS=100 per request; chunk
+# requests larger than that to stay under the cap. List enumeration uses the
+# same value for the per-page limit so each page maps to a single bulk call.
+_BULK_CHUNK_SIZE = 100
 
 
 router = APIRouter(
@@ -13,27 +48,141 @@ router = APIRouter(
 
 
 @router.post("/empty")
-async def empty_trash() -> TrashResponseDto:
+async def empty_trash(
+    client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
+    current_user_id: UUID = Depends(get_current_user_id),
+) -> TrashResponseDto:
+    """Permanently delete every trashed asset belonging to the caller.
+
+    Enumerates the caller's trashed ids, then issues bulk
+    ``DELETE /api/assets`` calls in chunks. Emits one ``on_asset_delete`` per
+    purged id, matching Immich's wire shape (single-id-per-event for permanent
+    deletes). Returns the total number of ids purged.
     """
-    Empty the trash.
-    This is a stub implementation that returns zero count.
-    """
-    return TrashResponseDto(count=0)
+    user_id = str(current_user_id)
+    trashed_gumnut_ids = await _list_trashed_ids(client)
+    total = 0
+    for chunk in batched(trashed_gumnut_ids, _BULK_CHUNK_SIZE):
+        chunk_list = list(chunk)
+        await client.delete(
+            "/api/assets",
+            body={"ids": chunk_list},
+            cast_to=type(None),
+        )
+        total += len(chunk_list)
+        for gumnut_id in chunk_list:
+            asset_uuid = safe_uuid_from_asset_id(gumnut_id)
+            try:
+                await emit_user_event(
+                    WebSocketEvent.ASSET_DELETE,
+                    user_id,
+                    str(asset_uuid),
+                )
+            except SocketIOError as ws_error:
+                logger.warning(
+                    "Failed to emit on_asset_delete during empty_trash",
+                    extra={
+                        "asset_id": str(asset_uuid),
+                        "error": str(ws_error),
+                    },
+                )
+    return TrashResponseDto(count=total)
 
 
 @router.post("/restore")
-async def restore_trash() -> TrashResponseDto:
+async def restore_trash(
+    client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
+    current_user_id: UUID = Depends(get_current_user_id),
+) -> TrashResponseDto:
+    """Restore every trashed asset belonging to the caller.
+
+    Enumerates the caller's trashed ids, then issues bulk
+    ``POST /api/assets/restore`` calls in chunks. Emits a single batched
+    ``on_asset_restore`` event per chunk carrying the chunk's id array, and
+    returns the total restored count.
     """
-    Restore all trashed assets.
-    This is a stub implementation that returns zero count.
-    """
-    return TrashResponseDto(count=0)
+    user_id = str(current_user_id)
+    trashed_gumnut_ids = await _list_trashed_ids(client)
+    total = 0
+    for chunk in batched(trashed_gumnut_ids, _BULK_CHUNK_SIZE):
+        chunk_list = list(chunk)
+        await client.post(
+            "/api/assets/restore",
+            body={"ids": chunk_list},
+            cast_to=type(None),
+        )
+        total += len(chunk_list)
+        chunk_uuid_strs = [str(safe_uuid_from_asset_id(gid)) for gid in chunk_list]
+        try:
+            await emit_user_event(
+                WebSocketEvent.ASSET_RESTORE,
+                user_id,
+                chunk_uuid_strs,
+            )
+        except SocketIOError as ws_error:
+            logger.warning(
+                "Failed to emit on_asset_restore during restore_trash",
+                extra={
+                    "asset_count": len(chunk_uuid_strs),
+                    "error": str(ws_error),
+                },
+            )
+    return TrashResponseDto(count=total)
 
 
 @router.post("/restore/assets")
-async def restore_assets(request: BulkIdsDto) -> TrashResponseDto:
+async def restore_assets(
+    request: BulkIdsDto,
+    client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
+    current_user_id: UUID = Depends(get_current_user_id),
+) -> TrashResponseDto:
+    """Restore the caller's trashed assets identified by the given ids.
+
+    Issues bulk ``POST /api/assets/restore`` calls in chunks of
+    ``_BULK_CHUNK_SIZE``. Emits a single batched ``on_asset_restore`` event
+    per chunk. Already-live ids are silently skipped on the backend; the
+    returned count therefore reflects the request size, not the number of
+    rows that actually transitioned (the backend's restore endpoint returns
+    204 with no count).
     """
-    Restore specific assets from trash.
-    This is a stub implementation that returns zero count.
+    if not request.ids:
+        return TrashResponseDto(count=0)
+
+    user_id = str(current_user_id)
+    for chunk in batched(request.ids, _BULK_CHUNK_SIZE):
+        gumnut_ids = [uuid_to_gumnut_asset_id(uid) for uid in chunk]
+        await client.post(
+            "/api/assets/restore",
+            body={"ids": gumnut_ids},
+            cast_to=type(None),
+        )
+        chunk_uuid_strs = [str(uid) for uid in chunk]
+        try:
+            await emit_user_event(
+                WebSocketEvent.ASSET_RESTORE,
+                user_id,
+                chunk_uuid_strs,
+            )
+        except SocketIOError as ws_error:
+            logger.warning(
+                "Failed to emit on_asset_restore during restore_assets",
+                extra={
+                    "asset_count": len(chunk_uuid_strs),
+                    "error": str(ws_error),
+                },
+            )
+    return TrashResponseDto(count=len(request.ids))
+
+
+async def _list_trashed_ids(client: AsyncGumnut) -> list[str]:
+    """Collect every trashed asset id for the caller, paginated.
+
+    The async iterator handles cursor pagination internally. We collect ids
+    upfront before any mutations so that paging cursors stay stable — once
+    we start restoring or purging, the ``state="trashed"`` view shrinks and
+    cursor-based resumption becomes ill-defined.
     """
-    return TrashResponseDto(count=0)
+    return [
+        asset.id
+        async for asset in client.assets.list(state="trashed", limit=_BULK_CHUNK_SIZE)
+    ]

--- a/routers/api/trash.py
+++ b/routers/api/trash.py
@@ -25,7 +25,10 @@ from routers.immich_models import (
     TrashResponseDto,
 )
 from routers.utils.current_user import get_current_user_id
-from routers.utils.gumnut_client import get_authenticated_gumnut_client
+from routers.utils.gumnut_client import (
+    BULK_CHUNK_SIZE,
+    get_authenticated_gumnut_client,
+)
 from routers.utils.gumnut_id_conversion import (
     safe_uuid_from_asset_id,
     uuid_to_gumnut_asset_id,
@@ -33,11 +36,6 @@ from routers.utils.gumnut_id_conversion import (
 from services.websockets import emit_user_event, WebSocketEvent
 
 logger = logging.getLogger(__name__)
-
-# Backend caps bulk-id endpoints at MAX_BULK_GET_IDS=100 per request; chunk
-# requests larger than that to stay under the cap. List enumeration uses the
-# same value for the per-page limit so each page maps to a single bulk call.
-_BULK_CHUNK_SIZE = 100
 
 
 router = APIRouter(
@@ -61,16 +59,13 @@ async def empty_trash(
     """
     user_id = str(current_user_id)
     trashed_gumnut_ids = await _list_trashed_ids(client)
-    total = 0
-    for chunk in batched(trashed_gumnut_ids, _BULK_CHUNK_SIZE):
-        chunk_list = list(chunk)
+    for chunk in batched(trashed_gumnut_ids, BULK_CHUNK_SIZE):
         await client.delete(
             "/api/assets",
-            body={"ids": chunk_list},
+            body={"ids": list(chunk)},
             cast_to=type(None),
         )
-        total += len(chunk_list)
-        for gumnut_id in chunk_list:
+        for gumnut_id in chunk:
             asset_uuid = safe_uuid_from_asset_id(gumnut_id)
             try:
                 await emit_user_event(
@@ -86,7 +81,7 @@ async def empty_trash(
                         "error": str(ws_error),
                     },
                 )
-    return TrashResponseDto(count=total)
+    return TrashResponseDto(count=len(trashed_gumnut_ids))
 
 
 @router.post("/restore")
@@ -103,16 +98,13 @@ async def restore_trash(
     """
     user_id = str(current_user_id)
     trashed_gumnut_ids = await _list_trashed_ids(client)
-    total = 0
-    for chunk in batched(trashed_gumnut_ids, _BULK_CHUNK_SIZE):
-        chunk_list = list(chunk)
+    for chunk in batched(trashed_gumnut_ids, BULK_CHUNK_SIZE):
         await client.post(
             "/api/assets/restore",
-            body={"ids": chunk_list},
+            body={"ids": list(chunk)},
             cast_to=type(None),
         )
-        total += len(chunk_list)
-        chunk_uuid_strs = [str(safe_uuid_from_asset_id(gid)) for gid in chunk_list]
+        chunk_uuid_strs = [str(safe_uuid_from_asset_id(gid)) for gid in chunk]
         try:
             await emit_user_event(
                 WebSocketEvent.ASSET_RESTORE,
@@ -127,7 +119,7 @@ async def restore_trash(
                     "error": str(ws_error),
                 },
             )
-    return TrashResponseDto(count=total)
+    return TrashResponseDto(count=len(trashed_gumnut_ids))
 
 
 @router.post("/restore/assets")
@@ -139,7 +131,7 @@ async def restore_assets(
     """Restore the caller's trashed assets identified by the given ids.
 
     Issues bulk ``POST /api/assets/restore`` calls in chunks of
-    ``_BULK_CHUNK_SIZE``. Emits a single batched ``on_asset_restore`` event
+    ``BULK_CHUNK_SIZE``. Emits a single batched ``on_asset_restore`` event
     per chunk. Already-live ids are silently skipped on the backend; the
     returned count therefore reflects the request size, not the number of
     rows that actually transitioned (the backend's restore endpoint returns
@@ -149,7 +141,7 @@ async def restore_assets(
         return TrashResponseDto(count=0)
 
     user_id = str(current_user_id)
-    for chunk in batched(request.ids, _BULK_CHUNK_SIZE):
+    for chunk in batched(request.ids, BULK_CHUNK_SIZE):
         gumnut_ids = [uuid_to_gumnut_asset_id(uid) for uid in chunk]
         await client.post(
             "/api/assets/restore",
@@ -184,5 +176,5 @@ async def _list_trashed_ids(client: AsyncGumnut) -> list[str]:
     """
     return [
         asset.id
-        async for asset in client.assets.list(state="trashed", limit=_BULK_CHUNK_SIZE)
+        async for asset in client.assets.list(state="trashed", limit=BULK_CHUNK_SIZE)
     ]

--- a/routers/utils/gumnut_client.py
+++ b/routers/utils/gumnut_client.py
@@ -39,6 +39,12 @@ _thread_local = threading.local()
 
 _shared_http_client: httpx.AsyncClient | None = None
 
+# Backend caps bulk-id endpoints at MAX_BULK_GET_IDS=100 per request; chunk
+# requests larger than that to stay under the cap. Also used as the per-page
+# `limit` when enumerating ids for bulk operations so each enumeration page
+# maps to a single bulk call.
+BULK_CHUNK_SIZE = 100
+
 
 def get_refreshed_token() -> str | None:
     """

--- a/services/websockets.py
+++ b/services/websockets.py
@@ -35,7 +35,12 @@ class WebSocketEvent(Enum):
     # Phase 1: Can implement now
     UPLOAD_SUCCESS = "on_upload_success"
     ASSET_UPLOAD_READY_V1 = "AssetUploadReadyV1"
+    # ASSET_DELETE carries a single id per event; ASSET_TRASH/ASSET_RESTORE
+    # carry an array of ids per event — matches Immich's wire contract:
+    # on_asset_delete: [string], on_asset_trash/on_asset_restore: [string[]].
     ASSET_DELETE = "on_asset_delete"
+    ASSET_TRASH = "on_asset_trash"
+    ASSET_RESTORE = "on_asset_restore"
     SESSION_DELETE = "on_session_delete"
     SERVER_VERSION = "on_server_version"
 
@@ -214,7 +219,8 @@ async def emit_user_event(
     Emit a WebSocket event to all of a user's connected clients.
 
     Use this for events that should reach all sessions for a user:
-    UPLOAD_SUCCESS, ASSET_UPLOAD_READY_V1, ASSET_DELETE, etc.
+    UPLOAD_SUCCESS, ASSET_UPLOAD_READY_V1, ASSET_DELETE, ASSET_TRASH,
+    ASSET_RESTORE, etc.
 
     Args:
         event: The event type (from WebSocketEvent enum)

--- a/services/websockets.py
+++ b/services/websockets.py
@@ -5,6 +5,7 @@ from typing import Any, TypeAlias
 
 import socketio
 from pydantic import BaseModel
+from socketio.exceptions import SocketIOError
 
 from config.settings import get_settings
 from routers.immich_models import SyncAssetExifV1, SyncAssetV1
@@ -222,6 +223,11 @@ async def emit_user_event(
     UPLOAD_SUCCESS, ASSET_UPLOAD_READY_V1, ASSET_DELETE, ASSET_TRASH,
     ASSET_RESTORE, etc.
 
+    Fire-and-forget: ``SocketIOError`` from the underlying transport is
+    caught and logged at WARN. Callers must not wrap this in try/except for
+    ``SocketIOError`` — emission failures should never break the request
+    they are paired with.
+
     Args:
         event: The event type (from WebSocketEvent enum)
         user_id: The Gumnut user ID
@@ -229,9 +235,19 @@ async def emit_user_event(
 
     Raises:
         pydantic.ValidationError: If payload is a Pydantic model that fails serialization
-        socketio.exceptions.SocketIOError: If the socket emission fails
     """
-    await _emit_event(event, user_id, payload)
+    try:
+        await _emit_event(event, user_id, payload)
+    except SocketIOError as ws_error:
+        logger.warning(
+            "Failed to emit WebSocket user event",
+            extra={
+                "event": event.value,
+                "user_id": user_id,
+                "error": str(ws_error),
+            },
+            exc_info=True,
+        )
 
 
 async def emit_session_event(
@@ -245,6 +261,11 @@ async def emit_session_event(
     Use this for events that should reach only one session:
     SESSION_DELETE, etc.
 
+    Fire-and-forget: ``SocketIOError`` from the underlying transport is
+    caught and logged at WARN. Callers must not wrap this in try/except for
+    ``SocketIOError`` — emission failures should never break the request
+    they are paired with.
+
     Args:
         event: The event type (from WebSocketEvent enum)
         session_id: The session ID (session token)
@@ -252,6 +273,16 @@ async def emit_session_event(
 
     Raises:
         pydantic.ValidationError: If payload is a Pydantic model that fails serialization
-        socketio.exceptions.SocketIOError: If the socket emission fails
     """
-    await _emit_event(event, session_id, payload)
+    try:
+        await _emit_event(event, session_id, payload)
+    except SocketIOError as ws_error:
+        logger.warning(
+            "Failed to emit WebSocket session event",
+            extra={
+                "event": event.value,
+                "session_id": session_id,
+                "error": str(ws_error),
+            },
+            exc_info=True,
+        )

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -1210,6 +1210,45 @@ class TestDeleteAssets:
         mock_client.post.assert_not_awaited()
         mock_client.delete.assert_not_awaited()
 
+    @pytest.mark.anyio
+    async def test_delete_assets_force_false_propagates_sdk_error(self):
+        """SDK errors on bulk-trash bubble to the global GumnutError handler.
+
+        Pins the no-swallow contract: a future refactor that wraps client.post
+        in try/except (e.g. to ignore per-id 404s the way the legacy per-id
+        loop did) must break this test.
+        """
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
+
+        mock_client = Mock()
+        mock_client.post = AsyncMock(side_effect=make_sdk_status_error(500, "boom"))
+
+        request = AssetBulkDeleteDto(ids=[uuid4()], force=False)
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            with pytest.raises(APIStatusError):
+                await delete_assets(
+                    request, client=mock_client, current_user_id=uuid4()
+                )
+
+    @pytest.mark.anyio
+    async def test_delete_assets_force_true_propagates_sdk_error(self):
+        """SDK errors on bulk hard-delete bubble to the global GumnutError handler."""
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
+
+        mock_client = Mock()
+        mock_client.delete = AsyncMock(side_effect=make_sdk_status_error(500, "boom"))
+
+        request = AssetBulkDeleteDto(ids=[uuid4()], force=True)
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            with pytest.raises(APIStatusError):
+                await delete_assets(
+                    request, client=mock_client, current_user_id=uuid4()
+                )
+
 
 class TestGetAllUserAssetsByDeviceId:
     """Test the get_all_user_assets_by_device_id endpoint."""

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -1181,8 +1181,10 @@ class TestDeleteAssets:
         request = AssetBulkDeleteDto(ids=[uuid4()], force=False)
         current_user_id = uuid4()
 
+        # Patch the underlying emit so the SocketIOError originates *inside*
+        # emit_user_event (which now swallows it centrally).
         with patch(
-            "routers.api.assets.emit_user_event",
+            "services.websockets._emit_event",
             new_callable=AsyncMock,
             side_effect=SocketIOError("WebSocket error"),
         ):

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -1146,6 +1146,33 @@ class TestDeleteAssets:
         assert mock_emit.await_count == 3
 
     @pytest.mark.anyio
+    async def test_delete_assets_force_true_chunks_and_emits_per_id(self):
+        """force=True over the cap chunks bulk DELETE and emits one event per id."""
+        mock_client = Mock()
+        mock_client.delete = AsyncMock(return_value=None)
+
+        asset_ids = [uuid4() for _ in range(250)]
+        request = AssetBulkDeleteDto(ids=asset_ids, force=True)
+        current_user_id = uuid4()
+
+        with patch(
+            "routers.api.assets.emit_user_event", new_callable=AsyncMock
+        ) as mock_emit:
+            result = await delete_assets(
+                request, client=mock_client, current_user_id=current_user_id
+            )
+
+        assert result.status_code == 204
+        assert mock_client.delete.await_count == 3
+        chunk_sizes = [
+            len(call.kwargs["body"]["ids"])
+            for call in mock_client.delete.await_args_list
+        ]
+        assert chunk_sizes == [100, 100, 50]
+        # 250 per-id on_asset_delete events across all chunks.
+        assert mock_emit.await_count == 250
+
+    @pytest.mark.anyio
     async def test_delete_assets_websocket_error_does_not_fail_deletion(self):
         """WebSocket emission errors must not fail the deletion."""
         mock_client = Mock()

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -998,67 +998,20 @@ class TestUpdateAssets:
 
 
 class TestDeleteAssets:
-    """Test the delete_assets endpoint."""
+    """Test the delete_assets endpoint.
+
+    The handler branches on ``force``: ``True`` → bulk hard-delete via
+    ``client.delete("/api/assets", body=...)`` with one ``on_asset_delete``
+    per id. ``False``/absent → bulk soft-delete via
+    ``client.post("/api/assets/trash", body=...)`` with one batched
+    ``on_asset_trash`` per chunk.
+    """
 
     @pytest.mark.anyio
-    async def test_delete_assets_success(self):
-        """Test successful assets deletion."""
-        # Setup - create mock client
+    async def test_delete_assets_force_false_calls_trash_endpoint(self):
+        """force=False routes to POST /api/assets/trash with the full id list."""
         mock_client = Mock()
-        mock_client.assets.delete = AsyncMock(return_value=None)
-
-        asset_ids = [uuid4(), uuid4()]
-        request = AssetBulkDeleteDto(ids=asset_ids, force=False)
-        current_user_id = uuid4()
-
-        # Execute
-        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
-            result = await delete_assets(
-                request, client=mock_client, current_user_id=current_user_id
-            )
-
-        # Assert
-        assert result.status_code == 204
-        assert mock_client.assets.delete.call_count == 2
-
-    @pytest.mark.anyio
-    async def test_delete_assets_partial_failure(self):
-        """Test deletion with some assets not found."""
-        from gumnut import NotFoundError
-        from tests.conftest import make_sdk_status_error
-
-        mock_client = Mock()
-
-        # First delete succeeds, second fails with NotFoundError (already gone).
-        mock_client.assets.delete = AsyncMock(
-            side_effect=[
-                None,
-                make_sdk_status_error(404, "Not found", cls=NotFoundError),
-            ]
-        )
-
-        asset_ids = [uuid4(), uuid4()]
-        request = AssetBulkDeleteDto(ids=asset_ids, force=False)
-        current_user_id = uuid4()
-
-        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
-            result = await delete_assets(
-                request, client=mock_client, current_user_id=current_user_id
-            )
-
-        # Per-item errors are logged and skipped; bulk endpoint still returns 204.
-        assert result.status_code == 204
-        assert mock_client.assets.delete.call_count == 2
-
-    @pytest.mark.anyio
-    async def test_delete_assets_non_404_does_not_abort_batch(self):
-        """A 5xx upstream error on one item must not abort the batch."""
-        from tests.conftest import make_sdk_status_error
-
-        mock_client = Mock()
-        mock_client.assets.delete = AsyncMock(
-            side_effect=[None, make_sdk_status_error(500, "boom")]
-        )
+        mock_client.post = AsyncMock(return_value=None)
 
         asset_ids = [uuid4(), uuid4()]
         request = AssetBulkDeleteDto(ids=asset_ids, force=False)
@@ -1070,20 +1023,21 @@ class TestDeleteAssets:
             )
 
         assert result.status_code == 204
-        assert mock_client.assets.delete.call_count == 2
+        mock_client.post.assert_awaited_once()
+        call = mock_client.post.await_args
+        assert call.args[0] == "/api/assets/trash"
+        body = call.kwargs["body"]
+        assert set(body["ids"]) == {uuid_to_gumnut_asset_id(uid) for uid in asset_ids}
 
     @pytest.mark.anyio
-    async def test_delete_assets_connection_error_does_not_abort_batch(self):
-        """A transport error on one item must not abort the batch."""
-        from tests.conftest import make_sdk_connection_error
-
+    async def test_delete_assets_force_absent_treated_as_soft_delete(self):
+        """force omitted (Immich's native default) routes to trash, not hard-delete."""
         mock_client = Mock()
-        mock_client.assets.delete = AsyncMock(
-            side_effect=[None, make_sdk_connection_error("DELETE")]
-        )
+        mock_client.post = AsyncMock(return_value=None)
+        mock_client.delete = AsyncMock(return_value=None)
 
-        asset_ids = [uuid4(), uuid4()]
-        request = AssetBulkDeleteDto(ids=asset_ids, force=False)
+        asset_ids = [uuid4()]
+        request = AssetBulkDeleteDto(ids=asset_ids)
         current_user_id = uuid4()
 
         with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
@@ -1092,20 +1046,41 @@ class TestDeleteAssets:
             )
 
         assert result.status_code == 204
-        assert mock_client.assets.delete.call_count == 2
+        mock_client.post.assert_awaited_once()
+        mock_client.delete.assert_not_awaited()
 
     @pytest.mark.anyio
-    async def test_delete_assets_emits_websocket_events(self):
-        """Test that delete_assets emits on_asset_delete for each deleted asset."""
-        # Setup - create mock client
+    async def test_delete_assets_force_true_calls_bulk_delete_endpoint(self):
+        """force=True routes to bulk DELETE /api/assets."""
         mock_client = Mock()
-        mock_client.assets.delete = AsyncMock(return_value=None)
+        mock_client.delete = AsyncMock(return_value=None)
+
+        asset_ids = [uuid4(), uuid4()]
+        request = AssetBulkDeleteDto(ids=asset_ids, force=True)
+        current_user_id = uuid4()
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            result = await delete_assets(
+                request, client=mock_client, current_user_id=current_user_id
+            )
+
+        assert result.status_code == 204
+        mock_client.delete.assert_awaited_once()
+        call = mock_client.delete.await_args
+        assert call.args[0] == "/api/assets"
+        body = call.kwargs["body"]
+        assert set(body["ids"]) == {uuid_to_gumnut_asset_id(uid) for uid in asset_ids}
+
+    @pytest.mark.anyio
+    async def test_delete_assets_force_false_emits_single_batched_trash_event(self):
+        """A single bulk soft-delete fires one on_asset_trash with the full id array."""
+        mock_client = Mock()
+        mock_client.post = AsyncMock(return_value=None)
 
         asset_ids = [uuid4(), uuid4(), uuid4()]
         request = AssetBulkDeleteDto(ids=asset_ids, force=False)
         current_user_id = uuid4()
 
-        # Execute
         with patch(
             "routers.api.assets.emit_user_event", new_callable=AsyncMock
         ) as mock_emit:
@@ -1113,27 +1088,72 @@ class TestDeleteAssets:
                 request, client=mock_client, current_user_id=current_user_id
             )
 
-            # Assert - emit_event should be called for each deleted asset
-            assert mock_emit.call_count == 3
-
-            # Verify each call has correct event type and user ID
-            for i, call in enumerate(mock_emit.call_args_list):
-                assert call[0][0] == WebSocketEvent.ASSET_DELETE
-                assert call[0][1] == str(current_user_id)
-                assert call[0][2] == str(asset_ids[i])
+        assert mock_emit.await_count == 1
+        event, user_id, payload = mock_emit.await_args_list[0].args
+        assert event == WebSocketEvent.ASSET_TRASH
+        assert user_id == str(current_user_id)
+        assert payload == [str(uid) for uid in asset_ids]
 
     @pytest.mark.anyio
-    async def test_delete_assets_websocket_error_does_not_fail_deletion(self):
-        """Test that WebSocket emission errors don't fail the deletion."""
-        # Setup - create mock client
+    async def test_delete_assets_force_true_emits_one_delete_event_per_id(self):
+        """A bulk hard-delete fires one on_asset_delete per id (single-id wire shape)."""
         mock_client = Mock()
-        mock_client.assets.delete = AsyncMock(return_value=None)
+        mock_client.delete = AsyncMock(return_value=None)
 
-        asset_ids = [uuid4()]
+        asset_ids = [uuid4(), uuid4(), uuid4()]
+        request = AssetBulkDeleteDto(ids=asset_ids, force=True)
+        current_user_id = uuid4()
+
+        with patch(
+            "routers.api.assets.emit_user_event", new_callable=AsyncMock
+        ) as mock_emit:
+            await delete_assets(
+                request, client=mock_client, current_user_id=current_user_id
+            )
+
+        assert mock_emit.await_count == 3
+        for i, call in enumerate(mock_emit.await_args_list):
+            event, user_id, payload = call.args
+            assert event == WebSocketEvent.ASSET_DELETE
+            assert user_id == str(current_user_id)
+            assert payload == str(asset_ids[i])
+
+    @pytest.mark.anyio
+    async def test_delete_assets_chunks_when_over_cap(self):
+        """Request larger than the per-call cap is split into chunks."""
+        mock_client = Mock()
+        mock_client.post = AsyncMock(return_value=None)
+
+        # 250 ids → 100 + 100 + 50 across three trash calls.
+        asset_ids = [uuid4() for _ in range(250)]
         request = AssetBulkDeleteDto(ids=asset_ids, force=False)
         current_user_id = uuid4()
 
-        # Execute with emit_event that raises a SocketIOError
+        with patch(
+            "routers.api.assets.emit_user_event", new_callable=AsyncMock
+        ) as mock_emit:
+            result = await delete_assets(
+                request, client=mock_client, current_user_id=current_user_id
+            )
+
+        assert result.status_code == 204
+        assert mock_client.post.await_count == 3
+        chunk_sizes = [
+            len(call.kwargs["body"]["ids"]) for call in mock_client.post.await_args_list
+        ]
+        assert chunk_sizes == [100, 100, 50]
+        # One batched on_asset_trash per chunk.
+        assert mock_emit.await_count == 3
+
+    @pytest.mark.anyio
+    async def test_delete_assets_websocket_error_does_not_fail_deletion(self):
+        """WebSocket emission errors must not fail the deletion."""
+        mock_client = Mock()
+        mock_client.post = AsyncMock(return_value=None)
+
+        request = AssetBulkDeleteDto(ids=[uuid4()], force=False)
+        current_user_id = uuid4()
+
         with patch(
             "routers.api.assets.emit_user_event",
             new_callable=AsyncMock,
@@ -1143,8 +1163,25 @@ class TestDeleteAssets:
                 request, client=mock_client, current_user_id=current_user_id
             )
 
-            # Deletion should still succeed despite WebSocket error
-            assert result.status_code == 204
+        assert result.status_code == 204
+
+    @pytest.mark.anyio
+    async def test_delete_assets_empty_id_list_is_noop(self):
+        """An empty ids list returns 204 without calling the backend."""
+        mock_client = Mock()
+        mock_client.post = AsyncMock(return_value=None)
+        mock_client.delete = AsyncMock(return_value=None)
+
+        request = AssetBulkDeleteDto(ids=[], force=False)
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            result = await delete_assets(
+                request, client=mock_client, current_user_id=uuid4()
+            )
+
+        assert result.status_code == 204
+        mock_client.post.assert_not_awaited()
+        mock_client.delete.assert_not_awaited()
 
 
 class TestGetAllUserAssetsByDeviceId:

--- a/tests/unit/api/test_auth.py
+++ b/tests/unit/api/test_auth.py
@@ -193,8 +193,10 @@ class TestPostLogout:
         mock_request.state.session_token = "test-session-token"
         mock_request.cookies = {}
 
+        # Patch the underlying emit so the SocketIOError originates *inside*
+        # emit_session_event (which now swallows it centrally).
         with patch(
-            "routers.api.auth.emit_session_event",
+            "services.websockets._emit_event",
             new_callable=AsyncMock,
             side_effect=SocketIOError("WebSocket error"),
         ):

--- a/tests/unit/api/test_sessions.py
+++ b/tests/unit/api/test_sessions.py
@@ -683,8 +683,10 @@ class TestDeleteSession:
         mock_session_store.get_by_id.return_value = session
         mock_session_store.delete_by_id.return_value = True
 
+        # Patch the underlying emit so the SocketIOError originates *inside*
+        # emit_session_event (which now swallows it centrally).
         with patch(
-            "routers.api.sessions.emit_session_event",
+            "services.websockets._emit_event",
             new_callable=AsyncMock,
             side_effect=SocketIOError("WebSocket error"),
         ):

--- a/tests/unit/api/test_trash.py
+++ b/tests/unit/api/test_trash.py
@@ -178,6 +178,25 @@ class TestRestoreTrash:
         assert set(payload) == {str(safe_uuid_from_asset_id(gid)) for gid in gumnut_ids}
 
     @pytest.mark.anyio
+    async def test_websocket_error_does_not_fail_restore_trash(self):
+        """SocketIOError from emit must not fail the restore-all flow."""
+        mock_client = Mock()
+        mock_client.post = AsyncMock(return_value=None)
+
+        gumnut_ids = [uuid_to_gumnut_asset_id(uuid4()) for _ in range(2)]
+        trashed_assets = [_make_trashed_asset_mock(gid) for gid in gumnut_ids]
+        mock_client.assets.list = Mock(return_value=MockSyncCursorPage(trashed_assets))
+
+        with patch(
+            "routers.api.trash.emit_user_event",
+            new_callable=AsyncMock,
+            side_effect=SocketIOError("ws error"),
+        ):
+            result = await restore_trash(client=mock_client, current_user_id=uuid4())
+
+        assert result.count == 2
+
+    @pytest.mark.anyio
     async def test_chunks_large_trash_lists(self):
         mock_client = Mock()
         mock_client.post = AsyncMock(return_value=None)
@@ -267,3 +286,22 @@ class TestEmptyTrash:
             for call in mock_client.delete.await_args_list
         ]
         assert chunk_sizes == [100, 50]
+
+    @pytest.mark.anyio
+    async def test_websocket_error_does_not_fail_empty_trash(self):
+        """SocketIOError from emit must not fail the empty-trash flow."""
+        mock_client = Mock()
+        mock_client.delete = AsyncMock(return_value=None)
+
+        gumnut_ids = [uuid_to_gumnut_asset_id(uuid4()) for _ in range(2)]
+        trashed_assets = [_make_trashed_asset_mock(gid) for gid in gumnut_ids]
+        mock_client.assets.list = Mock(return_value=MockSyncCursorPage(trashed_assets))
+
+        with patch(
+            "routers.api.trash.emit_user_event",
+            new_callable=AsyncMock,
+            side_effect=SocketIOError("ws error"),
+        ):
+            result = await empty_trash(client=mock_client, current_user_id=uuid4())
+
+        assert result.count == 2

--- a/tests/unit/api/test_trash.py
+++ b/tests/unit/api/test_trash.py
@@ -119,8 +119,10 @@ class TestRestoreAssets:
 
         request = BulkIdsDto(ids=[uuid4()])
 
+        # Patch the underlying emit so the SocketIOError originates *inside*
+        # emit_user_event (which now swallows it centrally).
         with patch(
-            "routers.api.trash.emit_user_event",
+            "services.websockets._emit_event",
             new_callable=AsyncMock,
             side_effect=SocketIOError("ws error"),
         ):
@@ -209,7 +211,7 @@ class TestRestoreTrash:
         mock_client.assets.list = Mock(return_value=MockSyncCursorPage(trashed_assets))
 
         with patch(
-            "routers.api.trash.emit_user_event",
+            "services.websockets._emit_event",
             new_callable=AsyncMock,
             side_effect=SocketIOError("ws error"),
         ):
@@ -337,7 +339,7 @@ class TestEmptyTrash:
         mock_client.assets.list = Mock(return_value=MockSyncCursorPage(trashed_assets))
 
         with patch(
-            "routers.api.trash.emit_user_event",
+            "services.websockets._emit_event",
             new_callable=AsyncMock,
             side_effect=SocketIOError("ws error"),
         ):

--- a/tests/unit/api/test_trash.py
+++ b/tests/unit/api/test_trash.py
@@ -130,6 +130,27 @@ class TestRestoreAssets:
 
         assert result.count == 1
 
+    @pytest.mark.anyio
+    async def test_propagates_sdk_error(self):
+        """SDK errors on bulk restore bubble to the global GumnutError handler.
+
+        Pins the no-swallow contract — a future refactor that wraps the bulk
+        call in try/except must break this test.
+        """
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
+
+        mock_client = Mock()
+        mock_client.post = AsyncMock(side_effect=make_sdk_status_error(500, "boom"))
+
+        request = BulkIdsDto(ids=[uuid4()])
+
+        with patch("routers.api.trash.emit_user_event", new_callable=AsyncMock):
+            with pytest.raises(APIStatusError):
+                await restore_assets(
+                    request, client=mock_client, current_user_id=uuid4()
+                )
+
 
 class TestRestoreTrash:
     """POST /api/trash/restore — restore every trashed asset for the caller."""
@@ -219,6 +240,23 @@ class TestRestoreTrash:
         assert chunk_sizes == [100, 100, 50]
         assert mock_emit.await_count == 3
 
+    @pytest.mark.anyio
+    async def test_propagates_sdk_error(self):
+        """SDK errors on bulk restore bubble to the global GumnutError handler."""
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
+
+        mock_client = Mock()
+        mock_client.post = AsyncMock(side_effect=make_sdk_status_error(500, "boom"))
+
+        gumnut_ids = [uuid_to_gumnut_asset_id(uuid4())]
+        trashed_assets = [_make_trashed_asset_mock(gid) for gid in gumnut_ids]
+        mock_client.assets.list = Mock(return_value=MockSyncCursorPage(trashed_assets))
+
+        with patch("routers.api.trash.emit_user_event", new_callable=AsyncMock):
+            with pytest.raises(APIStatusError):
+                await restore_trash(client=mock_client, current_user_id=uuid4())
+
 
 class TestEmptyTrash:
     """POST /api/trash/empty — permanently delete every trashed asset."""
@@ -272,20 +310,21 @@ class TestEmptyTrash:
         mock_client = Mock()
         mock_client.delete = AsyncMock(return_value=None)
 
-        gumnut_ids = [uuid_to_gumnut_asset_id(uuid4()) for _ in range(150)]
+        # 250 trashed assets → 100 + 100 + 50 across three delete calls.
+        gumnut_ids = [uuid_to_gumnut_asset_id(uuid4()) for _ in range(250)]
         trashed_assets = [_make_trashed_asset_mock(gid) for gid in gumnut_ids]
         mock_client.assets.list = Mock(return_value=MockSyncCursorPage(trashed_assets))
 
         with patch("routers.api.trash.emit_user_event", new_callable=AsyncMock):
             result = await empty_trash(client=mock_client, current_user_id=uuid4())
 
-        assert result.count == 150
-        assert mock_client.delete.await_count == 2
+        assert result.count == 250
+        assert mock_client.delete.await_count == 3
         chunk_sizes = [
             len(call.kwargs["body"]["ids"])
             for call in mock_client.delete.await_args_list
         ]
-        assert chunk_sizes == [100, 50]
+        assert chunk_sizes == [100, 100, 50]
 
     @pytest.mark.anyio
     async def test_websocket_error_does_not_fail_empty_trash(self):
@@ -305,3 +344,20 @@ class TestEmptyTrash:
             result = await empty_trash(client=mock_client, current_user_id=uuid4())
 
         assert result.count == 2
+
+    @pytest.mark.anyio
+    async def test_propagates_sdk_error(self):
+        """SDK errors on bulk hard-delete bubble to the global GumnutError handler."""
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
+
+        mock_client = Mock()
+        mock_client.delete = AsyncMock(side_effect=make_sdk_status_error(500, "boom"))
+
+        gumnut_ids = [uuid_to_gumnut_asset_id(uuid4())]
+        trashed_assets = [_make_trashed_asset_mock(gid) for gid in gumnut_ids]
+        mock_client.assets.list = Mock(return_value=MockSyncCursorPage(trashed_assets))
+
+        with patch("routers.api.trash.emit_user_event", new_callable=AsyncMock):
+            with pytest.raises(APIStatusError):
+                await empty_trash(client=mock_client, current_user_id=uuid4())

--- a/tests/unit/api/test_trash.py
+++ b/tests/unit/api/test_trash.py
@@ -1,0 +1,269 @@
+"""Tests for the trash router (restore-by-ids, restore-all, empty-trash).
+
+The router calls the photos-api trash primitives directly through the
+``AsyncGumnut`` client (``client.post``, ``client.delete``,
+``client.assets.list(state="trashed")``). Tests mock those entry points and
+assert on the bulk call shapes, WebSocket event shapes, and returned counts.
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+from socketio.exceptions import SocketIOError
+
+from routers.api.trash import empty_trash, restore_assets, restore_trash
+from routers.immich_models import BulkIdsDto
+from routers.utils.gumnut_id_conversion import (
+    safe_uuid_from_asset_id,
+    uuid_to_gumnut_asset_id,
+)
+from services.websockets import WebSocketEvent
+from tests.conftest import MockSyncCursorPage
+
+
+def _make_trashed_asset_mock(gumnut_id: str) -> Mock:
+    """Minimal mock of the SDK's AssetResponse for state='trashed' enumeration."""
+    asset = Mock()
+    asset.id = gumnut_id
+    return asset
+
+
+class TestRestoreAssets:
+    """POST /api/trash/restore/assets — restore by explicit ids."""
+
+    @pytest.mark.anyio
+    async def test_empty_id_list_returns_zero_without_calling_backend(self):
+        mock_client = Mock()
+        mock_client.post = AsyncMock(return_value=None)
+
+        with patch("routers.api.trash.emit_user_event", new_callable=AsyncMock):
+            result = await restore_assets(
+                BulkIdsDto(ids=[]), client=mock_client, current_user_id=uuid4()
+            )
+
+        assert result.count == 0
+        mock_client.post.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_calls_backend_restore_with_gumnut_ids(self):
+        mock_client = Mock()
+        mock_client.post = AsyncMock(return_value=None)
+
+        asset_ids = [uuid4(), uuid4()]
+        request = BulkIdsDto(ids=asset_ids)
+
+        with patch("routers.api.trash.emit_user_event", new_callable=AsyncMock):
+            result = await restore_assets(
+                request, client=mock_client, current_user_id=uuid4()
+            )
+
+        assert result.count == 2
+        mock_client.post.assert_awaited_once()
+        call = mock_client.post.await_args
+        assert call.args[0] == "/api/assets/restore"
+        body = call.kwargs["body"]
+        assert set(body["ids"]) == {uuid_to_gumnut_asset_id(uid) for uid in asset_ids}
+
+    @pytest.mark.anyio
+    async def test_emits_single_batched_restore_event_per_chunk(self):
+        mock_client = Mock()
+        mock_client.post = AsyncMock(return_value=None)
+
+        asset_ids = [uuid4(), uuid4(), uuid4()]
+        request = BulkIdsDto(ids=asset_ids)
+        current_user_id = uuid4()
+
+        with patch(
+            "routers.api.trash.emit_user_event", new_callable=AsyncMock
+        ) as mock_emit:
+            await restore_assets(
+                request, client=mock_client, current_user_id=current_user_id
+            )
+
+        assert mock_emit.await_count == 1
+        event, user_id, payload = mock_emit.await_args_list[0].args
+        assert event == WebSocketEvent.ASSET_RESTORE
+        assert user_id == str(current_user_id)
+        assert payload == [str(uid) for uid in asset_ids]
+
+    @pytest.mark.anyio
+    async def test_chunks_when_over_cap(self):
+        mock_client = Mock()
+        mock_client.post = AsyncMock(return_value=None)
+
+        # 150 ids → 100 + 50.
+        asset_ids = [uuid4() for _ in range(150)]
+        request = BulkIdsDto(ids=asset_ids)
+
+        with patch(
+            "routers.api.trash.emit_user_event", new_callable=AsyncMock
+        ) as mock_emit:
+            result = await restore_assets(
+                request, client=mock_client, current_user_id=uuid4()
+            )
+
+        assert result.count == 150
+        assert mock_client.post.await_count == 2
+        chunk_sizes = [
+            len(call.kwargs["body"]["ids"]) for call in mock_client.post.await_args_list
+        ]
+        assert chunk_sizes == [100, 50]
+        # One batched on_asset_restore event per chunk.
+        assert mock_emit.await_count == 2
+
+    @pytest.mark.anyio
+    async def test_websocket_error_does_not_fail_restore(self):
+        mock_client = Mock()
+        mock_client.post = AsyncMock(return_value=None)
+
+        request = BulkIdsDto(ids=[uuid4()])
+
+        with patch(
+            "routers.api.trash.emit_user_event",
+            new_callable=AsyncMock,
+            side_effect=SocketIOError("ws error"),
+        ):
+            result = await restore_assets(
+                request, client=mock_client, current_user_id=uuid4()
+            )
+
+        assert result.count == 1
+
+
+class TestRestoreTrash:
+    """POST /api/trash/restore — restore every trashed asset for the caller."""
+
+    @pytest.mark.anyio
+    async def test_no_trashed_assets_returns_zero(self):
+        mock_client = Mock()
+        mock_client.post = AsyncMock(return_value=None)
+        mock_client.assets.list = Mock(return_value=MockSyncCursorPage([]))
+
+        with patch("routers.api.trash.emit_user_event", new_callable=AsyncMock):
+            result = await restore_trash(client=mock_client, current_user_id=uuid4())
+
+        assert result.count == 0
+        mock_client.post.assert_not_awaited()
+        mock_client.assets.list.assert_called_once_with(state="trashed", limit=100)
+
+    @pytest.mark.anyio
+    async def test_restores_enumerated_ids_and_emits_per_chunk_event(self):
+        mock_client = Mock()
+        mock_client.post = AsyncMock(return_value=None)
+
+        gumnut_ids = [uuid_to_gumnut_asset_id(uuid4()) for _ in range(3)]
+        trashed_assets = [_make_trashed_asset_mock(gid) for gid in gumnut_ids]
+        mock_client.assets.list = Mock(return_value=MockSyncCursorPage(trashed_assets))
+
+        current_user_id = uuid4()
+        with patch(
+            "routers.api.trash.emit_user_event", new_callable=AsyncMock
+        ) as mock_emit:
+            result = await restore_trash(
+                client=mock_client, current_user_id=current_user_id
+            )
+
+        assert result.count == 3
+        mock_client.post.assert_awaited_once()
+        call = mock_client.post.await_args
+        assert call.args[0] == "/api/assets/restore"
+        assert set(call.kwargs["body"]["ids"]) == set(gumnut_ids)
+
+        # One batched on_asset_restore event with the chunk's UUID strings.
+        assert mock_emit.await_count == 1
+        event, user_id, payload = mock_emit.await_args_list[0].args
+        assert event == WebSocketEvent.ASSET_RESTORE
+        assert user_id == str(current_user_id)
+        assert set(payload) == {str(safe_uuid_from_asset_id(gid)) for gid in gumnut_ids}
+
+    @pytest.mark.anyio
+    async def test_chunks_large_trash_lists(self):
+        mock_client = Mock()
+        mock_client.post = AsyncMock(return_value=None)
+
+        # 250 trashed assets → 100 + 100 + 50 across three restore calls.
+        gumnut_ids = [uuid_to_gumnut_asset_id(uuid4()) for _ in range(250)]
+        trashed_assets = [_make_trashed_asset_mock(gid) for gid in gumnut_ids]
+        mock_client.assets.list = Mock(return_value=MockSyncCursorPage(trashed_assets))
+
+        with patch(
+            "routers.api.trash.emit_user_event", new_callable=AsyncMock
+        ) as mock_emit:
+            result = await restore_trash(client=mock_client, current_user_id=uuid4())
+
+        assert result.count == 250
+        assert mock_client.post.await_count == 3
+        chunk_sizes = [
+            len(call.kwargs["body"]["ids"]) for call in mock_client.post.await_args_list
+        ]
+        assert chunk_sizes == [100, 100, 50]
+        assert mock_emit.await_count == 3
+
+
+class TestEmptyTrash:
+    """POST /api/trash/empty — permanently delete every trashed asset."""
+
+    @pytest.mark.anyio
+    async def test_no_trashed_assets_returns_zero(self):
+        mock_client = Mock()
+        mock_client.delete = AsyncMock(return_value=None)
+        mock_client.assets.list = Mock(return_value=MockSyncCursorPage([]))
+
+        with patch("routers.api.trash.emit_user_event", new_callable=AsyncMock):
+            result = await empty_trash(client=mock_client, current_user_id=uuid4())
+
+        assert result.count == 0
+        mock_client.delete.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_purges_enumerated_ids_and_emits_per_id_delete_event(self):
+        mock_client = Mock()
+        mock_client.delete = AsyncMock(return_value=None)
+
+        gumnut_ids = [uuid_to_gumnut_asset_id(uuid4()) for _ in range(3)]
+        trashed_assets = [_make_trashed_asset_mock(gid) for gid in gumnut_ids]
+        mock_client.assets.list = Mock(return_value=MockSyncCursorPage(trashed_assets))
+
+        current_user_id = uuid4()
+        with patch(
+            "routers.api.trash.emit_user_event", new_callable=AsyncMock
+        ) as mock_emit:
+            result = await empty_trash(
+                client=mock_client, current_user_id=current_user_id
+            )
+
+        assert result.count == 3
+        mock_client.delete.assert_awaited_once()
+        call = mock_client.delete.await_args
+        assert call.args[0] == "/api/assets"
+        assert set(call.kwargs["body"]["ids"]) == set(gumnut_ids)
+
+        # One on_asset_delete per id (Immich's wire shape for permanent deletes).
+        assert mock_emit.await_count == 3
+        for emit_call in mock_emit.await_args_list:
+            event, user_id, payload = emit_call.args
+            assert event == WebSocketEvent.ASSET_DELETE
+            assert user_id == str(current_user_id)
+            # payload is a single asset UUID string
+            assert payload in {str(safe_uuid_from_asset_id(gid)) for gid in gumnut_ids}
+
+    @pytest.mark.anyio
+    async def test_chunks_large_trash_lists(self):
+        mock_client = Mock()
+        mock_client.delete = AsyncMock(return_value=None)
+
+        gumnut_ids = [uuid_to_gumnut_asset_id(uuid4()) for _ in range(150)]
+        trashed_assets = [_make_trashed_asset_mock(gid) for gid in gumnut_ids]
+        mock_client.assets.list = Mock(return_value=MockSyncCursorPage(trashed_assets))
+
+        with patch("routers.api.trash.emit_user_event", new_callable=AsyncMock):
+            result = await empty_trash(client=mock_client, current_user_id=uuid4())
+
+        assert result.count == 150
+        assert mock_client.delete.await_count == 2
+        chunk_sizes = [
+            len(call.kwargs["body"]["ids"])
+            for call in mock_client.delete.await_args_list
+        ]
+        assert chunk_sizes == [100, 50]

--- a/tests/unit/api/test_websockets.py
+++ b/tests/unit/api/test_websockets.py
@@ -453,6 +453,28 @@ class TestEmitUserEvent:
         await emit_user_event(WebSocketEvent.ASSET_UPLOAD_READY_V1, "user_123", "data")
         assert mock_sio_emit.call_args[0][0] == "AssetUploadReadyV1"
 
+    @pytest.mark.anyio
+    async def test_swallows_socketio_error(self, caplog):
+        """SocketIOError is logged at WARN and never propagated to callers.
+
+        Pins the fire-and-forget contract for the centralized handler so
+        callers don't reintroduce per-site try/except blocks.
+        """
+        from socketio.exceptions import SocketIOError
+
+        with patch.object(
+            sio, "emit", new_callable=AsyncMock, side_effect=SocketIOError("boom")
+        ):
+            with caplog.at_level("WARNING", logger="services.websockets"):
+                # Must not raise.
+                await emit_user_event(
+                    WebSocketEvent.ASSET_DELETE, "user_123", "asset-id"
+                )
+
+        assert any(
+            "Failed to emit WebSocket user event" in r.message for r in caplog.records
+        )
+
 
 class TestEmitSessionEvent:
     """Unit tests for emit_session_event()."""
@@ -496,6 +518,25 @@ class TestEmitSessionEvent:
             "on_session_delete",
             None,
             room="session_123",
+        )
+
+    @pytest.mark.anyio
+    async def test_swallows_socketio_error(self, caplog):
+        """SocketIOError is logged at WARN and never propagated to callers."""
+        from socketio.exceptions import SocketIOError
+
+        with patch.object(
+            sio, "emit", new_callable=AsyncMock, side_effect=SocketIOError("boom")
+        ):
+            with caplog.at_level("WARNING", logger="services.websockets"):
+                # Must not raise.
+                await emit_session_event(
+                    WebSocketEvent.SESSION_DELETE, "session_123", None
+                )
+
+        assert any(
+            "Failed to emit WebSocket session event" in r.message
+            for r in caplog.records
         )
 
 


### PR DESCRIPTION
## Summary

- `DELETE /api/assets` now honors `force`: `force=True` permanent-deletes via the backend's bulk `DELETE /api/assets`; `force=False` (or absent — Immich's native default) soft-deletes via `POST /api/assets/trash`. Replaces the per-id loop that silently ignored `force`.
- `routers/api/trash.py` rewritten end-to-end: `/restore/assets` bulk-restores by ids; `/restore` enumerates `state="trashed"` and chunked-restores all of the caller's trashed assets; `/empty` enumerates and chunked bulk-deletes. All three return real counts.
- `WebSocketEvent` gains `ASSET_TRASH = "on_asset_trash"` and `ASSET_RESTORE = "on_asset_restore"` to match Immich's wire contract — single batched event per chunk for soft transitions, per-id `on_asset_delete` for permanent deletes.

## Linear

https://linear.app/gumnut-ai/issue/GUM-635/trash-pr-b-adapter-delete-honors-force-trash-router-websocket-events

## Implementation notes

- Backend bulk endpoints (`POST /api/assets/{trash,restore}`, bulk `DELETE /api/assets`) accept `{"ids": [...]}` body and are capped at `MAX_BULK_GET_IDS = 100`. Adapter chunks via `itertools.batched(..., BULK_CHUNK_SIZE)` with `BULK_CHUNK_SIZE = 100` hoisted to `routers/utils/gumnut_client.py` for reuse.
- The Gumnut SDK does not yet expose typed methods for these endpoints, so calls go through the public raw HTTP layer (`AsyncGumnut.post()` / `.delete()` with `cast_to=type(None)`). This routes through the same JWT auth, retry, and response-hook plumbing as typed SDK methods. New code-practices doc section captures the pattern for future endpoints landing before SDK regen.
- Backend bulk endpoints are idempotent on already-transitioned rows, so the previous per-id 404 swallowing is intentionally removed; failures propagate via the global `GumnutError` handler.
- `/api/trash/empty` enumerates and chunked-deletes (rather than calling `POST /api/assets/empty-trash` once) to satisfy the design doc's "WebSocket events fire on every transition" requirement and to return an accurate count without a separate `counts` round-trip.
- The `server_features.trash` flag stays `False` in this PR — the trash page can't render until PR C (GUM-636) fixes the `GET /api/timeline/buckets?isTrashed=true` short-circuit. Flag flip will ship with PR C.

## Test plan

- [x] Unit tests pass: `uv run pytest` (747 passing)
- [x] Type check clean: `uv run pyright` on PR files (0 errors)
- [x] Lint/format clean: `uv run ruff check && uv run ruff format`
- [x] **Test 1 — `force=false` soft-delete (browser, `server_features.trash` temporarily flipped to True locally)**: selected assets in Immich web UI → clicked Delete → toast shown, assets removed from timeline. Adapter logs: single `POST /api/assets/trash → 204` (not per-id) and `emitting event "on_asset_trash"` to user room.
- [x] **Test 2 — restore by ids (curl)**: `DELETE /api/assets force=false` (2 ids) → `POST /api/trash/restore/assets` → `count=2`; both assets verified `isTrashed=false`, `deletedAt=null`.
- [x] **Test 3 — restore-all (curl)**: `POST /api/trash/restore` → `count=2`; backend `POST /api/assets/restore` and `on_asset_restore` event emitted.
- [x] **Test 4 — `force=true` permanent delete (curl)**: `DELETE /api/assets force=true` (1 id) → 204; subsequent `GET /api/assets/<id>` → 404 (asset purged, no trash hop).
- [x] **Test 5 — empty trash (curl)**: trashed 2 ids → `POST /api/trash/empty` → `count=2`; both ids → 404. Backend received bulk `DELETE /api/assets` after enumeration.
- [ ] Manual (deferred to PR C): trash page renders trashed assets with Restore affordance once `GET /api/timeline/buckets?isTrashed=true` is wired.
- [ ] Manual (deferred): Immich mobile delete lands asset in app's local trash collection via the sync-stream `SyncAssetV1` upsert (PR A's `deletedAt` plumbing).
- [ ] Manual (deferred, optional): WebSocket frame inspection in Firefox devtools confirming `on_asset_trash: [string[]]` payload shape vs `on_asset_delete: [string]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)