### PR TITLE
Add pyright venvPath/venv to pyrightconfig.json (GUM-748)

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,8 @@
 {
   "typeCheckingMode": "basic",
+  "venvPath": ".",
+  "venv": ".venv",
+  "pythonVersion": "3.14",
   "exclude": [
     "tools/**",
     ".venv/**"


### PR DESCRIPTION
## Summary

- Extend `pyrightconfig.json` with `venvPath="."`, `venv=".venv"`, and `pythonVersion="3.14"` so editor LSPs (VS Code, Cursor, Claude Code) running pyright can resolve `fastapi`, `pydantic`, `httpx`, and other third-party imports. Without venv config, every dependency shows up as `reportMissingImports`, training developers to ignore real diagnostics.
- `pythonVersion` matches the existing `requires-python = ">=3.14"` floor in `pyproject.toml`.

## Linear

https://linear.app/gumnut-ai/issue/GUM-748/standardize-pyright-venvpathvenv-config-in-all-python-repos-so-lsps

## Test plan

- [x] `uv run pyright` clean (0 errors, 0 warnings)
- [x] `uv run ruff check` / `uv run ruff format --check` clean
- [ ] Open the repo in an editor with a pyright-based LSP; confirm `fastapi`, `pydantic`, etc. are no longer flagged as missing imports

Generated by an AI coding agent.