### PR TITLE
Migrate uvicorn WebSocket transport to websockets-sansio (GUM-608)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,9 @@
                 "--port",
                 "8001",
                 "--host",
-                "0.0.0.0"
+                "0.0.0.0",
+                "--ws",
+                "websockets-sansio"
             ],
             "jinja": true,
             "envFile": "${workspaceFolder}/.env",

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,11 @@ ENV LOG_LEVEL=info
 # Run the application with optimized uvicorn settings
 # Render sets PORT environment variable automatically (typically 10000)
 # Using exec form with shell for proper signal handling and variable substitution
+# `--ws websockets-sansio` selects the modern websockets impl; default `auto`
+# routes through the deprecated legacy module which leaks shielded-future
+# exceptions on peer close. See docs/references/uvicorn-settings.md.
 CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8080} --log-level ${LOG_LEVEL} \
+  --ws websockets-sansio \
   --timeout-graceful-shutdown 60 \
   --timeout-keep-alive ${TIMEOUT_KEEP_ALIVE:-75} \
   --limit-concurrency ${LIMIT_CONCURRENCY:-200} \

--- a/README.md
+++ b/README.md
@@ -76,13 +76,14 @@ docker build --build-arg IMMICH_VERSION=v2.2.3 -t immich-adapter .
 For production deployments or when testing with mobile clients (iOS/Android), use these optimized settings:
 
 ```bash
-uv run fastapi run --port 3001 \
+uv run uvicorn main:app --port 3001 \
+  --ws websockets-sansio \
   --timeout-keep-alive 75 \
   --limit-concurrency 200 \
   --backlog 2048
 ```
 
-See [docs/references/uvicorn-settings.md](docs/references/uvicorn-settings.md) for details on these settings and why they matter for mobile clients.
+This invokes `uvicorn` directly because the `fastapi` CLI doesn't expose `--ws`, and the default `--ws auto` routes Socket.IO through a deprecated WebSocket transport. See [docs/references/uvicorn-settings.md](docs/references/uvicorn-settings.md) for details on each flag.
 
 ## Access the Application
 

--- a/docs/architecture/websocket-implementation.md
+++ b/docs/architecture/websocket-implementation.md
@@ -1,6 +1,6 @@
 ---
 title: "WebSocket Implementation Documentation for immich-adapter"
-last-updated: 2026-01-09
+last-updated: 2026-05-07
 ---
 
 # WebSocket Implementation Documentation for immich-adapter
@@ -9,9 +9,12 @@ last-updated: 2026-01-09
 
 This document describes how to implement WebSocket support in immich-adapter, with a focus on authentication and the extensible event system needed to support `on_upload_success` and future events.
 
+**Transport note:** the WebSocket transport that Socket.IO sits on top of is provided by uvicorn, configured via `--ws websockets-sansio` in the Dockerfile and `.vscode/launch.json`. The default `--ws auto` would route through the deprecated legacy `websockets` API and leak `"exception in shielded future"` errors on peer close. Application code in this file does not interact with that layer directly. See `../references/uvicorn-settings.md` § "ws (WebSocket protocol implementation)" for the full rationale.
+
 **Related Documentation:**
 
 - Immich WebSocket Events Reference - Detailed reference of Immich's event triggers, payloads, and client handling
+- Uvicorn Server Settings (`../references/uvicorn-settings.md`) - WebSocket protocol implementation, keep-alive, concurrency, and backlog settings
 
 ---
 

--- a/docs/guides/running-with-immich-mobile.md
+++ b/docs/guides/running-with-immich-mobile.md
@@ -1,6 +1,6 @@
 ---
 title: "Running with Immich Mobile"
-last-updated: 2026-03-19
+last-updated: 2026-05-07
 ---
 
 # Running with Immich Mobile
@@ -47,11 +47,12 @@ This creates `key.pem` and `cert.pem` in the current directory.
 ```bash
 uv run uvicorn main:app --reload --port 3001 \
   --host 192.168.1.100 \
+  --ws websockets-sansio \
   --ssl-keyfile=key.pem \
   --ssl-certfile=cert.pem
 ```
 
