### PR TITLE
GUM-686: Use precomputed asset_count for /people/{id}/statistics

### DIFF
--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -135,6 +135,12 @@ for asset_uuid in request.ids:
 
 Use `map_gumnut_error(e, context, extra=..., exc_info=True)` only when the call site needs to enrich the upstream log record with context the global handler can't see — most commonly the upload paths logging filename / device ids / tracebacks.
 
+### Counts and Aggregates
+
+When a response only needs a count over a person's / album's assets, read the precomputed field off the parent entity rather than enumerating a paginator. `PersonResponse.asset_count` and `AlbumResponse.asset_count` are computed in O(1) by the Photos API and already trusted elsewhere in the adapter (e.g., `_immich_people_sort_key`, album conversion). Enumerating with `len([a async for a in client.assets.list(person_id=...)])` fans out into N paginated GETs of full asset payloads — this scaled to >10s on large persons (GUM-686).
+
+Note that an `async for` paginator is always truthy: `if not client.assets.list(...)` is dead code, not an empty-list guard. The page contents are only known after iteration runs, so use the precomputed count rather than trying to short-circuit.
+
 ### Bulk-ID Endpoints
 
 For backend endpoints that accept `{"ids": [...]}` (e.g., `POST /api/assets/trash`, `POST /api/assets/restore`, bulk `DELETE /api/assets`), chunk the request to stay under the backend's `MAX_BULK_GET_IDS=100` cap. Use the shared `BULK_CHUNK_SIZE` constant from `routers/utils/gumnut_client.py` and `itertools.batched`:

--- a/routers/api/people.py
+++ b/routers/api/people.py
@@ -350,11 +350,8 @@ async def get_person_statistics(
     """
     Get asset statistics for a specific person.
     """
-    gumnut_assets = client.assets.list(person_id=uuid_to_gumnut_person_id(id))
-
-    if not gumnut_assets:
-        return PersonStatisticsResponseDto(assets=0)
-    return PersonStatisticsResponseDto(assets=len([a async for a in gumnut_assets]))
+    gumnut_person = await client.people.retrieve(uuid_to_gumnut_person_id(id))
+    return PersonStatisticsResponseDto(assets=gumnut_person.asset_count or 0)
 
 
 @router.delete("/{id}", status_code=204)

--- a/tests/unit/api/test_people.py
+++ b/tests/unit/api/test_people.py
@@ -910,61 +910,54 @@ class TestGetPersonStatistics:
 
     @pytest.mark.anyio
     async def test_get_person_statistics_success(
-        self, multiple_gumnut_assets, mock_sync_cursor_page, sample_uuid
+        self, sample_gumnut_person, sample_uuid
     ):
         """Test successful person statistics retrieval."""
-        # Setup - mock only the Gumnut client
         mock_client = Mock()
-        mock_client.assets.list.return_value = mock_sync_cursor_page(
-            multiple_gumnut_assets
-        )
+        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
 
-        # Execute
         result = await get_person_statistics(sample_uuid, client=mock_client)
 
-        # Assert
-        assert result.assets == 3  # Number of assets from multiple_gumnut_assets
-        mock_client.assets.list.assert_called_once()
+        assert result.assets == 5  # From sample_gumnut_person.asset_count
+        mock_client.people.retrieve.assert_called_once()
 
     @pytest.mark.anyio
-    async def test_get_person_statistics_no_assets(
-        self, mock_sync_cursor_page, sample_uuid
+    async def test_get_person_statistics_zero_assets(
+        self, sample_gumnut_person, sample_uuid
     ):
-        """Test person statistics with no assets."""
-        # Setup - mock only the Gumnut client
+        """A person with no associated assets reports zero."""
+        sample_gumnut_person.asset_count = 0
         mock_client = Mock()
-        mock_client.assets.list.return_value = None
+        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
 
-        # Execute
         result = await get_person_statistics(sample_uuid, client=mock_client)
 
-        # Assert
         assert result.assets == 0
 
     @pytest.mark.anyio
-    async def test_get_person_statistics_empty_assets(
-        self, mock_sync_cursor_page, sample_uuid
+    async def test_get_person_statistics_none_asset_count_treated_as_zero(
+        self, sample_gumnut_person, sample_uuid
     ):
-        """Test person statistics with empty asset list."""
-        # Setup - mock only the Gumnut client
+        """asset_count is Optional[int] in the SDK; None coerces to 0."""
+        sample_gumnut_person.asset_count = None
         mock_client = Mock()
-        mock_client.assets.list.return_value = mock_sync_cursor_page([])
+        mock_client.people.retrieve = AsyncMock(return_value=sample_gumnut_person)
 
-        # Execute
         result = await get_person_statistics(sample_uuid, client=mock_client)
 
-        # Assert
         assert result.assets == 0
 
     @pytest.mark.anyio
     async def test_get_person_statistics_not_found_propagates(self, sample_uuid):
-        """A NotFoundError on assets.list bubbles up to the global handler."""
+        """A NotFoundError on people.retrieve bubbles up to the global handler."""
         from gumnut import NotFoundError
         from tests.conftest import make_sdk_status_error
 
         mock_client = Mock()
-        mock_client.assets.list.side_effect = make_sdk_status_error(
-            404, "Person not found", cls=NotFoundError
+        mock_client.people.retrieve = AsyncMock(
+            side_effect=make_sdk_status_error(
+                404, "Person not found", cls=NotFoundError
+            )
         )
 
         with pytest.raises(NotFoundError):


### PR DESCRIPTION
## Summary

- `/people/{id}/statistics` paginated through every asset for the person and counted them in Python (`len([a async for a in client.assets.list(person_id=...)])`). For a person with thousands of photos this fanned out into N paginated GETs of full asset payloads (with thumbnails/metadata). Render p95 sat at 1–7s and the user-reported call took >10s.
- Replace with a single `client.people.retrieve(...)` call and read `PersonResponse.asset_count`, which Photos API computes in O(1) via `person_service.get_person_asset_count` and the adapter already trusts at `routers/api/people.py:83` for sorting.
- Mirror the no-try/except shape of `get_person` — errors flow through the global `GumnutError` handler.
- The previous `if not gumnut_assets` short-circuit was effectively dead code (SDK paginators are always truthy); document the broader pattern in `code-practices.md` so the bug class doesn't recur.

## Linear

https://linear.app/gumnut-ai/issue/GUM-686/immich-person-statistics-endpoint-takes-forever

## Test plan

- [x] Unit tests updated and passing (4 cases: populated, zero, None, 404 propagation)
- [x] `uv run ruff format` — clean
- [x] `uv run ruff check` — all checks passed
- [x] `uv run pyright routers/api/people.py tests/unit/api/test_people.py` — 0 errors
- [x] `uv run pytest` — 754 passed
- [ ] Spot-check on staging: `GET /api/people/{id}/statistics` returns the same `assets` count it did before, in <100ms instead of seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)