### PR TITLE
GUM-688: Normalize asset width/height to display orientation

### DIFF
--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -17,7 +17,7 @@ Style, patterns, and conventions for the immich-adapter codebase.
 
 ## Project Conventions
 
-- **Comments**: Never reference internal issue tracker IDs (e.g., `GUM-123`) in code comments. This is a public repository and not everyone has access to our bug tracker. Comments on fixes should include all relevant context inline so that the reasoning is self-contained.
+- **Comments and docstrings**: Never reference internal issue tracker IDs (e.g., `GUM-123`) in code comments, docstrings, or test docstrings. This is a public repository and not everyone has access to our bug tracker. Comments and docstrings on fixes should include all relevant context inline so that the reasoning is self-contained.
 - **Module organization**: `services/` is for stateful classes with methods (stores, pipelines, WebSocket handlers). `utils/` is for stateless utility functions and helpers. Don't put classes with state in `utils/`.
 - **Constructor parameters**: Accept specific parameters rather than the full `Settings` object in constructors. This keeps classes decoupled from the config layer and easier to test.
 - **Branching**: Always create a new branch from `main` before making changes. Don't modify files on an existing feature branch for unrelated work.

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -101,6 +101,15 @@ Forgetting step 2 causes silent drift — the served web UI stays on the old Imm
 5. **Validate compatibility**: Run `validate_api_compatibility.py` to ensure correct implementation
 6. **Test endpoints**: Verify responses match Immich API expectations
 
