### PR TITLE
Wire albumThumbnailAssetId through to gumnut-sdk for album cover updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.14"
 dependencies = [
     "cryptography>=46.0.0",
     "fastapi[standard]>=0.135.2",
-    "gumnut-sdk>=0.82.0",
+    "gumnut-sdk>=0.89.0",
     "pydantic-settings>=2.10.1",
     "pytest>=8.4.2",
     "python-socketio>=5.13.0",

--- a/routers/api/albums.py
+++ b/routers/api/albums.py
@@ -246,7 +246,7 @@ async def update_album(
 ) -> AlbumResponseDto:
     """
     Update an album using the Gumnut SDK.
-    Only name and description are supported by the Gumnut SDK.
+    Supports name, description, and cover (albumThumbnailAssetId).
     """
 
     gumnut_album_id = uuid_to_gumnut_album_id(id)
@@ -256,6 +256,10 @@ async def update_album(
         update_params["name"] = request.albumName
     if request.description is not None:
         update_params["description"] = request.description
+    if request.albumThumbnailAssetId is not None:
+        update_params["album_cover_asset_id"] = uuid_to_gumnut_asset_id(
+            request.albumThumbnailAssetId
+        )
 
     if update_params:
         # SDK raises NotFoundError on missing album → handled by global handler.

--- a/tests/unit/api/test_albums.py
+++ b/tests/unit/api/test_albums.py
@@ -831,27 +831,31 @@ class TestUpdateAlbum:
     async def test_update_album_with_album_cover_asset_id(
         self, sample_gumnut_album, sample_uuid, mock_current_user
     ):
-        """Test that album_cover_asset_id is converted to albumThumbnailAssetId in update_album."""
-        cover_asset_id = uuid_to_gumnut_asset_id(uuid4())
-        sample_gumnut_album.album_cover_asset_id = cover_asset_id
+        """albumThumbnailAssetId is forwarded to the SDK as album_cover_asset_id and echoed back."""
+        cover_uuid = uuid4()
+        cover_gumnut_id = uuid_to_gumnut_asset_id(cover_uuid)
+        sample_gumnut_album.album_cover_asset_id = cover_gumnut_id
 
         mock_client = Mock()
         sample_gumnut_album.name = "Updated Album"
-        sample_gumnut_album.description = "Updated Description"
         mock_client.albums.update = AsyncMock(return_value=sample_gumnut_album)
 
         request = UpdateAlbumDto(
-            albumName="Updated Album", description="Updated Description"
+            albumName="Updated Album", albumThumbnailAssetId=cover_uuid
         )
 
-        # Execute
         result = await update_album(
             sample_uuid, request, client=mock_client, current_user=mock_current_user
         )
 
-        # Assert - verify albumThumbnailAssetId is set correctly
-        expected_uuid = str(safe_uuid_from_asset_id(cover_asset_id))
-        assert result.albumThumbnailAssetId == expected_uuid
+        mock_client.albums.update.assert_called_once_with(
+            uuid_to_gumnut_album_id(sample_uuid),
+            name="Updated Album",
+            album_cover_asset_id=cover_gumnut_id,
+        )
+        assert result.albumThumbnailAssetId == str(
+            safe_uuid_from_asset_id(cover_gumnut_id)
+        )
 
     @pytest.mark.anyio
     async def test_update_album_not_found_propagates(

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-04-23T19:52:36.154458Z"
+exclude-newer = "2026-04-28T15:36:26.092129Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -305,7 +305,7 @@ wheels = [
 
 [[package]]
 name = "gumnut-sdk"
-version = "0.82.0"
+version = "0.89.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -315,9 +315,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/cc/431eb2d56bd1b1f793453147bc4c6529fcf1680169c0f6f20c8c4efe6c88/gumnut_sdk-0.82.0.tar.gz", hash = "sha256:799f0b599b3e1e834918c54243717d68ca5aeeea003bb45ad41c16b57ace3e40", size = 285694, upload-time = "2026-05-06T00:54:15.436Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/f2/49f15d99402bcc2e3894a486b99ca1529d3eb9666f794cda0f64f1651724/gumnut_sdk-0.89.0.tar.gz", hash = "sha256:85e4cf70209152eb14c5cd4941daade60c5558ce7f94d89d235fba2aafe3eaa3", size = 287798, upload-time = "2026-05-12T05:25:53.64Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/b4/5fdc9a3999ec78c0724c420d0925933ae61a58c9d976b0c0a0f6b2ecd006/gumnut_sdk-0.82.0-py3-none-any.whl", hash = "sha256:adf4247f231c2d3d53526259f8422d6f071d08e6112fb5c83bb5b5629d23fe3f", size = 159597, upload-time = "2026-05-06T00:54:14.034Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/db/a39dd0b5aaa976ab913b2376f02f9c8086423a8c487bfac6ee91ffa0941e/gumnut_sdk-0.89.0-py3-none-any.whl", hash = "sha256:a9062e1c4a1c6ff17f3c604e8ad1ba8fea30deb79100e99068af50fd2159efe0", size = 159488, upload-time = "2026-05-12T05:25:52.481Z" },
 ]
 
 [[package]]
@@ -410,7 +410,7 @@ dev = [
 requires-dist = [
     { name = "cryptography", specifier = ">=46.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.2" },
-    { name = "gumnut-sdk", specifier = ">=0.82.0" },
+    { name = "gumnut-sdk", specifier = ">=0.89.0" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "python-socketio", specifier = ">=5.13.0" },


### PR DESCRIPTION
## Summary
- Bumps `gumnut-sdk` floor from 0.82.0 to 0.89.0, which exposes the new `album_cover_asset_id` field on `AlbumUpdateParams` (added upstream after the photos-api fix in gumnut-ai/photos#614).
- In the `PATCH /api/albums/{id}` handler, translates the incoming `albumThumbnailAssetId` UUID to a Gumnut asset ID (via the existing `uuid_to_gumnut_asset_id` helper) and forwards it as `album_cover_asset_id` to `client.albums.update(...)`. Previously the field was silently dropped, so Immich web's "set as album cover" action no-op'd.
- Strengthens `test_update_album_with_album_cover_asset_id` to assert the SDK call shape, not just the response conversion — closes the regression coverage gap that allowed GUM-747.

## Linear
https://linear.app/gumnut-ai/issue/GUM-747

## Test plan
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run pyright` (0 errors)
- [x] `uv run pytest` (882 passed)
- [ ] Smoke test in Immich web: open an album, "Set as album cover" on an asset, confirm the album thumbnail updates and persists across reload

Generated by an AI coding agent.