### PR TITLE
Fix reversed path/body semantics in PUT /faces/{id} (GUM-679)

### DIFF
--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -100,6 +100,10 @@ Forgetting step 2 causes silent drift — the served web UI stays on the old Imm
 5. **Validate compatibility**: Run `validate_api_compatibility.py` to ensure correct implementation
 6. **Test endpoints**: Verify responses match Immich API expectations
 
+### Fixing Class-of-Bug Issues
+
+When a bug rooted in a recurring trap is found in one endpoint (e.g., a path/body semantic mismatch, an ID-prefix decoding mistake, or a missing source/target distinction), **audit sibling endpoints in the same router and adjacent routers for the same pattern** before closing the fix. Both reassign endpoints in the gotcha above shipped with the same swap on the same day in different PRs; fixing one without auditing the other left a production bug latent for weeks. A one-line search (`grep -rn` for the pattern, or read each handler in the affected router) is cheap insurance against the trap recurring.
+
 ### Exception Handling
 
 - Don't expose implementation details in exceptions thrown to consumers

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -97,12 +97,9 @@ Forgetting step 2 causes silent drift — the served web UI stays on the old Imm
 4. **Verify parameter semantics**: Check the Immich OpenAPI spec (`https://api.immich.app/endpoints/`) or source code (`immich/server/src/controllers/*.controller.ts` and the matching service) to confirm what each URL path and body parameter represents. URL `{id}` parameters don't always refer to the entity in the URL collection — face/person reassign endpoints in particular swap the natural reading. Both of these accept the **target person** as `{id}` in the path:
    - `PUT /people/{id}/reassign` — `{id}` is the target person (reassign TO); body items are sources.
    - `PUT /faces/{id}` — `{id}` is the target person (reassign TO); body `FaceDto.id` is the face being reassigned.
+   - When fixing a path/body or ID-decoding bug in one handler, audit sibling handlers in the same router (and adjacent routers) for the same trap before closing the fix. A one-line search (`grep -rn` for the pattern) is cheap insurance against the same class-of-bug recurring.
 5. **Validate compatibility**: Run `validate_api_compatibility.py` to ensure correct implementation
 6. **Test endpoints**: Verify responses match Immich API expectations
-
-### Fixing Class-of-Bug Issues
-
-When a bug rooted in a recurring trap is found in one endpoint (e.g., a path/body semantic mismatch, an ID-prefix decoding mistake, or a missing source/target distinction), **audit sibling endpoints in the same router and adjacent routers for the same pattern** before closing the fix. Both reassign endpoints in the gotcha above shipped with the same swap on the same day in different PRs; fixing one without auditing the other left a production bug latent for weeks. A one-line search (`grep -rn` for the pattern, or read each handler in the affected router) is cheap insurance against the trap recurring.
 
 ### Exception Handling
 

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -94,7 +94,9 @@ Forgetting step 2 causes silent drift — the served web UI stays on the old Imm
 1. **Generate models**: Use `generate_immich_models.py` to create up-to-date Pydantic models (see [development tools](development-tools.md))
 2. **Import models**: Use generated models from `routers.immich_models` for type safety
 3. **Define parameters**: Follow the parameter conventions above
-4. **Verify parameter semantics**: Check the Immich OpenAPI spec (`https://api.immich.app/endpoints/`) or source code to confirm what each URL path and body parameter represents. URL `{id}` parameters don't always refer to the entity being queried — e.g., in `PUT /people/{id}/reassign`, `{id}` is the target person (reassign TO), not the source.
+4. **Verify parameter semantics**: Check the Immich OpenAPI spec (`https://api.immich.app/endpoints/`) or source code (`immich/server/src/controllers/*.controller.ts` and the matching service) to confirm what each URL path and body parameter represents. URL `{id}` parameters don't always refer to the entity in the URL collection — face/person reassign endpoints in particular swap the natural reading. Both of these accept the **target person** as `{id}` in the path:
+   - `PUT /people/{id}/reassign` — `{id}` is the target person (reassign TO); body items are sources.
+   - `PUT /faces/{id}` — `{id}` is the target person (reassign TO); body `FaceDto.id` is the face being reassigned.
 5. **Validate compatibility**: Run `validate_api_compatibility.py` to ensure correct implementation
 6. **Test endpoints**: Verify responses match Immich API expectations
 

--- a/routers/api/faces.py
+++ b/routers/api/faces.py
@@ -49,9 +49,14 @@ async def reassign_faces_by_id(
     request: FaceDto,
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
 ):
-    """Reassigns a face to a different person."""
-    gumnut_face_id = uuid_to_gumnut_face_id(id)
-    gumnut_person_id = uuid_to_gumnut_person_id(request.id)
+    """Re-assign the face provided in the body to the person identified by the id in the path parameter.
+
+    Despite the URL collection being /faces, Immich's contract is: path `{id}`
+    is the target person, body `id` is the face being reassigned. Verified
+    against Immich's face.controller.ts and person.service.reassignFacesById.
+    """
+    gumnut_person_id = uuid_to_gumnut_person_id(id)
+    gumnut_face_id = uuid_to_gumnut_face_id(request.id)
     await client.faces.update(gumnut_face_id, person_id=gumnut_person_id)
     gumnut_person = await client.people.retrieve(gumnut_person_id)
     return convert_gumnut_person_to_immich(gumnut_person)

