### PR TITLE
Wire single-asset metadata edit endpoint to photos-api

### DIFF
--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Immich Adapter Architecture"
-last-updated: 2026-05-15
+last-updated: 2026-05-18
 ---
 
 # Immich Adapter Architecture
@@ -361,7 +361,7 @@ The adapter implements a subset of Immich's API surface. Unimplemented endpoints
 
 | Area | Endpoints | Notes |
 |------|-----------|-------|
-| Assets | Upload, download (original + thumbnail), video playback, delete, bulk delete, existence check, statistics | Streaming downloads via `StreamingResponse`; video playback streams the `original` variant from CDN with Range/seek support; `DELETE /api/assets` soft-deletes by default and permanently deletes when `force=true` |
+| Assets | Upload, download (original + thumbnail), video playback, delete, bulk delete, existence check, statistics, single-asset metadata edit | Streaming downloads via `StreamingResponse`; video playback streams the `original` variant from CDN with Range/seek support; `DELETE /api/assets` soft-deletes by default and permanently deletes when `force=true`; `PUT /api/assets/{id}` forwards `description`, paired `latitude` + `longitude`, and `dateTimeOriginal` to the Photos API and emits `on_asset_update` — `isFavorite`/`rating`/`visibility`/`livePhotoVideoId` are silently ignored, and the bulk `PUT /api/assets` endpoint remains stubbed pending a backend bulk contract |
 | Trash | Restore-by-ids, restore-all, empty-trash | `trashDays` comes from `TRASH_RETENTION_DAYS`; web and mobile clients see real trash state |
 | Albums | CRUD, add/remove assets, statistics | User sharing not supported (returns 501) |
 | People | CRUD, list with pagination/sort/filter, thumbnails, statistics, merge | |

--- a/docs/architecture/websocket-implementation.md
+++ b/docs/architecture/websocket-implementation.md
@@ -1,6 +1,6 @@
 ---
 title: "WebSocket Implementation Documentation for immich-adapter"
-last-updated: 2026-05-07
+last-updated: 2026-05-18
 ---
 
 # WebSocket Implementation Documentation for immich-adapter
@@ -165,6 +165,7 @@ Starting with `on_upload_success`, but designed for future extension:
 | `on_asset_delete` | `string` (assetId) | Yes | Yes | One per id; force=true permanent delete |
 | `on_asset_trash` | `string[]` (assetIds) | Yes | Yes | Batched per chunk; force=false soft delete |
 | `on_asset_restore` | `string[]` (assetIds) | Yes | Yes | Batched per chunk; restore from trash |
+| `on_asset_update` | `AssetResponseDto` | Yes | Yes | Emitted from `PUT /api/assets/{id}` after a successful metadata edit |
 | `on_session_delete` | `string` (sessionId) | Yes | No | Sessions managed by immich-adapter |
 | `on_server_version` | `ServerVersionResponseDto` | Yes | No | Sent on connect (existing) |
 
@@ -180,7 +181,6 @@ These events require features that don't exist in photos-api:
 
 | Event | Reason |
 |---|---|
-| `on_asset_update` | Assets are immutable after creation |
 | `on_asset_stack_update` | Stacks not implemented |
 | `on_asset_hidden` | Asset visibility not supported |
 | `on_notification` | Album sharing & job failures not implemented |

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -1,6 +1,6 @@
 ---
 title: "Code Practices"
-last-updated: 2026-05-15
+last-updated: 2026-05-18
 ---
 
 # Code Practices
@@ -115,6 +115,10 @@ Forgetting step 2 causes silent drift — the served web UI stays on the old Imm
 
    After updating the dedicated sections and tables, also grep each touched doc for **other paragraphs that summarize the prior state** — design-decision notes, recommendations, server-feature flag rollups, etc. The gap-analysis doc in particular has a `GET /server/features` design-decision paragraph that enumerates which client UI flags are on/off; flipping a server-feature flag in the code without updating that paragraph leaves it contradicting both the code and the gap section you just updated. Search for the feature name (e.g., `map`, `trash`, `duplicateDetection`) across the doc before considering the update done.
 
+   If the new endpoint also emits a WebSocket event (existing one or new), also update **both** websocket docs and bump their `last-updated`:
+   - `docs/architecture/websocket-implementation.md` — move the event out of the "Not Applicable" table into the Phase 1 supported table (or add a new row), with the payload, Web/Mobile columns, and a Notes value that names the emit site.
+   - `docs/references/websocket-events-reference.md` — update the Summary Table row and the per-event section. Upstream-Immich and adapter triggers may diverge (e.g., upstream emits `on_asset_update` only from sidecar processing; the adapter emits it from `PUT /api/assets/{id}`); make both paths explicit so future readers don't assume the upstream-only note still applies.
+
 ### Asset dimensions and orientation
 
 photos-api owns display-space dims at ingest — `asset.width` / `asset.height` already reflect post-rotation dimensions and must be emitted **verbatim** on the wire (immich web reads them via `getAssetRatio`). Pre-rotation raw dims live on `metadata.raw_width` / `metadata.raw_height`; surface them on `exifInfo.exifImageWidth` / `exifImageHeight` so Immich mobile can re-derive display dims locally. When raw dims are present, the EXIF `orientation` tag is emitted unchanged — mobile pairs it with the raw dims to compute display dims; immich web ignores it (it reads `asset.width/height` directly).
