### PR TITLE
GUM-821: cascade through file_created_at before falling to created_at

### DIFF
--- a/routers/utils/asset_conversion.py
+++ b/routers/utils/asset_conversion.py
@@ -282,13 +282,29 @@ def build_asset_upload_ready_payload(
         gumnut_asset.metadata.modified_datetime if gumnut_asset.metadata else None
     )
 
-    # fileCreatedAt: capture time in actual UTC, fallback to upload time
-    file_created_at = to_actual_utc(metadata_original_dt) or gumnut_asset.created_at
-    # fileModifiedAt: modify time in actual UTC, fallback to upload time
-    file_modified_at = to_actual_utc(metadata_modified_dt) or gumnut_asset.updated_at
-    # localDateTime: capture time in keepLocalTime format, fallback to upload time
+    # fileCreatedAt: capture time in actual UTC.
+    # Cascade mirrors Gumnut's REST Asset.local_datetime resolution:
+    # metadata.original_datetime → asset.file_created_at → asset.created_at.
+    # Falling all the way to created_at (upload time) makes assets without
+    # EXIF capture-date show "today" in the Immich timeline.
+    file_created_at = (
+        to_actual_utc(metadata_original_dt)
+        or to_actual_utc(gumnut_asset.file_created_at)
+        or gumnut_asset.created_at
+    )
+    # fileModifiedAt: modify time in actual UTC; same cascade against the
+    # file-modified chain.
+    file_modified_at = (
+        to_actual_utc(metadata_modified_dt)
+        or to_actual_utc(gumnut_asset.file_modified_at)
+        or gumnut_asset.updated_at
+    )
+    # localDateTime: capture time in keepLocalTime format; cascades through
+    # the same capture-time fields as fileCreatedAt.
     local_date_time = (
-        to_immich_local_datetime(metadata_original_dt) or gumnut_asset.created_at
+        to_immich_local_datetime(metadata_original_dt)
+        or to_immich_local_datetime(gumnut_asset.file_created_at)
+        or gumnut_asset.created_at
     )
 
     width = gumnut_asset.width