--- a/tests/unit/api/test_faces.py
+++ b/tests/unit/api/test_faces.py
@@ -262,7 +262,12 @@ class TestDeleteFace:
 
 
 class TestReassignFace:
-    """Test the reassign_faces_by_id endpoint."""
+    """Test the reassign_faces_by_id endpoint.
+
+    Immich's PUT /faces/{id} contract is non-obvious: the URL `{id}` is the
+    target person (reassign TO) and the body `id` is the face being reassigned.
+    See routers/api/faces.py for the citation; these tests lock in that shape.
+    """
 
     @pytest.mark.anyio
     async def test_reassigns_face_to_person(self):
@@ -278,9 +283,9 @@ class TestReassignFace:
         mock_client.faces.update = AsyncMock()
         mock_client.people.retrieve = AsyncMock(return_value=person)
 
-        request = FaceDto(id=person_uuid)
+        request = FaceDto(id=face_uuid)
         result = await reassign_faces_by_id(
-            id=face_uuid, request=request, client=mock_client
+            id=person_uuid, request=request, client=mock_client
         )
 
         mock_client.faces.update.assert_called_once_with(
@@ -304,8 +309,8 @@ class TestReassignFace:
             side_effect=make_sdk_status_error(500, "boom")
         )
 
-        request = FaceDto(id=person_uuid)
+        request = FaceDto(id=face_uuid)
         with pytest.raises(APIStatusError):
             await reassign_faces_by_id(
-                id=face_uuid, request=request, client=mock_client
+                id=person_uuid, request=request, client=mock_client
             )


### PR DESCRIPTION
## Summary

- **Bug fix**: `PUT /api/faces/{id}` had path and body decoded in inverted directions vs. Immich's actual contract. Per Immich's `face.controller.ts` and `person.service.ts:111` (`reassignFacesById(auth, personId, dto)`), `{id}` is the **target person** and `FaceDto.id` is the face being reassigned. The adapter was treating `{id}` as a face id and `request.id` as a person id, so every PUT from Immich web returned 404 (`"Face '...' not found in library"`).
- **Test fix**: `tests/unit/api/test_faces.py` baked in the same swap, so the existing test passed while the production behavior was wrong. Tests now lock in the correct shape; a class-level docstring documents the surprising semantics.
- **Doc sharpening**: The gotcha at `code-practices.md:97` was added in PR #124 (GUM-505) when the same swap was fixed in `PUT /people/{id}/reassign` — but it only listed the people endpoint as the example. The faces-side bug was introduced earlier the same day in PR #123 and survived. Now both reassign endpoints are listed by name.
- **Process learning**: Added an "audit siblings when fixing class-of-bug issues" step to the same doc, so future fixes for class-of-bug traps don't leave latent bugs in adjacent endpoints.

## Sibling-endpoint audit

To make sure no other adapter endpoint has the same path/body swap, I audited every `@router.{method}("/{id}")`-style handler in `routers/api/` against Immich's controllers and services. Verdict: **`PUT /faces/{id}` was the only remaining case** — no other adapter endpoint inverts path/body semantics relative to Immich's contract.

Confirmed clean:

| File | Endpoints checked | Result |
|------|------------------|--------|
| `faces.py` | `DELETE /faces/{id}`, `GET /faces` | OK — `{id}` is the face id, matches Immich |
| `people.py` | `PUT /people/{id}/reassign`, person CRUD endpoints | OK — already fixed in PR #124 |
| `albums.py` | `PUT/DELETE /albums/{id}/assets`, `PATCH /albums/{id}` | OK — `{id}` is the album, body items reference assets |
| `assets.py` | asset-by-id endpoints | OK |
| `tags.py`, `partners.py`, `memories.py`, `stacks.py`, `shared_links.py` | id-in-path handlers | OK — path id consistently matches the URL collection |

## Linear

https://linear.app/gumnut-ai/issue/GUM-679/failed-to-assign-face-from-brigi-to-pamela

## Test plan

- [x] `uv run ruff format && uv run ruff check` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest` — 731 passed (including the reshaped face reassign tests)
- [ ] Manual smoke test from Immich web: navigate to a person's photo, reassign one of the faces to a different person; confirm the request returns 200 and the face moves to the target person.

## Notes for reviewer

The Immich endpoint name and URL are misleading — `PUT /faces/{id}` looks like it should modify the face named in the path. It does not. Both reassign-style endpoints in Immich (`PUT /people/{id}/reassign` and `PUT /faces/{id}`) accept the **target person** in the path. The fixed docstring quotes Immich's own description verbatim and cites the upstream source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)