-This uses `uvicorn` directly because the `fastapi` CLI doesn't expose SSL options. `--host` is set to your machine's IP (the same one from step 2) because the default (`127.0.0.1`) only accepts connections from the local machine. Using the specific IP rather than `0.0.0.0` limits access to your LAN interface instead of exposing the server on all network interfaces.
+This uses `uvicorn` directly because the `fastapi` CLI doesn't expose SSL options. `--ws websockets-sansio` matches what production runs — see `docs/references/uvicorn-settings.md` § "ws (WebSocket protocol implementation)" for why the default is wrong for our Socket.IO transport. `--host` is set to your machine's IP (the same one from step 2) because the default (`127.0.0.1`) only accepts connections from the local machine. Using the specific IP rather than `0.0.0.0` limits access to your LAN interface instead of exposing the server on all network interfaces.
 
 The server will now be available at `https://192.168.1.100:3001`.
 

--- a/docs/references/uvicorn-settings.md
+++ b/docs/references/uvicorn-settings.md
@@ -36,13 +36,13 @@ These settings control how uvicorn (the ASGI server running our FastAPI applicat
 
 `--ws` selects which WebSocket implementation uvicorn uses for the WebSocket transport that the ASGI app (Socket.IO via `python-engineio`, in our case) sits on top of.
 
-### Setting we use
+### Setting We Use
 
 ```text
 --ws websockets-sansio
 ```
 
-### Why not the default `--ws auto`
+### Why Not the Default `--ws auto`
 
 `auto` picks an implementation based on what's installed: if the `websockets` package is present (it is — it's pulled in transitively), uvicorn selects `uvicorn.protocols.websockets.websockets_impl:WebSocketProtocol`. That module imports `WebSocketServerProtocol` from `websockets.server`, which since `websockets` 14.0 is a deprecated lazy-import alias for `websockets.legacy.server.WebSocketServerProtocol` — the legacy class.
 
