### PR TITLE
Defer on_upload_success for video uploads to let thumbnails materialize

### DIFF
--- a/docs/architecture/websocket-implementation.md
+++ b/docs/architecture/websocket-implementation.md
@@ -1,6 +1,6 @@
 ---
 title: "WebSocket Implementation Documentation for immich-adapter"
-last-updated: 2026-05-18
+last-updated: 2026-05-22
 ---
 
 # WebSocket Implementation Documentation for immich-adapter
@@ -160,8 +160,8 @@ Starting with `on_upload_success`, but designed for future extension:
 
 | Event | Payload | Web | Mobile | Notes |
 |---|---|---|---|---|
-| `on_upload_success` | `AssetResponseDto` | Yes | Legacy | photos-api thumbnails are synchronous |
-| `AssetUploadReadyV1` | `SyncAssetV1` + `SyncAssetExifV1` | No | v2 sync | Emit alongside `on_upload_success` |
+| `on_upload_success` | `AssetResponseDto` | Yes | Legacy | Images: emitted synchronously (CDN resizes the original — variants ready at upload time). Videos: emission deferred by `_VIDEO_EMIT_DELAY_SECONDS` (3s) in `routers/api/assets.py` so the still-image `derived_path` has time to materialize before the web client tries to render `/api/assets/{id}/thumbnail` — otherwise the timeline card shows "Error loading image" until refresh. |
+| `AssetUploadReadyV1` | `SyncAssetV1` + `SyncAssetExifV1` | No | v2 sync | Emit alongside `on_upload_success` (shares the video deferral above) |
 | `on_asset_delete` | `string` (assetId) | Yes | Yes | One per id; force=true permanent delete |
 | `on_asset_trash` | `string[]` (assetIds) | Yes | Yes | Batched per chunk; force=false soft delete |
 | `on_asset_restore` | `string[]` (assetIds) | Yes | Yes | Batched per chunk; restore from trash |

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -1,6 +1,6 @@
 ---
 title: "Code Practices"
-last-updated: 2026-05-18
+last-updated: 2026-05-22
 ---
 
 # Code Practices
