### PR TITLE
Harden GitHub Actions workflows + add zizmor

### DIFF
--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -12,6 +12,9 @@ on:
         required: false
         default: "server"
 
+permissions:
+  contents: read
+
 jobs:
   check-compatibility:
     runs-on: ubuntu-latest
@@ -28,7 +31,7 @@ jobs:
           python-version-file: ".python-version"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 
@@ -46,10 +49,12 @@ jobs:
           echo "OpenAPI specification generated successfully"
 
       - name: Run API compatibility check
+        # Pass workflow_dispatch input via env: rather than ${{ }} interpolation
+        # into the run body (template-injection anti-pattern — see
+        # gumnut-dev-setup/docs/references/github-actions-best-practices.md).
+        env:
+          ENDPOINTS: ${{ github.event.inputs.endpoints || 'server' }}
         run: |
-          # Use workflow input or default to 'server' endpoint
-          ENDPOINTS="${{ github.event.inputs.endpoints || 'server' }}"
-
           echo "Checking compatibility for endpoints: $ENDPOINTS"
 
           uv run tools/validate_api_compatibility.py \

--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -49,9 +49,9 @@ jobs:
           echo "OpenAPI specification generated successfully"
 
       - name: Run API compatibility check
-        # Pass workflow_dispatch input via env: rather than ${{ }} interpolation
-        # into the run body (template-injection anti-pattern — see
-        # gumnut-dev-setup/docs/references/github-actions-best-practices.md).
+        # Pass workflow_dispatch inputs via env: rather than ${{ }} interpolation
+        # into run bodies — direct interpolation expands before the shell parses,
+        # allowing template injection.
         env:
           ENDPOINTS: ${{ github.event.inputs.endpoints || 'server' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-typecheck:
     name: Lint and type check
@@ -23,7 +26,7 @@ jobs:
           python-version-file: ".python-version"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 
@@ -53,7 +56,7 @@ jobs:
           python-version-file: ".python-version"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,7 +1,7 @@
 name: zizmor
 
-# Lints `.github/workflows/*.yml` for supply-chain and template-injection
-# anti-patterns. See gumnut-dev-setup/docs/references/github-actions-best-practices.md.
+# Lints .github/workflows/*.yml for supply-chain and template-injection
+# anti-patterns.
 
 on:
   push:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: zizmor
+
+# Lints `.github/workflows/*.yml` for supply-chain and template-injection
+# anti-patterns. See gumnut-dev-setup/docs/references/github-actions-best-practices.md.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -19,6 +19,15 @@ permissions:
 jobs:
   zizmor:
     runs-on: ubuntu-latest
+    permissions:
+      # zizmor-action defaults to advanced-security: true and uploads a
+      # SARIF via github/codeql-action/upload-sarif; these scopes are what
+      # that upload requires on private repos.
+      contents: read
+      actions: read
+      security-events: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,7 +1,6 @@
 # zizmor configuration. See: https://docs.zizmor.sh/configuration/
 #
-# Requires SHA-pin on third-party actions; allows tag/branch refs on
-# first-party actions/* (per gumnut-dev-setup/docs/references/github-actions-best-practices.md).
+# Requires SHA-pin on third-party actions; allows tag refs on first-party actions/*.
 
 rules:
   unpinned-uses:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,11 @@
+# zizmor configuration. See: https://docs.zizmor.sh/configuration/
+#
+# Requires SHA-pin on third-party actions; allows tag/branch refs on
+# first-party actions/* (per gumnut-dev-setup/docs/references/github-actions-best-practices.md).
+
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        actions/*: ref-pin
+        "*": hash-pin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 Before starting work, read `README.md` for project setup and consult the Documentation Map below for relevant docs.
 
+**This repo is public.** Do not reference private sibling repos (e.g., `gumnut-ai/gumnut-dev-setup`) from committed files or PR bodies — links resolve to dead ends for external readers and surface the existence of internal docs. Inline the relevant rationale or context instead. Same principle as the existing clarity rule about absolute author-machine paths in committed files.
+
 # Pre-Commit Commands
 
 Run from the `immich-adapter/` directory:


### PR DESCRIPTION
## Summary

Hardens GitHub Actions workflows in this repo per common security best practices and adds zizmor for ongoing enforcement:

- Adds explicit `permissions: contents: read` to `ci.yml` and `api-compatibility.yml`.
- Pins `astral-sh/setup-uv@v7` → `37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7`.
- **Fixes a template-injection anti-pattern** in `api-compatibility.yml`: the `workflow_dispatch.inputs.endpoints` value was interpolated directly into a `run:` body via `${{ ... }}`, which expands before the shell parses the script. Moves it to an `env:` block on the step so the shell sees a normal env var. (`workflow_dispatch` requires repo write to invoke, so this was low practical risk.)
- Adds `.github/workflows/zizmor.yml` and `.github/zizmor.yml` config (config exempts first-party `actions/*` from the SHA-pin requirement; SHA-pinning is required for all third-party actions).

Verified locally with `zizmor v1.24.1`: 0 High/Medium findings.

## Linear

https://linear.app/gumnut-ai/issue/GUM-685/github-actions-workflow-best-practices

## Test plan

- [ ] `ci.yml` lint/typecheck/test jobs all run green
- [ ] `api-compatibility.yml` runs green and `validate_api_compatibility.py` receives the expected `--endpoints` value (default `server` on push/PR, configurable via `workflow_dispatch`)
- [ ] `zizmor.yml` workflow is green on this PR

Generated by an AI coding agent.