### PR TITLE
Trash PR C: timeline + statistics isTrashed pass-through, flip flag

### DIFF
--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -685,7 +685,9 @@ async def get_asset_statistics(
     Counts total assets and categorizes them by type (images vs videos) using mime_type.
     """
 
-    gumnut_assets = client.assets.list()
+    gumnut_assets = (
+        client.assets.list(state="trashed") if isTrashed else client.assets.list()
+    )
 
     total_assets = 0
     image_count = 0

--- a/routers/api/server.py
+++ b/routers/api/server.py
@@ -43,8 +43,7 @@ server_features = {
     # Sidecar (.xmp) files are not processed.
     "sidecar": False,
     "search": True,
-    # Trash endpoints are stubs; delete goes straight through.
-    "trash": False,
+    "trash": True,
     "oauth": True,
     # Auto-redirect to OAuth provider on login page instead of showing login form
     "oauthAutoLaunch": True,

--- a/routers/api/timeline.py
+++ b/routers/api/timeline.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, List
+from typing import Any, List, Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
@@ -34,6 +34,7 @@ async def fetch_asset_counts(
     *,
     album_id: str | None = None,
     person_id: str | None = None,
+    state: Literal["live", "trashed", "all"] | None = None,
 ) -> list[Data]:
     """Fetch all monthly asset counts from photos-api, paginating if needed."""
     kwargs: dict[str, Any] = {"group_by": "month", "limit": PHOTOS_API_MAX_PAGE_SIZE}
@@ -41,6 +42,8 @@ async def fetch_asset_counts(
         kwargs["album_id"] = album_id
     if person_id is not None:
         kwargs["person_id"] = person_id
+    if state is not None:
+        kwargs["state"] = state
 
     all_buckets: list[Data] = []
     while True:
@@ -75,18 +78,19 @@ async def get_time_buckets(
     bbox: str = Query(default=None),
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
 ) -> List[TimeBucketsResponseDto]:
-    if (
-        isFavorite
-        or isTrashed
-        or (visibility is not None and visibility != AssetVisibility.timeline)
+    if isFavorite or (
+        visibility is not None and visibility != AssetVisibility.timeline
     ):
-        return []  # Gumnut does not support favorites, trashed, hidden, archived or locked assets, so return empty list
+        return []  # Gumnut does not support favorites, hidden, archived or locked assets, so return empty list
 
     album_id = uuid_to_gumnut_album_id(albumId) if albumId else None
     person_id = uuid_to_gumnut_person_id(personId) if personId else None
 
     raw_buckets = await fetch_asset_counts(
-        client, album_id=album_id, person_id=person_id
+        client,
+        album_id=album_id,
+        person_id=person_id,
+        state="trashed" if isTrashed else None,
     )
 
     # Map to Immich format: normalize time_bucket to month start (YYYY-MM-01)
@@ -158,27 +162,15 @@ async def get_time_bucket(
         "local_datetime_before": next_month_start.isoformat(),
     }
 
+    list_kwargs: dict[str, Any] = {"extra_query": date_range_query}
+    if isTrashed:
+        list_kwargs["state"] = "trashed"
     if albumId:
-        gumnut_album_id = uuid_to_gumnut_album_id(albumId)
-        filtered_assets = [
-            a
-            async for a in client.assets.list(
-                album_id=gumnut_album_id,
-                extra_query=date_range_query,
-            )
-        ]
+        list_kwargs["album_id"] = uuid_to_gumnut_album_id(albumId)
     elif personId:
-        filtered_assets = [
-            a
-            async for a in client.assets.list(
-                person_id=uuid_to_gumnut_person_id(personId),
-                extra_query=date_range_query,
-            )
-        ]
-    else:
-        filtered_assets = [
-            a async for a in client.assets.list(extra_query=date_range_query)
-        ]
+        list_kwargs["person_id"] = uuid_to_gumnut_person_id(personId)
+
+    filtered_assets = [a async for a in client.assets.list(**list_kwargs)]
 
     asset_count = len(filtered_assets)
 
@@ -188,6 +180,7 @@ async def get_time_bucket(
     ratio_list = []
     visibility_list = []
     local_offset_hours_list = []
+    is_trashed_list = []
 
     for asset in filtered_assets:
         asset_id = asset.id
@@ -217,6 +210,8 @@ async def get_time_bucket(
 
         local_offset_hours_list.append(local_datetime_offset)
 
+        is_trashed_list.append(bool(asset.trashed_at))
+
     # Return as dict to bypass Pydantic validation issues with None in List[str]
     # XXX revisit this issue later
     return {
@@ -232,7 +227,7 @@ async def get_time_bucket(
         "visibility": visibility_list,
         "localOffsetHours": local_offset_hours_list,
         "isFavorite": [False] * asset_count,
-        "isTrashed": [False] * asset_count,
+        "isTrashed": is_trashed_list,
         "ownerId": [str(current_user_id)] * asset_count,
         "thumbhash": ["FBgGFYRQjHbAZpiWWpeEhWPANQZr"] * asset_count,
         "latitude": [None] * asset_count,

--- a/tests/integration/test_server_features.py
+++ b/tests/integration/test_server_features.py
@@ -23,7 +23,6 @@ class TestServerFeaturesEndpoint:
             "duplicateDetection",
             "map",
             "reverseGeocoding",
-            "trash",
             "sidecar",
         ):
             assert data[flag] is False, f"{flag} must be False — endpoint is a stub"
@@ -40,6 +39,7 @@ class TestServerFeaturesEndpoint:
             "search",
             "oauth",
             "oauthAutoLaunch",
+            "trash",
         ):
             assert data[flag] is True, f"{flag} should be True"
 

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -1320,6 +1320,41 @@ class TestGetAssetStatistics:
         with pytest.raises(APIStatusError):
             await get_asset_statistics(client=mock_client)
 
+    @pytest.mark.anyio
+    async def test_get_asset_statistics_is_trashed_passes_state(
+        self, multiple_gumnut_assets, mock_sync_cursor_page
+    ):
+        """isTrashed=True routes to assets.list(state='trashed')."""
+        mock_client = Mock()
+
+        assets = multiple_gumnut_assets
+        assets[0].mime_type = "image/jpeg"
+        assets[1].mime_type = "video/mp4"
+        assets[2].mime_type = "image/png"
+
+        mock_client.assets.list.return_value = mock_sync_cursor_page(assets)
+
+        result = await get_asset_statistics(isTrashed=True, client=mock_client)
+
+        assert result.total == 3
+        assert result.images == 2
+        assert result.videos == 1
+        mock_client.assets.list.assert_called_once_with(state="trashed")
+
+    @pytest.mark.anyio
+    async def test_get_asset_statistics_is_trashed_false_omits_state(
+        self, multiple_gumnut_assets, mock_sync_cursor_page
+    ):
+        """isTrashed=False (or absent) calls assets.list() with no state — backend default (live) applies."""
+        mock_client = Mock()
+        mock_client.assets.list.return_value = mock_sync_cursor_page(
+            multiple_gumnut_assets
+        )
+
+        await get_asset_statistics(isTrashed=False, client=mock_client)
+
+        mock_client.assets.list.assert_called_once_with()
+
 
 class TestGetRandom:
     """Test the get_random endpoint."""

--- a/tests/unit/api/test_timeline.py
+++ b/tests/unit/api/test_timeline.py
@@ -249,11 +249,36 @@ class TestGetTimeBuckets:
         result = await call_get_time_buckets(isFavorite=True)
         assert result == []
 
-        result = await call_get_time_buckets(isTrashed=True)
-        assert result == []
-
         result = await call_get_time_buckets(visibility=AssetVisibility.archive)
         assert result == []
+
+    @pytest.mark.anyio
+    async def test_get_time_buckets_is_trashed_passes_state(self):
+        """isTrashed=True routes through to backend counts with state='trashed'."""
+        mock_client = Mock()
+        mock_client.assets.counts = AsyncMock(
+            return_value=_make_counts_response([_make_data(datetime(2024, 1, 1), 4)])
+        )
+
+        result = await call_get_time_buckets(isTrashed=True, client=mock_client)
+
+        assert len(result) == 1
+        assert result[0].count == 4
+        kwargs = mock_client.assets.counts.call_args[1]
+        assert kwargs["state"] == "trashed"
+
+    @pytest.mark.anyio
+    async def test_get_time_buckets_is_trashed_false_omits_state(self):
+        """isTrashed=False (or absent) does not pass state, so the backend default (live) applies."""
+        mock_client = Mock()
+        mock_client.assets.counts = AsyncMock(
+            return_value=_make_counts_response([_make_data(datetime(2024, 1, 1), 1)])
+        )
+
+        await call_get_time_buckets(isTrashed=False, client=mock_client)
+
+        kwargs = mock_client.assets.counts.call_args[1]
+        assert "state" not in kwargs
 
     @pytest.mark.anyio
     async def test_get_time_buckets_empty_assets(self):
@@ -727,6 +752,76 @@ class TestGetTimeBucket:
             assert result["localOffsetHours"][1] == 0
             assert result["localOffsetHours"][2] == -5
             assert result["localOffsetHours"][3] == 0
+
+    @pytest.mark.anyio
+    async def test_get_time_bucket_is_trashed_passes_state_and_populates_flag(
+        self, multiple_gumnut_assets, mock_sync_cursor_page
+    ):
+        """isTrashed=True routes to assets.list(state='trashed') and the per-asset
+        isTrashed flag is sourced from each asset's trashed_at."""
+        mock_client = Mock()
+
+        assets = multiple_gumnut_assets
+        assets[0].id = uuid_to_gumnut_asset_id(uuid4())
+        assets[0].local_datetime = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        assets[0].mime_type = "image/jpeg"
+        assets[0].width = 1920
+        assets[0].height = 1080
+        assets[0].trashed_at = datetime(2024, 1, 20, 12, 0, 0, tzinfo=timezone.utc)
+
+        assets[1].id = uuid_to_gumnut_asset_id(uuid4())
+        assets[1].local_datetime = datetime(2024, 1, 25, 16, 0, 0, tzinfo=timezone.utc)
+        assets[1].mime_type = "image/png"
+        assets[1].width = 1080
+        assets[1].height = 1080
+        assets[1].trashed_at = datetime(2024, 1, 26, 9, 0, 0, tzinfo=timezone.utc)
+
+        mock_client.assets.list.return_value = mock_sync_cursor_page(assets[:2])
+
+        with patch("routers.api.timeline.get_current_user_id") as mock_user_id:
+            mock_user_id.return_value = uuid4()
+
+            result = await call_get_time_bucket(
+                timeBucket="2024-01-01T00:00:00",
+                isTrashed=True,
+                client=mock_client,
+            )
+
+            assert len(result["id"]) == 2
+            assert result["isTrashed"] == [True, True]
+            mock_client.assets.list.assert_called_once_with(
+                extra_query=JANUARY_2024_DATE_RANGE,
+                state="trashed",
+            )
+
+    @pytest.mark.anyio
+    async def test_get_time_bucket_default_path_reads_trashed_at_per_asset(
+        self, multiple_gumnut_assets, mock_sync_cursor_page
+    ):
+        """Live path reads each asset's trashed_at — defensive: backend should already
+        filter trashed rows, but the per-asset flag must reflect reality, not a constant."""
+        mock_client = Mock()
+
+        assets = multiple_gumnut_assets
+        for asset in assets[:2]:
+            asset.id = uuid_to_gumnut_asset_id(uuid4())
+            asset.local_datetime = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+            asset.mime_type = "image/jpeg"
+            asset.width = 1920
+            asset.height = 1080
+        # Both assets are live (trashed_at=None from the fixture).
+        mock_client.assets.list.return_value = mock_sync_cursor_page(assets[:2])
+
+        with patch("routers.api.timeline.get_current_user_id") as mock_user_id:
+            mock_user_id.return_value = uuid4()
+
+            result = await call_get_time_bucket(
+                timeBucket="2024-01-01T00:00:00", client=mock_client
+            )
+
+            assert result["isTrashed"] == [False, False]
+            kwargs = mock_client.assets.list.call_args.kwargs
+            assert "state" not in kwargs
 
 
 class TestTimezoneAwareTimeBucket:

--- a/tests/unit/api/test_timeline.py
+++ b/tests/unit/api/test_timeline.py
@@ -134,6 +134,31 @@ class TestFetchAssetCounts:
         assert second_call_kwargs["local_datetime_before"] == feb_bucket.time_bucket
 
     @pytest.mark.anyio
+    async def test_pagination_preserves_state(self):
+        """state kwarg is preserved on every page, not just the first call.
+
+        fetch_asset_counts mutates kwargs in place inside its while loop to add
+        local_datetime_before. A future change that rebuilds kwargs each iteration
+        could silently drop state on subsequent pages — assert it on every call.
+        """
+        mock_client = Mock()
+        feb_bucket = _make_data(datetime(2024, 2, 1), 5)
+        jan_bucket = _make_data(datetime(2024, 1, 1), 10)
+
+        mock_client.assets.counts = AsyncMock(
+            side_effect=[
+                _make_counts_response([feb_bucket], has_more=True),
+                _make_counts_response([jan_bucket], has_more=False),
+            ]
+        )
+
+        await fetch_asset_counts(mock_client, state="trashed")
+
+        assert mock_client.assets.counts.call_count == 2
+        for call in mock_client.assets.counts.call_args_list:
+            assert call.kwargs["state"] == "trashed"
+
+    @pytest.mark.anyio
     async def test_with_album_id(self):
         """album_id is passed through as a kwarg."""
         mock_client = Mock()
@@ -279,6 +304,23 @@ class TestGetTimeBuckets:
 
         kwargs = mock_client.assets.counts.call_args[1]
         assert "state" not in kwargs
+
+    @pytest.mark.anyio
+    async def test_get_time_buckets_combines_state_with_album_id(self, sample_uuid):
+        """isTrashed=True together with albumId forwards both kwargs — neither branch
+        overwrites the other in fetch_asset_counts."""
+        mock_client = Mock()
+        mock_client.assets.counts = AsyncMock(
+            return_value=_make_counts_response([_make_data(datetime(2024, 1, 1), 1)])
+        )
+
+        await call_get_time_buckets(
+            isTrashed=True, albumId=sample_uuid, client=mock_client
+        )
+
+        kwargs = mock_client.assets.counts.call_args[1]
+        assert kwargs["state"] == "trashed"
+        assert kwargs["album_id"] == uuid_to_gumnut_album_id(sample_uuid)
 
     @pytest.mark.anyio
     async def test_get_time_buckets_empty_assets(self):
@@ -822,6 +864,41 @@ class TestGetTimeBucket:
             assert result["isTrashed"] == [False, False]
             kwargs = mock_client.assets.list.call_args.kwargs
             assert "state" not in kwargs
+
+    @pytest.mark.anyio
+    async def test_get_time_bucket_combines_state_with_album_id(
+        self, multiple_gumnut_assets, mock_sync_cursor_page, sample_uuid
+    ):
+        """isTrashed=True together with albumId forwards both kwargs — the album branch
+        does not overwrite or short-circuit the state kwarg in list_kwargs."""
+        mock_client = Mock()
+
+        assets = multiple_gumnut_assets
+        assets[0].id = uuid_to_gumnut_asset_id(uuid4())
+        assets[0].local_datetime = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        assets[0].mime_type = "image/jpeg"
+        assets[0].width = 1920
+        assets[0].height = 1080
+        assets[0].trashed_at = datetime(2024, 1, 20, 12, 0, 0, tzinfo=timezone.utc)
+
+        mock_client.assets.list.return_value = mock_sync_cursor_page([assets[0]])
+
+        with patch("routers.api.timeline.get_current_user_id") as mock_user_id:
+            mock_user_id.return_value = sample_uuid
+
+            result = await call_get_time_bucket(
+                timeBucket="2024-01-01T00:00:00",
+                isTrashed=True,
+                albumId=sample_uuid,
+                client=mock_client,
+            )
+
+            assert result["isTrashed"] == [True]
+            mock_client.assets.list.assert_called_once_with(
+                extra_query=JANUARY_2024_DATE_RANGE,
+                state="trashed",
+                album_id=uuid_to_gumnut_album_id(sample_uuid),
+            )
 
 
 class TestTimezoneAwareTimeBucket:


### PR DESCRIPTION
## Summary

- Wire `isTrashed` query parameter through to the Gumnut backend on `GET /api/timeline/buckets`, `GET /api/timeline/bucket`, and `GET /api/assets/statistics` (replaces the previous short-circuits / hardcoded constants); populate the per-asset `isTrashed` parallel array from each asset's `trashed_at`.
- Flip `server_features["trash"]` to `True` and remove the now-stale stub comment, completing the trash soft-delete rollout end-to-end (PR A wired DTO conversion / sync hydration; PR B wired `force` honoring + trash router + WebSocket events; this PR makes the trash page render and the flag advertise).

## Linear

https://linear.app/gumnut-ai/issue/GUM-636/trash-pr-c-adapter-timeline-statistics-istrashed-pass

Spec: `docs/design-docs/trash-soft-delete-adapter.md` (Migration / Rollout Plan, PR C).

## Test plan

- [ ] `uv run ruff check && uv run ruff format --check && uv run pyright` pass.
- [ ] `uv run pytest` — full suite green (763 tests).
- [ ] Hit `/api/timeline/buckets?isTrashed=true` against the adapter and confirm non-empty when trashed assets exist.
- [ ] Hit `/api/timeline/bucket?timeBucket=…&isTrashed=true` and confirm `isTrashed=[true, …]` in the parallel array.
- [ ] Hit `/api/assets/statistics?isTrashed=true` and confirm non-zero totals for a user with trashed assets.
- [ ] `/api/server/features` returns `trash: true`; the Immich web client shows the Trash nav item, "In trash" indicator in the asset viewer, and defaults `DELETE /api/assets` to soft-delete.
- [ ] Web trash page renders the caller's trashed assets (previously empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)