@@ -341,6 +341,8 @@ await client.delete("/api/assets", body={"ids": gumnut_ids}, cast_to=type(None))
 
 For chunks that fire one event per id (e.g. `ASSET_DELETE`'s single-id wire shape), use `emit_user_event_per_id(event, user_id, payload_ids)` instead of rolling an inline `asyncio.gather(*(emit_user_event(...) for ... in chunk))` — the helper centralizes the per-id gather wave so callers don't duplicate it. Pass a generator or list of pre-stringified ids; the helper consumes the iterable once.
 
+When a change modifies **when** an existing WebSocket event fires (deferral, debounce, batching, conditional skip) — not just when adding a brand-new event — the trigger described in `docs/references/websocket-events-reference.md` and the Notes column in `docs/architecture/websocket-implementation.md`'s Phase 1 table go stale. Update both docs and bump their `last-updated` whenever the emit-timing contract changes, even if the event itself already existed. The "Implementing New Endpoints" checklist step 9 covers new emit sites; this rule covers timing changes to existing ones. The image-vs-video `on_upload_success` deferral is the canonical example — the docs had previously claimed "photos-api thumbnails are synchronous", which became false the moment videos started waiting.
+
 ### Immich Client Error Handling
 
 - **Observed behavior:** Immich mobile and web clients have no HTTP 429 (rate limit) handling. A 429 causes sync failures, broken thumbnails, and upload errors with no automatic recovery.
@@ -360,6 +362,7 @@ For chunks that fire one event per id (e.g. `ASSET_DELETE`'s single-id wire shap
 - When mocking SDK response objects whose attributes are checked for truthiness (e.g., `if asset.metadata:`), explicitly set the attribute to its expected falsy value (`mock.metadata = None`). Unset Mock attributes return a truthy `Mock` object, silently flipping the branch and producing confusing downstream errors instead of clean `None`-path coverage. Audit `Mock`-based fixtures whenever an SDK field is renamed or added — grep across `tests/` for every `Mock()` construction of the relevant entity, including shared fixtures in `tests/conftest.py` and `tests/unit/api/sync/conftest.py` AND per-file inline mocks. Missing one is enough to silently flip a downstream Pydantic validation result.
 - The same audit applies to any code change that introduces a **new branching predicate** on an SDK attribute that previously didn't matter (e.g., adding `if asset.mime_type.startswith("video/"):` to a helper). Unset Mock attributes will satisfy `.startswith(...)` (returns a truthy `Mock`), `==` (matches another `Mock`), and most other predicates — silently making every existing fixture take the new branch. Helper-based fixtures (e.g., `_make_mock_asset_with_urls`) should grow an explicit kwarg for the newly-branched attribute (with a realistic default that matches the fixture's stated shape), and existing call sites whose `asset_urls` describe video MIME should pass `mime_type="video/mp4"` to pin the realistic call path. Without this, a future refactor that flips a constant (e.g., adding `"original"` to a "video-only variants" set) can silently break video playback without any test failing.
 - Do not add `__init__.py` to test directories — the project uses pytest's rootdir-based import resolution. Adding `__init__.py` switches pytest to package-based imports, breaking test discovery.
+- When code under test sleeps on a module-level delay/timeout constant (e.g., `_VIDEO_EMIT_DELAY_SECONDS` in `routers/api/assets.py`), **every** test that exercises the delayed path must patch the constant to a near-zero value (typically `0.0`) — not just the test that explicitly asserts on the deferral. Tests that only touch the delayed path incidentally (drains, end-of-test cleanup, error-path coverage) silently wait the real delay otherwise, ballooning suite runtime. Use `patch("module.path._CONSTANT_NAME", 0.0)` inside the same `with` block as the other mocks so the patch covers the spawned task's lifetime. When adding a new delay constant, grep tests for every call site that reaches it and audit each test for an explicit patch — `tests/unit/api/test_assets.py::test_upload_regular_video_proceeds` and `test_video_upload_defers_websocket_events` are the canonical pattern.
 
 ## Logging
 

--- a/docs/references/websocket-events-reference.md
+++ b/docs/references/websocket-events-reference.md
@@ -1,6 +1,6 @@
 ---
 title: "Immich WebSocket Events Reference"
-last-updated: 2026-05-18
+last-updated: 2026-05-22
 ---
 
 # Immich WebSocket Events Reference
@@ -33,7 +33,12 @@ This document describes the WebSocket events emitted by the Immich server and ho
 
 ### `on_upload_success`
 
-**Trigger**: Emitted when `AssetGenerateThumbnails` job completes (`job.service.ts:343-366`).
+**Upstream trigger**: Emitted when `AssetGenerateThumbnails` job completes (`job.service.ts:343-366`).
+
+**Adapter trigger**:
+- **Images**: emitted synchronously from the upload handler. Image variants (`thumbnail`, `preview`, `fullsize`) are CDN-resized URLs to the same uploaded file, so they're available the moment the upload write completes.
+- **Videos**: emission is **deferred** by `_VIDEO_EMIT_DELAY_SECONDS` (3.0s, defined in `routers/api/assets.py`) via a detached `asyncio.create_task`. Video still-image variants (`thumbnail_image`, `preview_image`, `fullsize_image`) live at a separate `derived_path` that only exists after photos-api's ffmpeg extraction finishes — without the delay, the Immich web client receives `on_upload_success`, inserts the asset into the timeline grid, then renders "Error loading image" because the thumbnail URL still 404s. The HTTP `POST /api/assets` 201 response is **not** delayed; only the WebSocket emission waits.
+
 **Sent to**: Asset owner (by userId)
 **Payload**: Full `AssetResponseDto`
 

--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -1,3 +1,4 @@
+import asyncio
 from itertools import batched
 from typing import Any, List, Literal, NamedTuple, cast
 from uuid import UUID, uuid4
@@ -289,11 +290,24 @@ def _extract_upload_fields(fields: dict[str, str]) -> UploadFields:
     return UploadFields(device_asset_id, device_id, file_created_at, file_modified_at)
 
 
-async def _emit_upload_events(
+# Delay applied before emitting upload-success events for video uploads, to give
+# photos-api time to extract the still-image variants (`thumbnail_image`,
+# `preview_image`, `fullsize_image`) before the Immich web client tries to render
+# the thumbnail. Image uploads emit immediately — their CDN-resized variants are
+# available the moment the file is written. Tune this constant if telemetry shows
+# the typical extraction time has drifted.
+_VIDEO_EMIT_DELAY_SECONDS = 3.0
+
+# Strong refs for in-flight delayed-emit tasks. asyncio only holds weak refs to
+# `create_task` results; without this set the GC can collect a sleeping task.
+_pending_emit_tasks: set[asyncio.Task[None]] = set()
+
+
+async def _do_emit_upload_events(
     gumnut_asset: AssetResponse,
     current_user: UserResponseDto,
 ) -> None:
-    """Emit WebSocket events after a successful upload."""
+    """Emit the UPLOAD_SUCCESS + ASSET_UPLOAD_READY_V1 WebSocket events."""
     try:
         asset_response = convert_gumnut_asset_to_immich(gumnut_asset, current_user)
         await emit_user_event(
@@ -312,6 +326,40 @@ async def _emit_upload_events(
                 "error": str(ws_error),
             },
         )
+
+
+async def _delayed_emit_upload_events(
+    gumnut_asset: AssetResponse,
+    current_user: UserResponseDto,
+    delay_seconds: float,
+) -> None:
+    """Sleep, then emit upload events. Used for videos to wait out thumbnail extraction."""
+    await asyncio.sleep(delay_seconds)
+    await _do_emit_upload_events(gumnut_asset, current_user)
+
+
+async def _emit_upload_events(
+    gumnut_asset: AssetResponse,
+    current_user: UserResponseDto,
+) -> None:
+    """Emit WebSocket events after a successful upload.
+
+    Images emit synchronously. Videos defer emission by `_VIDEO_EMIT_DELAY_SECONDS`
+    via a detached background task — the HTTP response is not blocked, but the
+    Immich web client's timeline insertion (triggered by `on_upload_success`) waits
+    until video thumbnail extraction has had a chance to complete.
+    """
+    if gumnut_asset.mime_type.startswith("video/"):
+        task = asyncio.create_task(
+            _delayed_emit_upload_events(
+                gumnut_asset, current_user, _VIDEO_EMIT_DELAY_SECONDS
+            )
+        )
+        _pending_emit_tasks.add(task)
+        task.add_done_callback(_pending_emit_tasks.discard)
+        return
+
+    await _do_emit_upload_events(gumnut_asset, current_user)
 
 
 @router.post(

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -644,9 +644,12 @@ class TestUploadAsset:
         request = _make_mock_request(mock_file=mock_file)
         settings = _make_mock_settings()
 
+        from routers.api.assets import _pending_emit_tasks
+
         with (
             patch("routers.api.assets.is_live_photo_video", return_value=False),
             patch("routers.api.assets.emit_user_event", new_callable=AsyncMock),
+            patch("routers.api.assets._VIDEO_EMIT_DELAY_SECONDS", 0.0),
         ):
             result = await upload_asset(
                 request=request,
@@ -655,17 +658,15 @@ class TestUploadAsset:
                 settings=settings,
             )
 
-        assert isinstance(result, AssetMediaResponseDto)
-        assert result.id == str(sample_uuid)
-        assert result.status == AssetMediaStatus.created
-        mock_client.assets.with_raw_response.create.assert_called_once()
+            assert isinstance(result, AssetMediaResponseDto)
+            assert result.id == str(sample_uuid)
+            assert result.status == AssetMediaStatus.created
+            mock_client.assets.with_raw_response.create.assert_called_once()
 
-        # Drain the deferred-emit task spawned for the video upload so it
-        # doesn't outlive the test with patched mocks still in effect.
-        from routers.api.assets import _pending_emit_tasks
-
-        if _pending_emit_tasks:
-            await asyncio.gather(*list(_pending_emit_tasks))
+            # Drain the deferred-emit task spawned for the video upload so it
+            # completes inside the patched-mocks scope.
+            if _pending_emit_tasks:
+                await asyncio.gather(*list(_pending_emit_tasks))
 
     @pytest.mark.anyio
     async def test_video_upload_defers_websocket_events(

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -1,5 +1,6 @@
 """Tests for assets.py endpoints."""
 
+import asyncio
 import json
 
 import pytest
@@ -658,6 +659,87 @@ class TestUploadAsset:
         assert result.id == str(sample_uuid)
         assert result.status == AssetMediaStatus.created
         mock_client.assets.with_raw_response.create.assert_called_once()
+
+        # Drain the deferred-emit task spawned for the video upload so it
+        # doesn't outlive the test with patched mocks still in effect.
+        from routers.api.assets import _pending_emit_tasks
+
+        if _pending_emit_tasks:
+            await asyncio.gather(*list(_pending_emit_tasks))
+
+    @pytest.mark.anyio
+    async def test_video_upload_defers_websocket_events(
+        self, sample_uuid, mock_current_user
+    ):
+        """Video uploads defer WebSocket emission until after the configured delay."""
+        mock_gumnut_asset = Mock()
+        mock_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
+        mock_gumnut_asset.checksum = "abc123"
+        mock_gumnut_asset.original_file_name = "video.mp4"
+        mock_gumnut_asset.created_at = datetime.now(timezone.utc)
+        mock_gumnut_asset.updated_at = datetime.now(timezone.utc)
+        mock_gumnut_asset.local_datetime = mock_gumnut_asset.created_at
+        mock_gumnut_asset.file_created_at = mock_gumnut_asset.created_at
+        mock_gumnut_asset.file_modified_at = mock_gumnut_asset.updated_at
+        mock_gumnut_asset.mime_type = "video/mp4"
+        mock_gumnut_asset.width = 1920
+        mock_gumnut_asset.height = 1080
+        mock_gumnut_asset.file_size_bytes = 10240
+        mock_gumnut_asset.metadata = None
+        mock_gumnut_asset.people = []
+        mock_gumnut_asset.trashed_at = None
+
+        mock_raw_response = Mock()
+        mock_raw_response.status_code = 201
+        mock_raw_response.parse = AsyncMock(return_value=mock_gumnut_asset)
+
+        mock_client = Mock()
+        mock_client.assets.with_raw_response.create = AsyncMock(
+            return_value=mock_raw_response
+        )
+
+        mock_file = Mock()
+        mock_file.filename = "video.mp4"
+        mock_file.content_type = "video/mp4"
+        mock_file.file = BytesIO(b"fake video data")
+        mock_file.seek = AsyncMock()
+
+        request = _make_mock_request(mock_file=mock_file)
+        settings = _make_mock_settings()
+
+        from routers.api.assets import _pending_emit_tasks
+
+        with (
+            patch("routers.api.assets.is_live_photo_video", return_value=False),
+            patch(
+                "routers.api.assets.emit_user_event", new_callable=AsyncMock
+            ) as mock_emit,
+            patch("routers.api.assets._VIDEO_EMIT_DELAY_SECONDS", 0.0),
+        ):
+            await upload_asset(
+                request=request,
+                client=mock_client,
+                current_user=mock_current_user,
+                settings=settings,
+            )
+
+            # Emission is deferred — nothing fired before we yield to the loop.
+            assert mock_emit.call_count == 0
+            assert len(_pending_emit_tasks) == 1
+
+            await asyncio.gather(*list(_pending_emit_tasks))
+
+            assert mock_emit.call_count == 2
+            first_call = mock_emit.call_args_list[0]
+            assert first_call[0][0] == WebSocketEvent.UPLOAD_SUCCESS
+            assert first_call[0][1] == mock_current_user.id
+
+            second_call = mock_emit.call_args_list[1]
+            assert second_call[0][0] == WebSocketEvent.ASSET_UPLOAD_READY_V1
+            assert second_call[0][1] == mock_current_user.id
+
+            # done_callback drops the completed task from the strong-ref set.
+            assert len(_pending_emit_tasks) == 0
 
     @pytest.mark.anyio
     async def test_upload_asset_websocket_error_does_not_fail_upload(


### PR DESCRIPTION
## What
- Defer `UPLOAD_SUCCESS` and `ASSET_UPLOAD_READY_V1` WebSocket emission for **video** uploads by `_VIDEO_EMIT_DELAY_SECONDS` (3.0s) via a detached `asyncio.create_task`. Images keep emitting synchronously.
- HTTP `POST /api/assets` response is **not** delayed — clients still receive their 201 immediately.
- Strong-ref `set[asyncio.Task]` holds in-flight delayed-emit tasks (asyncio only keeps weak refs to `create_task` results); `add_done_callback` cleans them up.
- Update both websocket docs to call out the new image-vs-video asymmetry and replace the stale "photos-api thumbnails are synchronous" note.
- Add two `code-practices.md` testing/emission rules surfaced during self-review.

## Why
The Immich web client only inserts a freshly-uploaded asset into the timeline grid when it receives `on_upload_success` — never directly from the HTTP response. The adapter was firing that event the moment the upload write completed, before photos-api's ffmpeg job had extracted the video's still-image variants (`thumbnail_image` / `preview_image` / `fullsize_image`). The client's `<img>` request to `/api/assets/{id}/thumbnail` then 404'd, leaving "Error loading image" in the grid until refresh.

Images don't hit this race because their `thumbnail` / `preview` / `fullsize` variants are CDN-resized URLs to the same uploaded file — populated synchronously at upload time.

A small fixed delay handles the common case (drag-and-drop in the web client typically resolves in well under 3s) at a tiny fraction of the complexity an aggregated poller would have required. Long / 4K video extractions that exceed the delay still hit the original race — **same behavior as today's worst case, not a regression**. If telemetry shows that matters, escalate to a poller design later.

## Linear
<https://linear.app/gumnut-ai/issue/GUM-877/video-uploads-show-error-loading-image-in-immich-web-until-refresh>

## Test plan
- [x] `uv run pytest` — full suite green (920 passing).
- [x] `uv run ruff check`, `uv run ruff format`, `uv run pyright` — clean.
- [x] New unit test `test_video_upload_defers_websocket_events` patches `_VIDEO_EMIT_DELAY_SECONDS=0`, asserts `mock_emit.call_count == 0` immediately after `upload_asset` returns, then drains the spawned task and asserts both events fire and the strong-ref set drains.
- [x] Existing `test_upload_regular_video_proceeds` patches the delay to 0 so the suite doesn't sleep the full 3s on every run.
- [ ] **Manual**: drag-and-drop a video in the Immich web client against a deployed adapter and confirm the timeline grid card shows the correct thumbnail without an intermediate "Error loading image" state and without page refresh.
- [ ] **Manual**: drag-and-drop an image and confirm there is no perceivable regression in how quickly it appears in the grid.
- [ ] **Post-deploy**: watch for support reports of long / 4K videos still hitting the bug — that's the escalation signal for the poller design.

Generated by an AI coding agent.