@@ -50,20 +50,24 @@ The legacy class implements its receive loop with `asyncio.shield(self.transfer_
 
 In production this surfaced as ~70 Sentry events/day (close codes 1000 / 1005 / 1011) attributed to `logger=asyncio` with `mechanism=logging`.
 
-### What `websockets-sansio` does differently
+### What `websockets-sansio` Does Differently
 
-`websockets-sansio` (added in uvicorn 0.30, available in our pinned 0.40.0) uses the modern sans-I/O `websockets.server.ServerProtocol`. Its receive loop has no `asyncio.shield`; close frames flow out naturally and there are no shielded-future leaks.
+`websockets-sansio` uses the modern sans-I/O `websockets.server.ServerProtocol`. Its receive loop has no `asyncio.shield`; close frames flow out naturally and there are no shielded-future leaks.
 
 The ASGI WebSocket scope/receive/send contract is identical between the two impls, so consumers (`python-engineio`, `python-socketio`, our Socket.IO handlers) don't need any code changes.
 
-### Why we don't use `--ws wsproto`
+### Why We Require uvicorn ≥ 0.44.0
+
+The sansio impl shipped in uvicorn 0.35.0, but it didn't gain WebSocket keepalive pings until **0.44.0**. Without keepalive pings the server would stop probing dead peers, which would silently regress the close-code 1011 ("keepalive ping timeout") detection that the legacy impl was doing for us. The pyproject.toml constraint `uvicorn[standard]>=0.44.0` exists for this reason — do **not** loosen it without first confirming the sansio impl in the target version still emits pings. uvicorn 0.42.0 also fixed several sansio bugs we want to be on the safe side of.
+
+### Why We Don't Use `--ws wsproto`
 
 `wsproto` is a different sans-I/O library entirely. We have no operational reason to switch libraries; staying on `websockets` (modern API) keeps the dependency graph simple and the failure modes well-known.
 
-### Verifying the change
+### Verifying the Change
 
-- Static: `tests/unit/test_uvicorn_ws_config.py` asserts the setting resolves to the modern protocol class.
-- Runtime: post-deploy, watch Sentry issues `IMMICH-ADAPTER-14`, `IMMICH-ADAPTER-15`, and `IMMICH-ADAPTER-1E` over a 48h window — they should stop receiving new events.
+- Static: `tests/unit/config/test_uvicorn_ws_config.py` asserts the setting resolves to the modern protocol class.
+- Runtime: post-deploy, watch Sentry for asyncio `"exception in shielded future"` ERROR records (close codes 1000 / 1005 / 1011) over a 48h window — they should stop appearing.
 
 ---
 

--- a/docs/references/uvicorn-settings.md
+++ b/docs/references/uvicorn-settings.md
@@ -1,28 +1,69 @@
 ---
 title: "Uvicorn Server Settings"
-last-updated: 2025-11-12
+last-updated: 2026-05-07
 ---
 
 # Uvicorn Server Settings Explained
 
 ## Overview
 
-This document provides a deep dive into the three uvicorn server settings recommended for iOS/Flutter client compatibility: `timeout-keep-alive`, `limit-concurrency`, and `backlog`.
+This document covers the uvicorn server settings used by `immich-adapter`:
 
-These settings control how uvicorn (the ASGI server running your FastAPI application) handles HTTP connections, which is critical for mobile clients that make rapid successive requests.
+- HTTP-tier settings tuned for iOS/Flutter client compatibility — `timeout-keep-alive`, `limit-concurrency`, `backlog`.
+- The WebSocket protocol implementation choice — `--ws websockets-sansio`.
+
+These settings control how uvicorn (the ASGI server running our FastAPI application) handles HTTP and WebSocket connections, which is critical for mobile clients that make rapid successive requests and for the Socket.IO sync stream that backs the live Immich web/mobile UIs.
 
 ---
 
 ## Table of Contents
 
-1. [timeout-keep-alive](#timeout-keep-alive)
-2. [limit-concurrency](#limit-concurrency)
-3. [backlog](#backlog)
-4. [Where These Settings Come From](#where-these-settings-come-from)
-5. [Default Values and Why They Matter](#default-values-and-why-they-matter)
-6. [How These Settings Work Together](#how-these-settings-work-together)
-7. [Platform-Specific Behavior](#platform-specific-behavior)
-8. [Monitoring and Tuning](#monitoring-and-tuning)
+1. [ws (WebSocket protocol implementation)](#ws-websocket-protocol-implementation)
+2. [timeout-keep-alive](#timeout-keep-alive)
+3. [limit-concurrency](#limit-concurrency)
+4. [backlog](#backlog)
+5. [Where These Settings Come From](#where-these-settings-come-from)
+6. [Default Values and Why They Matter](#default-values-and-why-they-matter)
+7. [How These Settings Work Together](#how-these-settings-work-together)
+8. [Platform-Specific Behavior](#platform-specific-behavior)
+9. [Monitoring and Tuning](#monitoring-and-tuning)
+
+---
+
+## ws (WebSocket protocol implementation)
+
+### What It Is
+
+`--ws` selects which WebSocket implementation uvicorn uses for the WebSocket transport that the ASGI app (Socket.IO via `python-engineio`, in our case) sits on top of.
+
+### Setting we use
+
+```text
+--ws websockets-sansio
+```
+
+### Why not the default `--ws auto`
+
+`auto` picks an implementation based on what's installed: if the `websockets` package is present (it is — it's pulled in transitively), uvicorn selects `uvicorn.protocols.websockets.websockets_impl:WebSocketProtocol`. That module imports `WebSocketServerProtocol` from `websockets.server`, which since `websockets` 14.0 is a deprecated lazy-import alias for `websockets.legacy.server.WebSocketServerProtocol` — the legacy class.
+
+The legacy class implements its receive loop with `asyncio.shield(self.transfer_data_task)` so explicit close frames aren't cancelled by user-side timeouts. When a peer closes (gracefully or via keepalive timeout), the shielded task raises `ConnectionClosedError` / `ConnectionClosedOK`. The library's surrounding lifecycle doesn't always observe that exception before the task is GC'd, and asyncio logs `"exception in shielded future"` at ERROR.
+
+In production this surfaced as ~70 Sentry events/day (close codes 1000 / 1005 / 1011) attributed to `logger=asyncio` with `mechanism=logging`.
+
+### What `websockets-sansio` does differently
+
+`websockets-sansio` (added in uvicorn 0.30, available in our pinned 0.40.0) uses the modern sans-I/O `websockets.server.ServerProtocol`. Its receive loop has no `asyncio.shield`; close frames flow out naturally and there are no shielded-future leaks.
+
+The ASGI WebSocket scope/receive/send contract is identical between the two impls, so consumers (`python-engineio`, `python-socketio`, our Socket.IO handlers) don't need any code changes.
+
+### Why we don't use `--ws wsproto`
+
+`wsproto` is a different sans-I/O library entirely. We have no operational reason to switch libraries; staying on `websockets` (modern API) keeps the dependency graph simple and the failure modes well-known.
+
+### Verifying the change
+
+- Static: `tests/unit/test_uvicorn_ws_config.py` asserts the setting resolves to the modern protocol class.
+- Runtime: post-deploy, watch Sentry issues `IMMICH-ADAPTER-14`, `IMMICH-ADAPTER-15`, and `IMMICH-ADAPTER-1E` over a 48h window — they should stop receiving new events.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,10 @@ dependencies = [
     "sentry-sdk[fastapi,httpx]>=2.37.1",
     "shortuuid>=1.0.13",
     "user-agents>=2.2.0",
+    # uvicorn 0.44.0 added keepalive pings for the websockets-sansio impl,
+    # which is what we run via `--ws websockets-sansio` to avoid the legacy
+    # `websockets` shielded-future leak. See docs/references/uvicorn-settings.md.
+    "uvicorn[standard]>=0.44.0",
 ]
 
 [tool.uv]

--- a/tests/unit/config/test_uvicorn_ws_config.py
+++ b/tests/unit/config/test_uvicorn_ws_config.py
@@ -1,0 +1,43 @@
+"""Static guard: uvicorn must resolve `--ws websockets-sansio` to the
+modern sans-I/O implementation.
+
+The Dockerfile invokes uvicorn with `--ws websockets-sansio` to avoid the
+deprecated legacy `websockets` API, whose receive loop wraps
+`asyncio.shield(self.transfer_data_task)` and leaks
+`"exception in shielded future"` records on peer close. This test fails
+loudly if a future uvicorn version renames or removes the sansio impl key.
+See `docs/references/uvicorn-settings.md` § "ws (WebSocket protocol
+implementation)".
+"""
+
+import uvicorn
+from uvicorn.protocols.websockets.websockets_sansio_impl import (
+    WebSocketsSansIOProtocol,
+)
+
+
+async def _noop_app(scope, receive, send):  # pragma: no cover
+    """Minimal ASGI app, only needed to satisfy `uvicorn.Config`."""
+
+
+def test_websockets_sansio_resolves_to_modern_protocol():
+    """`ws='websockets-sansio'` must select the sans-I/O server protocol class."""
+    config = uvicorn.Config(_noop_app, ws="websockets-sansio")
+    config.load()
+    assert config.ws_protocol_class is WebSocketsSansIOProtocol
+
+
+def test_websockets_sansio_does_not_import_legacy():
+    """The sansio impl must not pull in the deprecated `websockets.legacy` tree.
+
+    The legacy module is what produces the shielded-future leak. If a future
+    refactor causes `websockets_sansio_impl` to import from `.legacy`, this
+    test catches it before deploy.
+    """
+    import inspect
+
+    from uvicorn.protocols.websockets import websockets_sansio_impl
+
+    source = inspect.getsource(websockets_sansio_impl)
+    assert "websockets.legacy" not in source
+    assert "from .legacy" not in source

--- a/tests/unit/config/test_uvicorn_ws_config.py
+++ b/tests/unit/config/test_uvicorn_ws_config.py
@@ -31,7 +31,7 @@ def test_websockets_sansio_does_not_import_legacy():
     """The sansio impl must not pull in the deprecated `websockets.legacy` tree.
 
     The legacy module is what produces the shielded-future leak. If a future
-    refactor causes `websockets_sansio_impl` to import from `.legacy`, this
+    refactor of the sansio impl reaches into `websockets.legacy.*`, this
     test catches it before deploy.
     """
     import inspect
@@ -40,4 +40,3 @@ def test_websockets_sansio_does_not_import_legacy():
 
     source = inspect.getsource(websockets_sansio_impl)
     assert "websockets.legacy" not in source
-    assert "from .legacy" not in source

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-04-22T01:02:00.833784Z"
+exclude-newer = "2026-04-23T19:52:36.154458Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -396,6 +396,7 @@ dependencies = [
     { name = "sentry-sdk", extra = ["fastapi", "httpx"] },
     { name = "shortuuid" },
     { name = "user-agents" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.dev-dependencies]
@@ -417,6 +418,7 @@ requires-dist = [
     { name = "sentry-sdk", extras = ["fastapi", "httpx"], specifier = ">=2.37.1" },
     { name = "shortuuid", specifier = ">=1.0.13" },
     { name = "user-agents", specifier = ">=2.2.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.44.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -999,15 +1001,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.40.0"
+version = "0.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Switch uvicorn's WebSocket transport from the deprecated legacy `websockets` impl (selected by `--ws auto`) to `--ws websockets-sansio` in the Dockerfile, `.vscode/launch.json`, the README's Production Mode recipe, and the mobile-dev guide. The legacy impl wraps its receive loop in `asyncio.shield(self.transfer_data_task)`; the shielded task raises `ConnectionClosedError` / `ConnectionClosedOK` on peer close and the surrounding lifecycle doesn't always observe it before GC, producing ~70 Sentry asyncio ERROR records per day for benign close codes 1000 / 1005 / 1011.
- Bump `uvicorn[standard]` from 0.40.0 → 0.46.0 (declared as a direct dep with floor `>=0.44.0`). The bump is required, not cosmetic: 0.44.0 added keepalive pings to the sansio impl. Without it, flipping the `--ws` flag would silence the leak but also stop probing dead peers, regressing the close-code-1011 detection the legacy impl was doing for us. 0.42.0 also fixed several sansio bugs.
- Add a `tests/unit/config/test_uvicorn_ws_config.py` static guard that asserts `uvicorn.Config(..., ws="websockets-sansio").load()` resolves to `WebSocketsSansIOProtocol` and that the sansio impl module doesn't import from `websockets.legacy`. No application code changes — the ASGI WebSocket scope/receive/send contract is identical between impls, so `python-socketio` / `python-engineio` / `services/websockets.py` all stay as-is.
- Document in `docs/references/uvicorn-settings.md` (new "ws" section) and cross-link from `docs/architecture/websocket-implementation.md` so the next person editing Socket.IO code knows the transport is configured at the uvicorn layer.

## Linear

https://linear.app/gumnut-ai/issue/GUM-608/migrate-immich-adapter-from-legacy-websockets-api-to-websocketsasyncio

## Test plan

- [x] `uv run ruff check && uv run ruff format --check && uv run pyright` — clean
- [x] `uv run pytest` — 882 tests pass, including the new static guard
- [ ] Post-deploy: watch Sentry for asyncio `"exception in shielded future"` ERROR records (close codes 1000 / 1005 / 1011) over a 48h window — they should stop appearing. The acceptance criterion in the Linear task is fundamentally a runtime signal that can't be asserted in CI without booting a full uvicorn server and racing the 75s keepalive timeout, so production monitoring is the validation surface.
- [ ] Post-deploy: smoke-test the Immich web and mobile sync streams (handshake, live updates, reconnection after a network drop) to confirm the sansio transport keeps client behavior identical.

Generated by an AI coding agent.