@@ -179,6 +183,28 @@ for asset_uuid in request.ids:
 ```
 
 Use `map_gumnut_error(e, context, extra=..., exc_info=True)` only when the call site needs to enrich the upstream log record with context the global handler can't see — most commonly the upload paths logging filename / device ids / tracebacks.
+
+### Omit vs explicit-null in update-style DTOs — use `model_fields_set`
+
+Many generated Immich update DTOs declare each field as `T | None = None` (e.g., `UpdateAssetDto`'s `description`, `latitude`, `longitude`, `dateTimeOriginal`). On the wire, Immich clients distinguish two different intents:
+
+- **Omitted** (`{}` or no key for the field) — "leave this field unchanged."
+- **Explicit null** (`{"description": null}`) — "clear this field."
+
+Both arrive at the model as `None` because the default is `None`. To disambiguate, read **`request.model_fields_set`** (Pydantic v2). It records the set of field names that were present in the input JSON, independent of their value:
+
+```python
+provided = request.model_fields_set
+patch: dict[str, Any] = {}
+if "description" in provided:
+    patch["description"] = request.description  # may be None — that's "clear"
+# Fields not in `provided` are omitted from the patch entirely so the SDK's
+# `Omit` sentinel default applies.
+```
+
+When the SDK method accepts `Omit | None | T`, leaving the kwarg out of the `**patch` unpack maps cleanly to "leave unchanged"; including it with `None` maps to "clear." Without `model_fields_set`, the adapter can only see `None` and conflates the two intents.
+
+This pattern is needed wherever the upstream Immich DTO uses `T | None = None` defaults AND the backend (or wire contract) distinguishes "unset" from "cleared." Bulk-update DTOs, single-asset edit, person/album edits — audit each new update endpoint for this trap before forwarding the DTO to the SDK.
 
 ### Forwarding pagination parameters
 

--- a/docs/references/websocket-events-reference.md
+++ b/docs/references/websocket-events-reference.md
@@ -1,6 +1,6 @@
 ---
 title: "Immich WebSocket Events Reference"
-last-updated: 2026-01-09
+last-updated: 2026-05-18
 ---
 
 # Immich WebSocket Events Reference
@@ -16,7 +16,7 @@ This document describes the WebSocket events emitted by the Immich server and ho
 | `on_asset_delete` | Asset permanently deleted | `assetId: string` | Global listener | Listener |
 | `on_asset_trash` | Asset moved to trash | `assetIds: string[]` | Global listener | Listener |
 | `on_asset_restore` | Asset restored from trash | `assetIds: string[]` | Global listener | Listener |
-| `on_asset_update` | Sidecar metadata extracted | `AssetResponseDto` | Global listener | Listener |
+| `on_asset_update` | Sidecar metadata extracted (upstream) / asset metadata edited (adapter) | `AssetResponseDto` | Global listener | Listener |
 | `on_asset_stack_update` | Stack created/updated/deleted | None | Global listener | Listener |
 | `on_asset_hidden` | Asset visibility changed | `assetId: string` | Global listener | Listener |
 | `on_person_thumbnail` | Person thumbnail generated | `personId: string` | Page-specific | Not used |
@@ -146,7 +146,10 @@ AssetResponseDto {
 
 ### `on_asset_update`
 
-**Trigger**: Emitted when metadata extracted from sidecar files (`notification.service.ts:157-171`). Only triggered by sidecar processing, NOT by direct user edits.
+**Trigger**:
+- **Upstream Immich**: Emitted when metadata extracted from sidecar files (`notification.service.ts:157-171`). Only triggered by sidecar processing, NOT by direct user edits.
+- **immich-adapter**: Emitted after a successful single-asset metadata edit via `PUT /api/assets/{id}` (description / paired latitude+longitude / dateTimeOriginal). The adapter has no sidecar processing, so this is the only emission path here.
+
 **Sent to**: Asset owner (by userId)
 **Payload**: Full `AssetResponseDto`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.14"
 dependencies = [
     "cryptography>=46.0.0",
     "fastapi[standard]>=0.135.2",
-    "gumnut-sdk>=0.90.0",
+    "gumnut-sdk>=0.92.0",
     "pydantic-settings>=2.10.1",
     "pytest>=8.4.2",
     "python-socketio>=5.13.0",

--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -1,5 +1,5 @@
 from itertools import batched
-from typing import List, Literal, NamedTuple, cast
+from typing import Any, List, Literal, NamedTuple, cast
 from uuid import UUID, uuid4
 import base64
 import logging
@@ -752,6 +752,68 @@ async def copy_asset(
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
+def _parse_update_original_datetime(value: str | None) -> datetime | None:
+    """Parse the `dateTimeOriginal` field on an `UpdateAssetDto`.
+
+    Distinct from `_parse_datetime` (which substitutes a fallback on parse
+    failure for upload paths) — here an invalid input must surface as 422.
+    A `None` value means "clear" and is passed through.
+    """
+    if value is None:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, AttributeError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid dateTimeOriginal: {value!r}",
+        ) from exc
+
+
+def _build_metadata_patch(request: UpdateAssetDto) -> dict[str, Any] | None:
+    """Build the SDK `update_asset` kwargs from an `UpdateAssetDto`.
+
+    Uses `model_fields_set` to distinguish "field omitted" from "field
+    explicitly null" — both look like `None` on the model because the DTO
+    defaults every field to `None`. Out-of-scope DTO fields
+    (`isFavorite`, `rating`, `visibility`, `livePhotoVideoId`) are silently
+    ignored; the request still succeeds, we just don't act on parts the
+    Photos API doesn't model. Returns `None` when no in-scope fields were
+    set, signalling the caller to skip the PATCH entirely.
+
+    Validates paired lat/lon adapter-side so the request 422s before the
+    network call when the client sends half-set or half-cleared coords.
+    """
+    provided = request.model_fields_set
+    patch: dict[str, Any] = {}
+
+    if "description" in provided:
+        patch["description"] = request.description
+
+    lat_set = "latitude" in provided
+    lon_set = "longitude" in provided
+    if lat_set != lon_set:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="latitude and longitude must be provided together",
+        )
+    if lat_set and lon_set:
+        if (request.latitude is None) != (request.longitude is None):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="latitude and longitude must be cleared together",
+            )
+        patch["latitude"] = request.latitude
+        patch["longitude"] = request.longitude
+
+    if "dateTimeOriginal" in provided:
+        patch["original_datetime"] = _parse_update_original_datetime(
+            request.dateTimeOriginal
+        )
+
+    return patch or None
+
+
 @router.put("/{id}")
 async def update_asset(
     id: UUID,
@@ -759,12 +821,27 @@ async def update_asset(
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
     current_user: UserResponseDto = Depends(get_current_user),
 ) -> AssetResponseDto:
+    """Update single-asset metadata.
+
+    Wires Immich's `PUT /api/assets/{id}` to the Photos API
+    `update_asset` PATCH. In-scope DTO fields: `description`,
+    `latitude` + `longitude`, `dateTimeOriginal`. Out-of-scope fields
+    (`isFavorite`, `rating`, `visibility`, `livePhotoVideoId`) are
+    silently ignored — the request still succeeds, but the adapter
+    doesn't act on parts the Photos API doesn't model.
     """
-    Update asset metadata.
-    This is a stub implementation as Gumnut does not support asset metadata updates.
-    Returns the asset as-is.
-    """
-    return await get_asset_info(id, client=client, current_user=current_user)
+    payload = _build_metadata_patch(request)
+    if payload is None:
+        return await get_asset_info(id, client=client, current_user=current_user)
+
+    gumnut_asset = await client.assets.update_asset(
+        uuid_to_gumnut_asset_id(id), **payload
+    )
+    immich_asset = convert_gumnut_asset_to_immich(gumnut_asset, current_user)
+    await emit_user_event(
+        WebSocketEvent.ASSET_UPDATE, str(current_user.id), immich_asset
+    )
+    return immich_asset
 
 
 @router.get("/{id}")

--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -838,9 +838,7 @@ async def update_asset(
         uuid_to_gumnut_asset_id(id), **payload
     )
     immich_asset = convert_gumnut_asset_to_immich(gumnut_asset, current_user)
-    await emit_user_event(
-        WebSocketEvent.ASSET_UPDATE, str(current_user.id), immich_asset
-    )
+    await emit_user_event(WebSocketEvent.ASSET_UPDATE, current_user.id, immich_asset)
     return immich_asset
 
 

--- a/services/websockets.py
+++ b/services/websockets.py
@@ -44,6 +44,10 @@ class WebSocketEvent(Enum):
     ASSET_DELETE = "on_asset_delete"
     ASSET_TRASH = "on_asset_trash"
     ASSET_RESTORE = "on_asset_restore"
+    # Payload is the full AssetResponseDto (matches upstream Immich + web client
+    # type `(asset: AssetResponseDto) => void`). Web upserts the asset into the
+    # timeline manager on receipt; mobile triggers a generic sync refresh.
+    ASSET_UPDATE = "on_asset_update"
     SESSION_DELETE = "on_session_delete"
     SERVER_VERSION = "on_server_version"
 

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -1431,7 +1431,7 @@ class TestUpdateAsset:
         # Payload is the converted AssetResponseDto, not a bare ID string —
         # matches upstream Immich + the web client signature.
         mock_emit.assert_awaited_once_with(
-            WebSocketEvent.ASSET_UPDATE, str(mock_current_user.id), result
+            WebSocketEvent.ASSET_UPDATE, mock_current_user.id, result
         )
 
 

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -1173,13 +1173,22 @@ class TestUpdateAsset:
         mock_client.assets.update_asset.assert_not_awaited()
 
     @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"latitude": None, "longitude": 1.0},
+            {"latitude": 1.0, "longitude": None},
+        ],
+    )
     async def test_update_asset_half_cleared_coords_is_422(
-        self, sample_uuid, mock_current_user
+        self, sample_uuid, mock_current_user, payload
     ):
+        # XOR-style check is symmetric in latitude/longitude — cover both
+        # directions so a typo that broke one side wouldn't pass.
         mock_client = Mock()
         mock_client.assets.update_asset = AsyncMock()
 
-        request = UpdateAssetDto.model_validate({"latitude": None, "longitude": 1.0})
+        request = UpdateAssetDto.model_validate(payload)
 
         with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
             with pytest.raises(HTTPException) as exc_info:

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -3,7 +3,7 @@
 import json
 
 import pytest
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from unittest.mock import Mock, AsyncMock, patch
 from fastapi import HTTPException
@@ -48,6 +48,7 @@ from routers.immich_models import (
     AssetBulkUploadCheckItem,
     AssetCopyDto,
     AssetMediaResponseDto,
+    AssetVisibility,
     CheckExistingAssetsDto,
     AssetBulkUpdateDto,
     AssetBulkDeleteDto,
@@ -1001,6 +1002,430 @@ class TestUpdateAssets:
         assert result.status_code == 204
 
 
+class TestUpdateAsset:
+    """Test the single-asset metadata edit endpoint.
+
+    `PUT /api/assets/{id}` forwards a subset of `UpdateAssetDto` to the Photos
+    API `update_asset` PATCH: `description`, paired `latitude` + `longitude`,
+    and `dateTimeOriginal`. Out-of-scope fields (`isFavorite`, `rating`,
+    `visibility`, `livePhotoVideoId`) are silently ignored — the request
+    succeeds, the adapter just doesn't act on parts the Photos API doesn't
+    model. An empty payload returns the asset unchanged without an SDK call.
+    """
+
+    @pytest.mark.anyio
+    async def test_update_asset_description_round_trips(
+        self, sample_uuid, sample_gumnut_asset, mock_current_user
+    ):
+        sample_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
+        mock_client = Mock()
+        mock_client.assets.update_asset = AsyncMock(return_value=sample_gumnut_asset)
+
+        request = UpdateAssetDto(description="hello")
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            result = await update_asset(
+                sample_uuid,
+                request,
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+        mock_client.assets.update_asset.assert_awaited_once_with(
+            uuid_to_gumnut_asset_id(sample_uuid), description="hello"
+        )
+        assert result.id == str(sample_uuid)
+
+    @pytest.mark.anyio
+    async def test_update_asset_description_null_clears(
+        self, sample_uuid, sample_gumnut_asset, mock_current_user
+    ):
+        sample_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
+        mock_client = Mock()
+        mock_client.assets.update_asset = AsyncMock(return_value=sample_gumnut_asset)
+
+        request = UpdateAssetDto.model_validate({"description": None})
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            await update_asset(
+                sample_uuid,
+                request,
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+        mock_client.assets.update_asset.assert_awaited_once_with(
+            uuid_to_gumnut_asset_id(sample_uuid), description=None
+        )
+
+    @pytest.mark.anyio
+    async def test_update_asset_empty_description_lets_backend_reject(
+        self, sample_uuid, sample_gumnut_asset, mock_current_user
+    ):
+        # Empty string is forwarded; the backend rejects it with 422 via the
+        # global GumnutError handler. The adapter doesn't pre-validate length.
+        sample_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
+        mock_client = Mock()
+        mock_client.assets.update_asset = AsyncMock(return_value=sample_gumnut_asset)
+
+        request = UpdateAssetDto(description="")
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            await update_asset(
+                sample_uuid,
+                request,
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+        mock_client.assets.update_asset.assert_awaited_once_with(
+            uuid_to_gumnut_asset_id(sample_uuid), description=""
+        )
+
+    @pytest.mark.anyio
+    async def test_update_asset_lat_lon_round_trips(
+        self, sample_uuid, sample_gumnut_asset, mock_current_user
+    ):
+        sample_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
+        mock_client = Mock()
+        mock_client.assets.update_asset = AsyncMock(return_value=sample_gumnut_asset)
+
+        request = UpdateAssetDto(latitude=37.7749, longitude=-122.4194)
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            await update_asset(
+                sample_uuid,
+                request,
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+        mock_client.assets.update_asset.assert_awaited_once_with(
+            uuid_to_gumnut_asset_id(sample_uuid),
+            latitude=37.7749,
+            longitude=-122.4194,
+        )
+
+    @pytest.mark.anyio
+    async def test_update_asset_lat_lon_both_null_clears(
+        self, sample_uuid, sample_gumnut_asset, mock_current_user
+    ):
+        sample_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
+        mock_client = Mock()
+        mock_client.assets.update_asset = AsyncMock(return_value=sample_gumnut_asset)
+
+        request = UpdateAssetDto.model_validate({"latitude": None, "longitude": None})
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            await update_asset(
+                sample_uuid,
+                request,
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+        mock_client.assets.update_asset.assert_awaited_once_with(
+            uuid_to_gumnut_asset_id(sample_uuid),
+            latitude=None,
+            longitude=None,
+        )
+
+    @pytest.mark.anyio
+    async def test_update_asset_only_latitude_is_422(
+        self, sample_uuid, mock_current_user
+    ):
+        mock_client = Mock()
+        mock_client.assets.update_asset = AsyncMock()
+
+        request = UpdateAssetDto(latitude=37.7749)
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            with pytest.raises(HTTPException) as exc_info:
+                await update_asset(
+                    sample_uuid,
+                    request,
+                    client=mock_client,
+                    current_user=mock_current_user,
+                )
+
+        assert exc_info.value.status_code == 422
+        mock_client.assets.update_asset.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_update_asset_only_longitude_is_422(
+        self, sample_uuid, mock_current_user
+    ):
+        mock_client = Mock()
+        mock_client.assets.update_asset = AsyncMock()
+
+        request = UpdateAssetDto(longitude=-122.4194)
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            with pytest.raises(HTTPException) as exc_info:
+                await update_asset(
+                    sample_uuid,
+                    request,
+                    client=mock_client,
+                    current_user=mock_current_user,
+                )
+
+        assert exc_info.value.status_code == 422
+        mock_client.assets.update_asset.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_update_asset_half_cleared_coords_is_422(
+        self, sample_uuid, mock_current_user
+    ):
+        mock_client = Mock()
+        mock_client.assets.update_asset = AsyncMock()
+
+        request = UpdateAssetDto.model_validate({"latitude": None, "longitude": 1.0})
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            with pytest.raises(HTTPException) as exc_info:
+                await update_asset(
+                    sample_uuid,
+                    request,
+                    client=mock_client,
+                    current_user=mock_current_user,
+                )
+
+        assert exc_info.value.status_code == 422
+        mock_client.assets.update_asset.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_update_asset_datetime_with_offset_round_trips(
+        self, sample_uuid, sample_gumnut_asset, mock_current_user
+    ):
+        sample_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
+        mock_client = Mock()
+        mock_client.assets.update_asset = AsyncMock(return_value=sample_gumnut_asset)
+
+        request = UpdateAssetDto(dateTimeOriginal="2024-06-15T14:30:00-07:00")
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            await update_asset(
+                sample_uuid,
+                request,
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+        mock_client.assets.update_asset.assert_awaited_once_with(
+            uuid_to_gumnut_asset_id(sample_uuid),
+            original_datetime=datetime(
+                2024, 6, 15, 14, 30, 0, tzinfo=timezone(-timedelta(hours=7))
+            ),
+        )
+
+    @pytest.mark.anyio
+    async def test_update_asset_datetime_naive_round_trips(
+        self, sample_uuid, sample_gumnut_asset, mock_current_user
+    ):
+        # Naive datetime (no offset, no Z). The backend accepts naive; the
+        # adapter does not synthesise an offset.
+        sample_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
+        mock_client = Mock()
+        mock_client.assets.update_asset = AsyncMock(return_value=sample_gumnut_asset)
+
+        request = UpdateAssetDto(dateTimeOriginal="2024-06-15T14:30:00")
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            await update_asset(
+                sample_uuid,
+                request,
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+        mock_client.assets.update_asset.assert_awaited_once_with(
+            uuid_to_gumnut_asset_id(sample_uuid),
+            original_datetime=datetime(2024, 6, 15, 14, 30, 0),
+        )
+
+    @pytest.mark.anyio
+    async def test_update_asset_datetime_z_suffix_round_trips(
+        self, sample_uuid, sample_gumnut_asset, mock_current_user
+    ):
+        sample_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
+        mock_client = Mock()
+        mock_client.assets.update_asset = AsyncMock(return_value=sample_gumnut_asset)
+
+        request = UpdateAssetDto(dateTimeOriginal="2024-06-15T14:30:00Z")
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            await update_asset(
+                sample_uuid,
+                request,
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+        mock_client.assets.update_asset.assert_awaited_once_with(
+            uuid_to_gumnut_asset_id(sample_uuid),
+            original_datetime=datetime(2024, 6, 15, 14, 30, 0, tzinfo=timezone.utc),
+        )
+
+    @pytest.mark.anyio
+    async def test_update_asset_datetime_null_clears(
+        self, sample_uuid, sample_gumnut_asset, mock_current_user
+    ):
+        sample_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
+        mock_client = Mock()
+        mock_client.assets.update_asset = AsyncMock(return_value=sample_gumnut_asset)
+
+        request = UpdateAssetDto.model_validate({"dateTimeOriginal": None})
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            await update_asset(
+                sample_uuid,
+                request,
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+        mock_client.assets.update_asset.assert_awaited_once_with(
+            uuid_to_gumnut_asset_id(sample_uuid), original_datetime=None
+        )
+
+    @pytest.mark.anyio
+    async def test_update_asset_invalid_datetime_is_422(
+        self, sample_uuid, mock_current_user
+    ):
+        mock_client = Mock()
+        mock_client.assets.update_asset = AsyncMock()
+
+        request = UpdateAssetDto(dateTimeOriginal="not-a-datetime")
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            with pytest.raises(HTTPException) as exc_info:
+                await update_asset(
+                    sample_uuid,
+                    request,
+                    client=mock_client,
+                    current_user=mock_current_user,
+                )
+
+        assert exc_info.value.status_code == 422
+        mock_client.assets.update_asset.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_update_asset_empty_payload_no_sdk_call(
+        self, sample_uuid, sample_gumnut_asset, mock_current_user
+    ):
+        # Empty DTO + retrieve path: asset is fetched via get_asset_info, no
+        # PATCH is sent, no websocket fires.
+        sample_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
+        mock_client = Mock()
+        mock_client.assets.update_asset = AsyncMock()
+        mock_client.assets.retrieve = AsyncMock(return_value=sample_gumnut_asset)
+
+        request = UpdateAssetDto()
+
+        with patch(
+            "routers.api.assets.emit_user_event", new_callable=AsyncMock
+        ) as mock_emit:
+            result = await update_asset(
+                sample_uuid,
+                request,
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+        mock_client.assets.update_asset.assert_not_awaited()
+        mock_client.assets.retrieve.assert_awaited_once_with(
+            uuid_to_gumnut_asset_id(sample_uuid)
+        )
+        mock_emit.assert_not_awaited()
+        assert result.id == str(sample_uuid)
+
+    @pytest.mark.anyio
+    async def test_update_asset_out_of_scope_fields_no_sdk_call(
+        self, sample_uuid, sample_gumnut_asset, mock_current_user
+    ):
+        # Out-of-scope fields (favorite/rating/visibility/livePhotoVideoId)
+        # by themselves don't trigger a PATCH — the request still succeeds
+        # via the retrieve path so client UIs don't show errors.
+        sample_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
+        mock_client = Mock()
+        mock_client.assets.update_asset = AsyncMock()
+        mock_client.assets.retrieve = AsyncMock(return_value=sample_gumnut_asset)
+
+        request = UpdateAssetDto(
+            isFavorite=True,
+            rating=5.0,
+            visibility=AssetVisibility.archive,
+            livePhotoVideoId=uuid4(),
+        )
+
+        with patch(
+            "routers.api.assets.emit_user_event", new_callable=AsyncMock
+        ) as mock_emit:
+            await update_asset(
+                sample_uuid,
+                request,
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+        mock_client.assets.update_asset.assert_not_awaited()
+        mock_emit.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_update_asset_out_of_scope_fields_ignored_when_mixed(
+        self, sample_uuid, sample_gumnut_asset, mock_current_user
+    ):
+        # When a mix of in-scope and out-of-scope fields is sent, only the
+        # in-scope kwargs reach the SDK.
+        sample_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
+        mock_client = Mock()
+        mock_client.assets.update_asset = AsyncMock(return_value=sample_gumnut_asset)
+
+        request = UpdateAssetDto(
+            description="caption",
+            isFavorite=True,
+            rating=4.0,
+        )
+
+        with patch("routers.api.assets.emit_user_event", new_callable=AsyncMock):
+            await update_asset(
+                sample_uuid,
+                request,
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+        mock_client.assets.update_asset.assert_awaited_once_with(
+            uuid_to_gumnut_asset_id(sample_uuid), description="caption"
+        )
+
+    @pytest.mark.anyio
+    async def test_update_asset_emits_websocket_event(
+        self, sample_uuid, sample_gumnut_asset, mock_current_user
+    ):
+        sample_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
+        mock_client = Mock()
+        mock_client.assets.update_asset = AsyncMock(return_value=sample_gumnut_asset)
+
+        request = UpdateAssetDto(description="new caption")
+
+        with patch(
+            "routers.api.assets.emit_user_event", new_callable=AsyncMock
+        ) as mock_emit:
+            result = await update_asset(
+                sample_uuid,
+                request,
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+        # Payload is the converted AssetResponseDto, not a bare ID string —
+        # matches upstream Immich + the web client signature.
+        mock_emit.assert_awaited_once_with(
+            WebSocketEvent.ASSET_UPDATE, str(mock_current_user.id), result
+        )
+
+
 class TestDeleteAssets:
     """Test the delete_assets endpoint.
 
@@ -1395,32 +1820,6 @@ class TestRunAssetJobs:
 
         # Assert
         assert result.status_code == 204
-
-
-class TestUpdateAsset:
-    """Test the update_asset endpoint."""
-
-    @pytest.mark.anyio
-    async def test_update_asset_success(
-        self, sample_gumnut_asset, sample_uuid, mock_current_user
-    ):
-        """Test successful asset update (calls get_asset_info)."""
-        # Setup - create mock client
-        mock_client = Mock()
-        mock_client.assets.retrieve = AsyncMock(return_value=sample_gumnut_asset)
-
-        request = UpdateAssetDto(isFavorite=True)
-
-        # Execute
-        result = await update_asset(
-            sample_uuid, request, client=mock_client, current_user=mock_current_user
-        )
-
-        # Assert
-        # Should return a converted AssetResponseDto from get_asset_info
-        assert hasattr(result, "id")
-        assert hasattr(result, "deviceAssetId")
-        mock_client.assets.retrieve.assert_called_once()
 
 
 class TestGetAssetInfo:

--- a/tests/unit/utils/test_cdn_client.py
+++ b/tests/unit/utils/test_cdn_client.py
@@ -34,7 +34,7 @@ class TestStreamFromCdn:
         """Test successful CDN streaming."""
         cdn_response = mock_cdn_response(200)
         mock_client = AsyncMock()
-        mock_client.build_request.return_value = Mock()
+        mock_client.build_request = Mock(return_value=Mock())
         mock_client.send = AsyncMock(return_value=cdn_response)
 
         with patch(
@@ -59,7 +59,7 @@ class TestStreamFromCdn:
         """
         cdn_response = mock_cdn_response(200)
         mock_client = AsyncMock()
-        mock_client.build_request.return_value = Mock()
+        mock_client.build_request = Mock(return_value=Mock())
         mock_client.send = AsyncMock(return_value=cdn_response)
 
         with patch(
@@ -85,7 +85,7 @@ class TestStreamFromCdn:
             },
         )
         mock_client = AsyncMock()
-        mock_client.build_request.return_value = Mock()
+        mock_client.build_request = Mock(return_value=Mock())
         mock_client.send = AsyncMock(return_value=cdn_response)
 
         with patch(
@@ -114,7 +114,7 @@ class TestStreamFromCdn:
         """Test CDN 403 is mapped to adapter 404."""
         cdn_response = mock_cdn_response(403)
         mock_client = AsyncMock()
-        mock_client.build_request.return_value = Mock()
+        mock_client.build_request = Mock(return_value=Mock())
         mock_client.send = AsyncMock(return_value=cdn_response)
 
         with patch(
@@ -133,7 +133,7 @@ class TestStreamFromCdn:
         """Test CDN 404 is mapped to adapter 404."""
         cdn_response = mock_cdn_response(404)
         mock_client = AsyncMock()
-        mock_client.build_request.return_value = Mock()
+        mock_client.build_request = Mock(return_value=Mock())
         mock_client.send = AsyncMock(return_value=cdn_response)
 
         with patch(
@@ -152,7 +152,7 @@ class TestStreamFromCdn:
         """Test CDN 416 Range Not Satisfiable is passed through as 416."""
         cdn_response = mock_cdn_response(416)
         mock_client = AsyncMock()
-        mock_client.build_request.return_value = Mock()
+        mock_client.build_request = Mock(return_value=Mock())
         mock_client.send = AsyncMock(return_value=cdn_response)
 
         with patch(
@@ -184,7 +184,7 @@ class TestStreamFromCdn:
             },
         )
         mock_client = AsyncMock()
-        mock_client.build_request.return_value = Mock()
+        mock_client.build_request = Mock(return_value=Mock())
         mock_client.send = AsyncMock(return_value=cdn_response)
 
         with patch(
@@ -214,7 +214,7 @@ class TestStreamFromCdn:
             },
         )
         mock_client = AsyncMock()
-        mock_client.build_request.return_value = Mock()
+        mock_client.build_request = Mock(return_value=Mock())
         mock_client.send = AsyncMock(return_value=cdn_response)
 
         with patch(
@@ -237,7 +237,7 @@ class TestStreamFromCdn:
         """Test CDN 5xx is mapped to adapter 502."""
         cdn_response = mock_cdn_response(502)
         mock_client = AsyncMock()
-        mock_client.build_request.return_value = Mock()
+        mock_client.build_request = Mock(return_value=Mock())
         mock_client.send = AsyncMock(return_value=cdn_response)
 
         with patch(
@@ -256,7 +256,7 @@ class TestStreamFromCdn:
         """Test CDN 429 is mapped to adapter 502 (never expose 429 to Immich clients)."""
         cdn_response = mock_cdn_response(429)
         mock_client = AsyncMock()
-        mock_client.build_request.return_value = Mock()
+        mock_client.build_request = Mock(return_value=Mock())
         mock_client.send = AsyncMock(return_value=cdn_response)
 
         with patch(
@@ -276,7 +276,7 @@ class TestStreamFromCdn:
         import httpx
 
         mock_client = AsyncMock()
-        mock_client.build_request.return_value = Mock()
+        mock_client.build_request = Mock(return_value=Mock())
         mock_client.send = AsyncMock(
             side_effect=httpx.ConnectError("Connection refused")
         )

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-04-30T17:56:03.350994Z"
+exclude-newer = "2026-05-04T21:08:21.959584Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -302,7 +302,7 @@ wheels = [
 
 [[package]]
 name = "gumnut-sdk"
-version = "0.91.0"
+version = "0.95.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -312,9 +312,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/f9/5e263c9a79fc19f58b059c18fcadb84d86068578bee8ed52e53c883e7b7d/gumnut_sdk-0.91.0.tar.gz", hash = "sha256:a2bea97a736ef4bbce024872ebc7ab8ddd4b219d89691ee20881424c3542cd6d", size = 288238, upload-time = "2026-05-13T17:33:36.574Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/5a/eff08dee3a1b18790e783b29e17c45fdbfe62b27ae329a1a755fb6e152a7/gumnut_sdk-0.95.0.tar.gz", hash = "sha256:6155a8e933079fb782d2a509943475f3866e19341769caa0bac5eb986a33e890", size = 291383, upload-time = "2026-05-18T19:26:50.169Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/d3/cfccc60881ccc39235664cb6b8b30d9b89c616b8725e9efd617985f48e2b/gumnut_sdk-0.91.0-py3-none-any.whl", hash = "sha256:24b2895126efccd0cc4c809f9253ef8823d48c4415e14c6f381b8f090c220c47", size = 160223, upload-time = "2026-05-13T17:33:35.245Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5d/36a12de0f40ac42a91ea9b1d8917b2f3271dcdf5b5ab08977f7fe1cb18cf/gumnut_sdk-0.95.0-py3-none-any.whl", hash = "sha256:4d4b323e91d8e344c4b7e4528ee568f9c1c6e2c83bd4e12bc3a6909f3728c576", size = 163091, upload-time = "2026-05-18T19:26:48.803Z" },
 ]
 
 [[package]]
@@ -407,7 +407,7 @@ dev = [
 requires-dist = [
     { name = "cryptography", specifier = ">=46.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.2" },
-    { name = "gumnut-sdk", specifier = ">=0.90.0" },
+    { name = "gumnut-sdk", specifier = ">=0.92.0" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "python-socketio", specifier = ">=5.13.0" },


### PR DESCRIPTION
## Summary

- Replaces the no-op `PUT /api/assets/{id}` stub with a real call to the Photos API `update_asset` PATCH; forwards `description`, paired `latitude` + `longitude`, and `dateTimeOriginal`. Out-of-scope DTO fields (`isFavorite`, `rating`, `visibility`, `livePhotoVideoId`) are silently ignored — request still succeeds, the adapter just doesn't act on parts the Photos API doesn't model. Bulk `PUT /api/assets` remains stubbed pending a backend bulk contract.
- Adds `WebSocketEvent.ASSET_UPDATE = "on_asset_update"` and emits it after a successful PATCH carrying the full converted `AssetResponseDto` — matches upstream Immich's emission shape and the web client signature `(asset: AssetResponseDto) => void`, so the web timeline manager can upsert on receipt.
- Adapter-side 422 validation: paired lat/lon (half-set or half-cleared) and invalid `dateTimeOriginal` short-circuit before the network call. Uses `model_fields_set` (Pydantic v2) to distinguish "field omitted" from "field explicitly null" — necessary because the DTO defaults every field to `None`.
- SDK floor bumped from `>=0.90.0` to `>=0.92.0` (resolves to 0.95.0). The backend PATCH returns the freshly-merged asset, so single-asset edits drop from 2 round-trips to 1.
- Docs synced: `adapter-architecture.md` Assets row, `websocket-implementation.md` (event moved from "Not Applicable" → Phase 1 supported), `websocket-events-reference.md` (trigger now disambiguates upstream sidecar processing vs. adapter direct edits). `code-practices.md` gains a new "Omit vs explicit-null" section documenting the `model_fields_set` pattern, and the "Implementing New Endpoints" checklist now includes the two websocket docs when a new event is emitted.

## Known gap (out of scope — tracked separately)

The Immich **mobile** client sends date, location, favorite, and visibility edits through the **bulk** endpoint `PUT /api/assets` (with `ids: [singleId]` even for single-asset edits) — confirmed in `immich/mobile/lib/repositories/asset_api.repository.dart`. This PR wires the single-asset endpoint only. The bulk endpoint stays a no-op stub until the backend bulk contract is settled.

Concretely, with this PR:

| Field | Web | Mobile |
|------|-----|--------|
| Description | ✅ single endpoint | ✅ single endpoint |
| Date / time | ✅ single asset; ❌ multi-select (bulk) | ❌ bulk |
| Location (lat/lon) | ✅ single asset; ❌ multi-select (bulk) | ❌ bulk |
| Rating | (out of scope) | ✅ single endpoint, ignored adapter-side |
| Favorite / visibility | (out of scope) | ❌ bulk |

Web users editing a single asset are fully covered. Mobile users editing description are covered; mobile users editing date/location see the UI update optimistically but the change does not persist. This matches what the issue body carved out explicitly. The user-visible mobile impact is broader than "multi-select flows" — flagged on the separate bulk ticket.

## Test plan

- [x] `uv run ruff format && uv run ruff check && uv run pyright && uv run pytest` — all green (915 passed)
- [x] CI passing
- New unit tests cover: each in-scope field round-trip; description clear via null; description="" forwarded (backend rejects); paired lat/lon validation in both directions; both-null clears coords; datetime parsing (with offset / Z / naive / invalid → 422 / null → clear); empty payload skips the SDK; out-of-scope-only payload skips the SDK; mixed in/out-of-scope payload sends only in-scope kwargs; `ASSET_UPDATE` websocket emit carries the full DTO.
- [x] Immich web single-asset "Edit date and time" modal changes the date and the photo moves in the timeline. (verified)
- [ ] Immich web description field on the asset detail panel persists across reloads.
- [ ] Immich web map drag / location-edit flow (single asset) updates lat/lon.
- [ ] Immich mobile "edit description" — works (single endpoint).
- [ ] Immich mobile "edit date" / "edit location" — known no-op until bulk endpoint lands; not gated by this PR.

Generated by an AI coding agent.