@@ -351,13 +367,29 @@ def convert_gumnut_asset_to_immich(
     created_at_fallback = gumnut_asset.created_at or datetime.now(timezone.utc)
     updated_at_fallback = gumnut_asset.updated_at or datetime.now(timezone.utc)
 
-    # fileCreatedAt: capture time in actual UTC, fallback to upload time
-    file_created_at = to_actual_utc(metadata_original_dt) or created_at_fallback
-    # fileModifiedAt: modify time in actual UTC, fallback to upload time
-    file_modified_at = to_actual_utc(metadata_modified_dt) or updated_at_fallback
-    # localDateTime: capture time in keepLocalTime format, fallback to upload time
+    # fileCreatedAt: capture time in actual UTC.
+    # Cascade mirrors Gumnut's REST Asset.local_datetime resolution:
+    # metadata.original_datetime → asset.file_created_at → asset.created_at.
+    # Falling all the way to created_at (upload time) makes assets without
+    # EXIF capture-date show "today" in the Immich timeline.
+    file_created_at = (
+        to_actual_utc(metadata_original_dt)
+        or to_actual_utc(gumnut_asset.file_created_at)
+        or created_at_fallback
+    )
+    # fileModifiedAt: modify time in actual UTC; same cascade against the
+    # file-modified chain.
+    file_modified_at = (
+        to_actual_utc(metadata_modified_dt)
+        or to_actual_utc(gumnut_asset.file_modified_at)
+        or updated_at_fallback
+    )
+    # localDateTime: capture time in keepLocalTime format; cascades through
+    # the same capture-time fields as fileCreatedAt.
     local_date_time = (
-        to_immich_local_datetime(metadata_original_dt) or created_at_fallback
+        to_immich_local_datetime(metadata_original_dt)
+        or to_immich_local_datetime(gumnut_asset.file_created_at)
+        or created_at_fallback
     )
 
     # Determine asset type based on MIME type

--- a/routers/utils/asset_conversion.py
+++ b/routers/utils/asset_conversion.py
@@ -367,25 +367,18 @@ def convert_gumnut_asset_to_immich(
     created_at_fallback = gumnut_asset.created_at or datetime.now(timezone.utc)
     updated_at_fallback = gumnut_asset.updated_at or datetime.now(timezone.utc)
 
-    # fileCreatedAt: capture time in actual UTC.
-    # Cascade mirrors Gumnut's REST Asset.local_datetime resolution:
-    # metadata.original_datetime → asset.file_created_at → asset.created_at.
-    # Falling all the way to created_at (upload time) makes assets without
-    # EXIF capture-date show "today" in the Immich timeline.
+    # Same date cascade as build_asset_upload_ready_payload above; see that
+    # function for the rationale.
     file_created_at = (
         to_actual_utc(metadata_original_dt)
         or to_actual_utc(gumnut_asset.file_created_at)
         or created_at_fallback
     )
-    # fileModifiedAt: modify time in actual UTC; same cascade against the
-    # file-modified chain.
     file_modified_at = (
         to_actual_utc(metadata_modified_dt)
         or to_actual_utc(gumnut_asset.file_modified_at)
         or updated_at_fallback
     )
-    # localDateTime: capture time in keepLocalTime format; cascades through
-    # the same capture-time fields as fileCreatedAt.
     local_date_time = (
         to_immich_local_datetime(metadata_original_dt)
         or to_immich_local_datetime(gumnut_asset.file_created_at)

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -508,6 +508,8 @@ class TestUploadAsset:
         mock_gumnut_asset.original_file_name = "test.jpg"
         mock_gumnut_asset.created_at = datetime.now(timezone.utc)
         mock_gumnut_asset.updated_at = datetime.now(timezone.utc)
+        mock_gumnut_asset.file_created_at = None
+        mock_gumnut_asset.file_modified_at = None
         mock_gumnut_asset.mime_type = "image/jpeg"
         mock_gumnut_asset.width = 1920
         mock_gumnut_asset.height = 1080

--- a/tests/unit/api/test_memories.py
+++ b/tests/unit/api/test_memories.py
@@ -54,6 +54,8 @@ def _make_asset(asset_id_uuid: UUID, captured_at: datetime) -> Mock:
     asset.created_at = captured_at
     asset.updated_at = captured_at
     asset.local_datetime = captured_at
+    asset.file_created_at = None
+    asset.file_modified_at = None
     asset.metadata = None
     asset.people = []
     asset.trashed_at = None

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -332,6 +332,8 @@ class TestSearchMetadata:
         gumnut_asset.checksum = "abc123"
         gumnut_asset.created_at = datetime(2024, 6, 1, tzinfo=timezone.utc)
         gumnut_asset.updated_at = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        gumnut_asset.file_created_at = None
+        gumnut_asset.file_modified_at = None
         gumnut_asset.width = 1920
         gumnut_asset.height = 1080
         gumnut_asset.file_size_bytes = 1024000

--- a/tests/unit/utils/test_asset_conversion.py
+++ b/tests/unit/utils/test_asset_conversion.py
@@ -22,6 +22,136 @@ from routers.utils.asset_conversion import (
 )
 
 
+class TestDateCascade:
+    """The Immich date fields cascade through Gumnut metadata, then file
+    timestamps, then DB row timestamps — mirroring REST ``Asset.local_datetime``
+    so assets without EXIF capture-date don't surface as upload time in the
+    Immich timeline.
+    """
+
+    METADATA_DT = datetime(2018, 7, 4, 10, 30, 0, tzinfo=timezone.utc)
+    FILE_CREATED_DT = datetime(2019, 8, 5, 12, 0, 0, tzinfo=timezone.utc)
+    FILE_MODIFIED_DT = datetime(2019, 8, 6, 13, 0, 0, tzinfo=timezone.utc)
+    CREATED_DT = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    UPDATED_DT = datetime(2026, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
+
+    def _set_dates(
+        self,
+        asset: Mock,
+        *,
+        metadata_original: datetime | None,
+        metadata_modified: datetime | None,
+        file_created: datetime | None,
+        file_modified: datetime | None,
+    ) -> None:
+        asset.created_at = self.CREATED_DT
+        asset.updated_at = self.UPDATED_DT
+        asset.file_created_at = file_created
+        asset.file_modified_at = file_modified
+        if metadata_original is None and metadata_modified is None:
+            asset.metadata = None
+            return
+        metadata = Mock()
+        metadata.original_datetime = metadata_original
+        metadata.modified_datetime = metadata_modified
+        # Avoid AttributeError on the dims/orientation path.
+        metadata.raw_width = None
+        metadata.raw_height = None
+        metadata.orientation = None
+        for attr in (
+            "make",
+            "model",
+            "lens_model",
+            "f_number",
+            "focal_length",
+            "iso",
+            "exposure_time",
+            "latitude",
+            "longitude",
+            "city",
+            "state",
+            "country",
+            "description",
+            "rating",
+            "projection_type",
+        ):
+            setattr(metadata, attr, None)
+        asset.metadata = metadata
+
+    def test_metadata_original_datetime_wins_when_present(
+        self, sample_gumnut_asset, mock_current_user
+    ):
+        """When metadata.original_datetime is set, both converters use it."""
+        self._set_dates(
+            sample_gumnut_asset,
+            metadata_original=self.METADATA_DT,
+            metadata_modified=self.METADATA_DT,
+            file_created=self.FILE_CREATED_DT,
+            file_modified=self.FILE_MODIFIED_DT,
+        )
+
+        rest = convert_gumnut_asset_to_immich(sample_gumnut_asset, mock_current_user)
+        assert rest.fileCreatedAt == self.METADATA_DT
+        assert rest.localDateTime == self.METADATA_DT
+
+        payload = build_asset_upload_ready_payload(
+            sample_gumnut_asset, owner_id="22222222-2222-2222-2222-222222222222"
+        )
+        assert payload.asset.fileCreatedAt == self.METADATA_DT
+        assert payload.asset.localDateTime == self.METADATA_DT
+
+    def test_falls_back_to_file_created_at_when_metadata_null(
+        self, sample_gumnut_asset, mock_current_user
+    ):
+        """When metadata.original_datetime is null but file_created_at differs
+        from created_at, the timeline uses file_created_at — not the upload
+        time."""
+        self._set_dates(
+            sample_gumnut_asset,
+            metadata_original=None,
+            metadata_modified=None,
+            file_created=self.FILE_CREATED_DT,
+            file_modified=self.FILE_MODIFIED_DT,
+        )
+
+        rest = convert_gumnut_asset_to_immich(sample_gumnut_asset, mock_current_user)
+        assert rest.fileCreatedAt == self.FILE_CREATED_DT
+        assert rest.fileModifiedAt == self.FILE_MODIFIED_DT
+        assert rest.localDateTime == self.FILE_CREATED_DT
+
+        payload = build_asset_upload_ready_payload(
+            sample_gumnut_asset, owner_id="22222222-2222-2222-2222-222222222222"
+        )
+        assert payload.asset.fileCreatedAt == self.FILE_CREATED_DT
+        assert payload.asset.fileModifiedAt == self.FILE_MODIFIED_DT
+        assert payload.asset.localDateTime == self.FILE_CREATED_DT
+
+    def test_falls_back_to_created_at_when_metadata_and_file_dates_null(
+        self, sample_gumnut_asset, mock_current_user
+    ):
+        """Final fallback to created_at/updated_at remains intact when nothing
+        higher in the cascade is available."""
+        self._set_dates(
+            sample_gumnut_asset,
+            metadata_original=None,
+            metadata_modified=None,
+            file_created=None,
+            file_modified=None,
+        )
+
+        rest = convert_gumnut_asset_to_immich(sample_gumnut_asset, mock_current_user)
+        assert rest.fileCreatedAt == self.CREATED_DT
+        assert rest.fileModifiedAt == self.UPDATED_DT
+        assert rest.localDateTime == self.CREATED_DT
+
+        payload = build_asset_upload_ready_payload(
+            sample_gumnut_asset, owner_id="22222222-2222-2222-2222-222222222222"
+        )
+        assert payload.asset.fileCreatedAt == self.CREATED_DT
+        assert payload.asset.fileModifiedAt == self.UPDATED_DT
+        assert payload.asset.localDateTime == self.CREATED_DT
+
+
 class TestConvertGumnutAssetToImmichTrashState:
     def test_live_asset_has_is_trashed_false(
         self, sample_gumnut_asset, mock_current_user

--- a/tests/unit/utils/test_asset_conversion.py
+++ b/tests/unit/utils/test_asset_conversion.py
@@ -92,12 +92,14 @@ class TestDateCascade:
 
         rest = convert_gumnut_asset_to_immich(sample_gumnut_asset, mock_current_user)
         assert rest.fileCreatedAt == self.METADATA_DT
+        assert rest.fileModifiedAt == self.METADATA_DT
         assert rest.localDateTime == self.METADATA_DT
 
         payload = build_asset_upload_ready_payload(
             sample_gumnut_asset, owner_id="22222222-2222-2222-2222-222222222222"
         )
         assert payload.asset.fileCreatedAt == self.METADATA_DT
+        assert payload.asset.fileModifiedAt == self.METADATA_DT
         assert payload.asset.localDateTime == self.METADATA_DT
 
     def test_falls_back_to_file_created_at_when_metadata_null(


### PR DESCRIPTION
## What
- Mirror Gumnut's REST `Asset.local_datetime` cascade in both Immich-adapter converters in `routers/utils/asset_conversion.py` (`build_asset_upload_ready_payload` and `convert_gumnut_asset_to_immich`). New cascade for `fileCreatedAt` and `localDateTime`: `metadata.original_datetime -> asset.file_created_at -> asset.created_at`. Symmetric chain for `fileModifiedAt`: `metadata.modified_datetime -> asset.file_modified_at -> asset.updated_at`.
- New `TestDateCascade` class in `tests/unit/utils/test_asset_conversion.py` covering metadata-wins, file-fallback, and full-fallback paths against both converters.
- Pre-existing mocks in `test_assets.py`, `test_memories.py`, and `test_search.py` now set `file_created_at`/`file_modified_at` to `None` so they reach the converters' real fallback path rather than operating on auto-generated `Mock` attribute stubs.

## Why
- When `metadata.original_datetime` is null (asset bytes have no usable EXIF `DateTimeOriginal`), the adapter was falling all the way back to `Asset.created_at` - DB row insertion time, i.e. upload time - skipping `Asset.file_created_at`, the uploader-asserted capture date. Result: any asset uploaded with a correct `timestamp` but no EXIF capture-date showed "today" in the Immich timeline.
- This is the root cause of GUM-770. A temporary seed-script workaround PATCHes `original_datetime` after asset creation; with this fix in place that workaround can be reverted.
- Fixes the timeline for **all** existing assets where `file_created_at` was set but EXIF is missing, not just newly-seeded ones. Pure internal precedence change - no schema, API shape, or contract changes.

## Linear
https://linear.app/gumnut-ai/issue/GUM-821/immich-adapter-fall-back-to-file-created-at-before-created-at-in-date

## Test plan
- [x] `uv run pytest` - 893 passed
- [x] `uv run ruff format && uv run ruff check && uv run pyright` - clean
- [ ] After merge, file follow-up to revert the temporary seed-data `original_datetime` PATCH workaround.

Generated by an AI coding agent.