+### Asset dimensions and orientation
+
+Immich's wire contract expects asset width/height to already reflect display orientation (post-rotation), and `orientation` to be `null` whenever a rotation has been baked in. Gumnut stores raw sensor dimensions plus the EXIF orientation tag separately, so every adapter site that emits asset dims to a wire model must normalize:
+
+- Width/height: pass through `display_dimensions(width, height, orientation)` from `routers/utils/asset_conversion.py` (swaps for orientations 5–8).
+- Orientation: pass through `wire_orientation(orientation, width, height)` from the same module (returns `None` whenever `display_dimensions` swapped, so clients don't double-rotate).
+
+Skipping this leaves the adapter inconsistent with upstream — immich web has both a `getAssetRatio` (uses raw `width/height`) and a `getDimensions` (re-applies orientation) helper, and one or the other will render incorrectly depending on which mismatch is present.
+
 ### Stub endpoints — fail closed on auth/authz checks
 
 The adapter has many stub endpoints (PIN code, session lock/unlock, change-password, etc.) that intentionally return success without doing real work, because Immich clients call them and expect a 2xx but the adapter doesn't model the underlying feature. That pattern is fine for purely informational stubs, but **don't apply it to endpoints whose contract is "tell the caller whether the request is authenticated/authorized"**. The Immich client trusts those answers — `auth_guard.dart` calls `/api/auth/validateToken` on app launch and lets the user past the login gate when the response is `authStatus=true`. A stub that always returns `True` lets unauthenticated clients past the gate, and the missing-auth failure only surfaces on the next API call (presenting as a sudden mid-session expiry rather than a missing-credential problem).

--- a/routers/api/sync/converters.py
+++ b/routers/api/sync/converters.py
@@ -26,7 +26,11 @@ from routers.immich_models import (
     SyncPersonV1,
     SyncUserV1,
 )
-from routers.utils.asset_conversion import normalize_rating, mime_type_to_asset_type
+from routers.utils.asset_conversion import (
+    display_dimensions,
+    mime_type_to_asset_type,
+    normalize_rating,
+)
 from routers.utils.datetime_utils import (
     format_timezone_immich,
     to_actual_utc,
@@ -146,6 +150,9 @@ def gumnut_asset_to_sync_asset_v1(asset: AssetResponse, owner_id: str) -> SyncAs
             extra={"asset_id": asset.id, "checksum": asset.checksum},
         )
 
+    orientation = asset.metadata.orientation if asset.metadata else None
+    width, height = display_dimensions(asset.width, asset.height, orientation)
+
     return SyncAssetV1(
         id=str(safe_uuid_from_asset_id(asset.id)),
         checksum=asset.checksum_sha1 or asset.checksum,
@@ -161,12 +168,12 @@ def gumnut_asset_to_sync_asset_v1(asset: AssetResponse, owner_id: str) -> SyncAs
         # Optional fields - use None when not available
         deletedAt=asset.trashed_at,
         duration=None,
-        height=asset.height,
+        height=height,
         libraryId=None,
         livePhotoVideoId=None,
         stackId=None,
         thumbhash=None,
-        width=asset.width,
+        width=width,
     )
 
 
@@ -195,14 +202,16 @@ def gumnut_metadata_to_sync_exif_v1(asset: AssetResponse) -> SyncAssetExifV1:
     original_datetime = to_actual_utc(metadata.original_datetime)
     modified_datetime = to_actual_utc(metadata.modified_datetime)
 
+    width, height = display_dimensions(asset.width, asset.height, metadata.orientation)
+
     return SyncAssetExifV1(
         assetId=str(safe_uuid_from_asset_id(metadata.asset_id)),
         city=metadata.city,
         country=metadata.country,
         dateTimeOriginal=original_datetime,
         description=metadata.description or "",
-        exifImageHeight=asset.height,
-        exifImageWidth=asset.width,
+        exifImageHeight=height,
+        exifImageWidth=width,
         exposureTime=_format_exposure_time(metadata.exposure_time),
         fNumber=metadata.f_number,
         fileSizeInByte=asset.file_size_bytes,

--- a/routers/api/sync/converters.py
+++ b/routers/api/sync/converters.py
@@ -30,6 +30,7 @@ from routers.utils.asset_conversion import (
     display_dimensions,
     mime_type_to_asset_type,
     normalize_rating,
+    wire_orientation,
 )
 from routers.utils.datetime_utils import (
     format_timezone_immich,
@@ -224,9 +225,7 @@ def gumnut_metadata_to_sync_exif_v1(asset: AssetResponse) -> SyncAssetExifV1:
         make=metadata.make,
         model=metadata.model,
         modifyDate=modified_datetime,
-        orientation=str(metadata.orientation)
-        if metadata.orientation is not None
-        else None,
+        orientation=wire_orientation(metadata.orientation, width, height),
         # profile_description is intentionally not surfaced on the Metadata
         # type (per the photos-api design); always emit None.
         profileDescription=None,

--- a/routers/api/timeline.py
+++ b/routers/api/timeline.py
@@ -13,7 +13,7 @@ from routers.immich_models import (
     AssetVisibility,
     TimeBucketsResponseDto,
 )
-from routers.utils.asset_conversion import mime_type_to_asset_type
+from routers.utils.asset_conversion import display_dimensions, mime_type_to_asset_type
 from routers.utils.current_user import get_current_user_id
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
 from routers.utils.gumnut_id_conversion import (
@@ -185,9 +185,9 @@ async def get_time_bucket(
     for asset in filtered_assets:
         asset_id = asset.id
         created_at = asset.local_datetime
-        aspect_ratio = (
-            asset.width / asset.height if asset.height and asset.width else 1.0
-        )
+        orientation = asset.metadata.orientation if asset.metadata else None
+        width, height = display_dimensions(asset.width, asset.height, orientation)
+        aspect_ratio = width / height if width and height else 1.0
         utc_offset = asset.local_datetime.utcoffset()
         if asset.local_datetime.tzinfo and utc_offset is not None:
             local_datetime_offset = int(utc_offset.total_seconds() / 3600)

--- a/routers/utils/asset_conversion.py
+++ b/routers/utils/asset_conversion.py
@@ -35,6 +35,31 @@ def normalize_rating(rating: float | int | None) -> int | None:
     return None if value == -1 else value
 
 
+# EXIF orientation tags 5–8 swap the image's width and height when applied
+# (90° / 270° rotations, with or without mirroring).
+_FLIPPED_ORIENTATIONS = frozenset({5, 6, 7, 8})
+
+
+def display_dimensions(
+    width: int | None,
+    height: int | None,
+    orientation: int | None,
+) -> tuple[int | None, int | None]:
+    """Return (width, height) in display orientation.
+
+    Gumnut stores raw sensor dimensions plus an EXIF orientation tag. Immich's
+    wire contract expects ``asset.width`` / ``asset.height`` to already reflect
+    the post-rotation (display) dimensions — clients (e.g. immich web's
+    ``getAssetRatio``) don't consult orientation when sizing layout boxes.
+
+    For orientations 5–8 (90°/270° rotations), swap the dimensions; otherwise
+    return them unchanged.
+    """
+    if width and height and orientation in _FLIPPED_ORIENTATIONS:
+        return height, width
+    return width, height
+
+
 def mime_type_to_asset_type(mime_type: str) -> AssetTypeEnum:
     """
     Convert a MIME type string to an Immich AssetTypeEnum.
@@ -107,8 +132,9 @@ def extract_exif_info(gumnut_asset: AssetResponse) -> ExifResponseDto:
     date_time_original = to_actual_utc(metadata.original_datetime)
     modify_date = to_actual_utc(metadata.modified_datetime)
 
-    width = gumnut_asset.width
-    height = gumnut_asset.height
+    width, height = display_dimensions(
+        gumnut_asset.width, gumnut_asset.height, orientation
+    )
     file_size = gumnut_asset.file_size_bytes
 
     return ExifResponseDto(
@@ -194,14 +220,18 @@ def extract_sync_exif(gumnut_asset: AssetResponse, asset_uuid: str) -> SyncAsset
     date_time_original = to_actual_utc(date_time_original)
     modify_date = to_actual_utc(modify_date)
 
+    width, height = display_dimensions(
+        gumnut_asset.width, gumnut_asset.height, orientation
+    )
+
     return SyncAssetExifV1(
         assetId=asset_uuid,
         city=str(city) if city else None,
         country=str(country) if country else None,
         dateTimeOriginal=date_time_original,
         description=str(description) if description else None,
-        exifImageHeight=int(gumnut_asset.height) if gumnut_asset.height else None,
-        exifImageWidth=int(gumnut_asset.width) if gumnut_asset.width else None,
+        exifImageHeight=int(height) if height else None,
+        exifImageWidth=int(width) if width else None,
         exposureTime=exposure_time_str,
         fNumber=float(f_number) if f_number else None,
         fileSizeInByte=int(gumnut_asset.file_size_bytes)
@@ -257,6 +287,11 @@ def build_asset_upload_ready_payload(
         to_immich_local_datetime(metadata_original_dt) or gumnut_asset.created_at
     )
 
+    orientation = gumnut_asset.metadata.orientation if gumnut_asset.metadata else None
+    width, height = display_dimensions(
+        gumnut_asset.width, gumnut_asset.height, orientation
+    )
+
     sync_asset = SyncAssetV1(
         id=asset_uuid,
         ownerId=owner_id,
@@ -266,7 +301,7 @@ def build_asset_upload_ready_payload(
         duration=None,
         fileCreatedAt=file_created_at,
         fileModifiedAt=file_modified_at,
-        height=int(gumnut_asset.height) if gumnut_asset.height else None,
+        height=int(height) if height else None,
         isEdited=False,
         isFavorite=False,
         libraryId=None,
@@ -276,7 +311,7 @@ def build_asset_upload_ready_payload(
         stackId=None,
         type=mime_type_to_asset_type(gumnut_asset.mime_type),
         visibility=AssetVisibility.timeline,
-        width=int(gumnut_asset.width) if gumnut_asset.width else None,
+        width=int(width) if width else None,
     )
 
     sync_exif = extract_sync_exif(gumnut_asset, asset_uuid)
@@ -334,6 +369,11 @@ def convert_gumnut_asset_to_immich(
     # Extract EXIF object directly from AssetResponse
     exif_info = extract_exif_info(gumnut_asset)
 
+    orientation = gumnut_asset.metadata.orientation if gumnut_asset.metadata else None
+    width, height = display_dimensions(
+        gumnut_asset.width, gumnut_asset.height, orientation
+    )
+
     return AssetResponseDto(
         id=str(safe_uuid_from_asset_id(asset_id)),
         deviceAssetId=str(asset_id),  # Keep original Gumnut asset ID
@@ -350,7 +390,7 @@ def convert_gumnut_asset_to_immich(
         createdAt=created_at_fallback,
         duration="00:00:00.000000" if asset_type == AssetTypeEnum.VIDEO else "",
         hasMetadata=True,
-        height=float(gumnut_asset.height) if gumnut_asset.height else None,
+        height=float(height) if height else None,
         isArchived=False,
         isEdited=False,
         isFavorite=False,
@@ -361,6 +401,6 @@ def convert_gumnut_asset_to_immich(
         owner=current_user,
         thumbhash="",
         visibility=AssetVisibility.timeline,
-        width=float(gumnut_asset.width) if gumnut_asset.width else None,
+        width=float(width) if width else None,
         people=people,
     )

--- a/routers/utils/asset_conversion.py
+++ b/routers/utils/asset_conversion.py
@@ -60,6 +60,26 @@ def display_dimensions(
     return width, height
 
 
+def wire_orientation(
+    orientation: int | None,
+    width: int | None,
+    height: int | None,
+) -> str | None:
+    """Return the EXIF orientation value to emit on the wire.
+
+    Paired with ``display_dimensions``: when the dimensions have been swapped
+    (orientation 5–8 with both dims present), the orientation tag must be
+    nulled out — otherwise immich web's ``getDimensions`` helper would re-apply
+    the rotation on already-rotated dims, producing wrong dimensions for any
+    consumer that calls it. Matches upstream Immich's documented wire output.
+    """
+    if orientation is None:
+        return None
+    if width and height and orientation in _FLIPPED_ORIENTATIONS:
+        return None
+    return str(orientation)
+
+
 def mime_type_to_asset_type(mime_type: str) -> AssetTypeEnum:
     """
     Convert a MIME type string to an Immich AssetTypeEnum.
@@ -162,7 +182,7 @@ def extract_exif_info(gumnut_asset: AssetResponse) -> ExifResponseDto:
         description=str(description) if description else "",
         dateTimeOriginal=date_time_original,
         modifyDate=modify_date,
-        orientation=str(orientation) if orientation else None,
+        orientation=wire_orientation(orientation, width, height),
         timeZone=time_zone,
         rating=normalize_rating(rating),
         projectionType=str(projection_type) if projection_type else None,
@@ -246,7 +266,7 @@ def extract_sync_exif(gumnut_asset: AssetResponse, asset_uuid: str) -> SyncAsset
         make=str(make) if make else None,
         model=str(model) if model else None,
         modifyDate=modify_date,
-        orientation=str(orientation) if orientation else None,
+        orientation=wire_orientation(orientation, width, height),
         profileDescription=None,  # Not available from Gumnut metadata
         projectionType=str(projection_type) if projection_type else None,
         rating=normalize_rating(rating),

--- a/tests/unit/api/sync/test_orientation.py
+++ b/tests/unit/api/sync/test_orientation.py
@@ -72,6 +72,9 @@ def test_sync_exif_v1_swaps_for_flipped_orientation():
 
     assert result.exifImageWidth == 2268
     assert result.exifImageHeight == 4032
+    # Orientation must be nulled when dims are swapped — see GUM-688
+    # (otherwise immich web's getDimensions re-applies the rotation).
+    assert result.orientation is None
 
 
 def test_sync_exif_v1_passes_through_unflipped_orientation():
@@ -86,3 +89,4 @@ def test_sync_exif_v1_passes_through_unflipped_orientation():
 
     assert result.exifImageWidth == 4032
     assert result.exifImageHeight == 2268
+    assert result.orientation == "1"

--- a/tests/unit/api/sync/test_orientation.py
+++ b/tests/unit/api/sync/test_orientation.py
@@ -44,8 +44,8 @@ def test_sync_asset_v1_passes_through_unflipped_orientations(orientation):
 
 @pytest.mark.parametrize("orientation", [5, 6, 7, 8])
 def test_sync_asset_v1_swaps_for_flipped_orientations(orientation):
-    """Regression: GUM-688 — Pixel-shot landscape buffers tagged orientation=6
-    were emitted unswapped, causing immich web to render portrait pixels into a
+    """Regression: Pixel-shot landscape buffers tagged orientation=6 were
+    emitted unswapped, causing immich web to render portrait pixels into a
     landscape layout box."""
     asset = create_mock_asset_data(UPDATED_AT)
     asset.width = 4032
@@ -72,8 +72,8 @@ def test_sync_exif_v1_swaps_for_flipped_orientation():
 
     assert result.exifImageWidth == 2268
     assert result.exifImageHeight == 4032
-    # Orientation must be nulled when dims are swapped — see GUM-688
-    # (otherwise immich web's getDimensions re-applies the rotation).
+    # Orientation must be nulled when dims are swapped, otherwise immich
+    # web's getDimensions re-applies the rotation on top of swapped dims.
     assert result.orientation is None
 
 

--- a/tests/unit/api/sync/test_orientation.py
+++ b/tests/unit/api/sync/test_orientation.py
@@ -1,0 +1,88 @@
+"""Tests for orientation-aware width/height normalization in sync converters.
+
+The sync stream's ``SyncAssetV1.width``/``height`` and
+``SyncAssetExifV1.exifImageWidth``/``exifImageHeight`` must reflect display
+orientation (post-rotation), matching upstream Immich's wire contract — clients
+read these directly without consulting the orientation tag.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from routers.api.sync.converters import (
+    gumnut_asset_to_sync_asset_v1,
+    gumnut_metadata_to_sync_exif_v1,
+)
+from tests.unit.api.sync.conftest import (
+    create_mock_asset_data,
+    create_mock_metadata_data,
+)
+
+
+OWNER_UUID = "22222222-2222-2222-2222-222222222222"
+UPDATED_AT = datetime(2026, 5, 1, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize("orientation", [None, 1, 2, 3, 4])
+def test_sync_asset_v1_passes_through_unflipped_orientations(orientation):
+    asset = create_mock_asset_data(UPDATED_AT)
+    asset.width = 4032
+    asset.height = 2268
+    if orientation is None:
+        asset.metadata = None
+    else:
+        metadata = create_mock_metadata_data(UPDATED_AT)
+        metadata.orientation = orientation
+        asset.metadata = metadata
+
+    result = gumnut_asset_to_sync_asset_v1(asset, owner_id=OWNER_UUID)
+
+    assert result.width == 4032
+    assert result.height == 2268
+
+
+@pytest.mark.parametrize("orientation", [5, 6, 7, 8])
+def test_sync_asset_v1_swaps_for_flipped_orientations(orientation):
+    """Regression: GUM-688 — Pixel-shot landscape buffers tagged orientation=6
+    were emitted unswapped, causing immich web to render portrait pixels into a
+    landscape layout box."""
+    asset = create_mock_asset_data(UPDATED_AT)
+    asset.width = 4032
+    asset.height = 2268
+    metadata = create_mock_metadata_data(UPDATED_AT)
+    metadata.orientation = orientation
+    asset.metadata = metadata
+
+    result = gumnut_asset_to_sync_asset_v1(asset, owner_id=OWNER_UUID)
+
+    assert result.width == 2268
+    assert result.height == 4032
+
+
+def test_sync_exif_v1_swaps_for_flipped_orientation():
+    asset = create_mock_asset_data(UPDATED_AT)
+    asset.width = 4032
+    asset.height = 2268
+    metadata = create_mock_metadata_data(UPDATED_AT)
+    metadata.orientation = 6
+    asset.metadata = metadata
+
+    result = gumnut_metadata_to_sync_exif_v1(asset)
+
+    assert result.exifImageWidth == 2268
+    assert result.exifImageHeight == 4032
+
+
+def test_sync_exif_v1_passes_through_unflipped_orientation():
+    asset = create_mock_asset_data(UPDATED_AT)
+    asset.width = 4032
+    asset.height = 2268
+    metadata = create_mock_metadata_data(UPDATED_AT)
+    metadata.orientation = 1
+    asset.metadata = metadata
+
+    result = gumnut_metadata_to_sync_exif_v1(asset)
+
+    assert result.exifImageWidth == 4032
+    assert result.exifImageHeight == 2268

--- a/tests/unit/api/test_timeline.py
+++ b/tests/unit/api/test_timeline.py
@@ -444,8 +444,8 @@ class TestGetTimeBucket:
     async def test_get_time_bucket_ratio_uses_display_orientation(
         self, multiple_gumnut_assets, mock_sync_cursor_page
     ):
-        """Regression: GUM-688 — the timeline's per-asset ``ratio`` must be
-        computed from display-orientation dimensions, not raw sensor dims.
+        """Regression: the timeline's per-asset ``ratio`` must be computed
+        from display-orientation dimensions, not raw sensor dims.
 
         For an asset with raw landscape buffer (4032x2268) tagged orientation=6,
         the ratio must be height/width (2268/4032) — otherwise immich web sizes

--- a/tests/unit/api/test_timeline.py
+++ b/tests/unit/api/test_timeline.py
@@ -441,6 +441,42 @@ class TestGetTimeBucket:
             )
 
     @pytest.mark.anyio
+    async def test_get_time_bucket_ratio_uses_display_orientation(
+        self, multiple_gumnut_assets, mock_sync_cursor_page
+    ):
+        """Regression: GUM-688 — the timeline's per-asset ``ratio`` must be
+        computed from display-orientation dimensions, not raw sensor dims.
+
+        For an asset with raw landscape buffer (4032x2268) tagged orientation=6,
+        the ratio must be height/width (2268/4032) — otherwise immich web sizes
+        the layout box landscape and renders the portrait pixels stretched.
+        """
+        mock_client = Mock()
+
+        assets = multiple_gumnut_assets
+        assets[0].id = uuid_to_gumnut_asset_id(uuid4())
+        assets[0].local_datetime = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        assets[0].created_at = assets[0].local_datetime
+        assets[0].mime_type = "image/jpeg"
+        assets[0].width = 4032
+        assets[0].height = 2268
+        metadata = Mock()
+        metadata.orientation = 6
+        assets[0].metadata = metadata
+
+        mock_client.assets.list.return_value = mock_sync_cursor_page([assets[0]])
+
+        with patch("routers.api.timeline.get_current_user_id") as mock_user_id:
+            mock_user_id.return_value = uuid4()
+
+            result = await call_get_time_bucket(
+                timeBucket="2024-01-01T00:00:00", client=mock_client
+            )
+
+            assert len(result["ratio"]) == 1
+            assert result["ratio"][0] == 2268 / 4032
+
+    @pytest.mark.anyio
     async def test_get_time_bucket_with_album_id(
         self, multiple_gumnut_assets, mock_sync_cursor_page, sample_uuid
     ):

--- a/tests/unit/utils/test_asset_conversion.py
+++ b/tests/unit/utils/test_asset_conversion.py
@@ -20,6 +20,7 @@ from routers.utils.asset_conversion import (
     display_dimensions,
     extract_exif_info,
     extract_sync_exif,
+    wire_orientation,
 )
 
 
@@ -118,6 +119,32 @@ class TestDisplayDimensions:
         assert display_dimensions(1920, None, 6) == (1920, None)
 
 
+class TestWireOrientation:
+    """wire_orientation pairs with display_dimensions: emit None when swapped."""
+
+    @pytest.mark.parametrize("orientation", [5, 6, 7, 8])
+    def test_swapped_orientations_emit_null(self, orientation):
+        # When dims are present and orientation triggers a swap, the wire
+        # value must be null so clients don't double-rotate.
+        assert wire_orientation(orientation, 4032, 2268) is None
+
+    @pytest.mark.parametrize(
+        "orientation,expected", [(1, "1"), (2, "2"), (3, "3"), (4, "4")]
+    )
+    def test_unflipped_orientations_pass_through(self, orientation, expected):
+        assert wire_orientation(orientation, 4032, 2268) == expected
+
+    def test_none_orientation_returns_none(self):
+        assert wire_orientation(None, 4032, 2268) is None
+
+    def test_missing_dims_emits_orientation_unchanged(self):
+        # Without dims, there's nothing to be inconsistent with — preserve
+        # the orientation tag verbatim.
+        assert wire_orientation(6, None, None) == "6"
+        assert wire_orientation(6, None, 2268) == "6"
+        assert wire_orientation(6, 4032, None) == "6"
+
+
 class TestOrientationNormalization:
     """All asset-conversion sites must emit width/height in display orientation.
 
@@ -136,6 +163,9 @@ class TestOrientationNormalization:
 
         assert result.exifImageWidth == 2268
         assert result.exifImageHeight == 4032
+        # When dims are swapped, orientation must be nulled out so that
+        # immich web's getDimensions doesn't re-apply the rotation.
+        assert result.orientation is None
 
     def test_extract_exif_info_passes_through_for_orientation_1(
         self, sample_gumnut_asset
@@ -148,6 +178,8 @@ class TestOrientationNormalization:
 
         assert result.exifImageWidth == 4032
         assert result.exifImageHeight == 2268
+        # Unflipped orientations are passed through unchanged.
+        assert result.orientation == "1"
 
     def test_extract_sync_exif_swaps_for_orientation_6(self, sample_gumnut_asset):
         sample_gumnut_asset.width = 4032
@@ -158,6 +190,7 @@ class TestOrientationNormalization:
 
         assert result.exifImageWidth == 2268
         assert result.exifImageHeight == 4032
+        assert result.orientation is None
 
     def test_convert_gumnut_asset_to_immich_swaps_top_level_dims(
         self, sample_gumnut_asset, mock_current_user

--- a/tests/unit/utils/test_asset_conversion.py
+++ b/tests/unit/utils/test_asset_conversion.py
@@ -10,10 +10,16 @@ The DTO conversion sites in ``routers/utils/asset_conversion.py`` must surface
 """
 
 from datetime import datetime, timezone
+from unittest.mock import Mock
+
+import pytest
 
 from routers.utils.asset_conversion import (
     build_asset_upload_ready_payload,
     convert_gumnut_asset_to_immich,
+    display_dimensions,
+    extract_exif_info,
+    extract_sync_exif,
 )
 
 
@@ -69,3 +75,130 @@ class TestBuildAssetUploadReadyPayloadTrashState:
         )
 
         assert payload.asset.deletedAt == trashed_at
+
+
+def _attach_metadata(asset: Mock, *, orientation: int | None) -> None:
+    """Attach a minimal metadata mock with a given orientation to a sample asset."""
+    metadata = Mock()
+    metadata.make = None
+    metadata.model = None
+    metadata.lens_model = None
+    metadata.f_number = None
+    metadata.focal_length = None
+    metadata.iso = None
+    metadata.exposure_time = None
+    metadata.latitude = None
+    metadata.longitude = None
+    metadata.city = None
+    metadata.state = None
+    metadata.country = None
+    metadata.description = None
+    metadata.orientation = orientation
+    metadata.rating = None
+    metadata.projection_type = None
+    metadata.original_datetime = None
+    metadata.modified_datetime = None
+    asset.metadata = metadata
+
+
+class TestDisplayDimensions:
+    """display_dimensions normalizes raw sensor dims to display orientation."""
+
+    @pytest.mark.parametrize("orientation", [None, 1, 2, 3, 4])
+    def test_unflipped_orientations_pass_through(self, orientation):
+        assert display_dimensions(4032, 2268, orientation) == (4032, 2268)
+
+    @pytest.mark.parametrize("orientation", [5, 6, 7, 8])
+    def test_flipped_orientations_swap(self, orientation):
+        assert display_dimensions(4032, 2268, orientation) == (2268, 4032)
+
+    def test_none_dimensions_pass_through(self):
+        assert display_dimensions(None, None, 6) == (None, None)
+        assert display_dimensions(None, 1080, 6) == (None, 1080)
+        assert display_dimensions(1920, None, 6) == (1920, None)
+
+
+class TestOrientationNormalization:
+    """All asset-conversion sites must emit width/height in display orientation.
+
+    Regression: an asset with raw landscape sensor dims (4032×2268) and EXIF
+    orientation=6 (rotate 90° CW) was emitted unswapped, causing immich web's
+    ``getAssetRatio`` to size the layout box as landscape while the served
+    pixels were portrait — the image rendered stretched.
+    """
+
+    def test_extract_exif_info_swaps_for_orientation_6(self, sample_gumnut_asset):
+        sample_gumnut_asset.width = 4032
+        sample_gumnut_asset.height = 2268
+        _attach_metadata(sample_gumnut_asset, orientation=6)
+
+        result = extract_exif_info(sample_gumnut_asset)
+
+        assert result.exifImageWidth == 2268
+        assert result.exifImageHeight == 4032
+
+    def test_extract_exif_info_passes_through_for_orientation_1(
+        self, sample_gumnut_asset
+    ):
+        sample_gumnut_asset.width = 4032
+        sample_gumnut_asset.height = 2268
+        _attach_metadata(sample_gumnut_asset, orientation=1)
+
+        result = extract_exif_info(sample_gumnut_asset)
+
+        assert result.exifImageWidth == 4032
+        assert result.exifImageHeight == 2268
+
+    def test_extract_sync_exif_swaps_for_orientation_6(self, sample_gumnut_asset):
+        sample_gumnut_asset.width = 4032
+        sample_gumnut_asset.height = 2268
+        _attach_metadata(sample_gumnut_asset, orientation=6)
+
+        result = extract_sync_exif(sample_gumnut_asset, asset_uuid="x")
+
+        assert result.exifImageWidth == 2268
+        assert result.exifImageHeight == 4032
+
+    def test_convert_gumnut_asset_to_immich_swaps_top_level_dims(
+        self, sample_gumnut_asset, mock_current_user
+    ):
+        """Top-level width/height are what ``getAssetRatio`` reads."""
+        sample_gumnut_asset.width = 4032
+        sample_gumnut_asset.height = 2268
+        _attach_metadata(sample_gumnut_asset, orientation=6)
+
+        result = convert_gumnut_asset_to_immich(sample_gumnut_asset, mock_current_user)
+
+        assert result.width == 2268.0
+        assert result.height == 4032.0
+        assert result.exifInfo is not None
+        assert result.exifInfo.exifImageWidth == 2268
+        assert result.exifInfo.exifImageHeight == 4032
+
+    def test_convert_gumnut_asset_to_immich_no_metadata_passes_through(
+        self, sample_gumnut_asset, mock_current_user
+    ):
+        sample_gumnut_asset.width = 4032
+        sample_gumnut_asset.height = 2268
+        sample_gumnut_asset.metadata = None
+
+        result = convert_gumnut_asset_to_immich(sample_gumnut_asset, mock_current_user)
+
+        assert result.width == 4032.0
+        assert result.height == 2268.0
+
+    def test_build_asset_upload_ready_payload_swaps_top_level_dims(
+        self, sample_gumnut_asset
+    ):
+        sample_gumnut_asset.width = 4032
+        sample_gumnut_asset.height = 2268
+        _attach_metadata(sample_gumnut_asset, orientation=6)
+
+        payload = build_asset_upload_ready_payload(
+            sample_gumnut_asset, owner_id="22222222-2222-2222-2222-222222222222"
+        )
+
+        assert payload.asset.width == 2268
+        assert payload.asset.height == 4032
+        assert payload.exif.exifImageWidth == 2268
+        assert payload.exif.exifImageHeight == 4032


### PR DESCRIPTION
## Summary

Some assets in immich web were rendered stretched — most visibly portrait photos shown in landscape layout boxes. Root cause: the adapter emitted `asset.width`/`asset.height` in raw sensor orientation while Immich's wire contract expects display orientation (post-EXIF-rotation), and the immich web client's `getAssetRatio` helper consults width/height directly without applying the orientation tag.

This PR normalizes width/height to display orientation at every adapter boundary that emits them, and also nulls the wire `orientation` field whenever a swap occurred (matching upstream Immich and preventing immich web's companion `getDimensions` helper from re-applying the rotation on already-rotated dims).

- New `display_dimensions(width, height, orientation)` helper in `routers/utils/asset_conversion.py` swaps width/height for orientations 5–8 (90°/270° rotations).
- New `wire_orientation(orientation, width, height)` helper returns `None` whenever `display_dimensions` would swap.
- Applied at all seven emit sites: `AssetResponseDto`, `SyncAssetV1`, `ExifResponseDto`, `SyncAssetExifV1`, `build_asset_upload_ready_payload`, `gumnut_asset_to_sync_asset_v1`, `gumnut_metadata_to_sync_exif_v1`, and the timeline `ratio` field.
- Codebase convention documented in `docs/references/code-practices.md`.

Out of scope: `routers/api/faces.py` emits raw image dims paired with raw bounding-box coords — fixing that requires also rotating the bounding boxes and is a separate change.

## Linear

https://linear.app/gumnut-ai/issue/GUM-688/some-images-in-immich-web-are-not-displayed-correctly

## Test plan

- [x] Unit tests for `display_dimensions` and `wire_orientation` (parametrized over orientations 1–8 and None).
- [x] Per-call-site regression tests asserting both swapped dims and nulled orientation for orientation=6, and pass-through for orientation=1.
- [x] Timeline regression test asserting `ratio` is computed from display dims.
- [x] Full suite: 810 passing; ruff format/check and pyright clean.
- [ ] Manual verification: load an affected asset (`width > height` + `orientation in {5,6,7,8}`) in immich web; confirm the preview is no longer stretched.

Generated by an AI coding agent.