### PR TITLE
Handle ClientDisconnect on asset upload instead of 500

### DIFF
--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -19,6 +19,7 @@ from fastapi import (
     status,
 )
 from fastapi.responses import JSONResponse, StreamingResponse
+from starlette.requests import ClientDisconnect
 from gumnut import AsyncGumnut
 from gumnut.types.asset_response import AssetResponse
 
@@ -73,6 +74,12 @@ from utils.livephoto import is_live_photo_video
 from routers.immich_models import AssetTypeEnum
 
 logger = logging.getLogger(__name__)
+
+# Non-standard status used when the client hangs up mid-upload. The response is
+# never delivered (the socket is already closed) — it exists only to give the
+# handler a well-defined return instead of letting ClientDisconnect escape as an
+# unhandled 500.
+HTTP_499_CLIENT_CLOSED_REQUEST = 499
 
 router = APIRouter(
     prefix="/api/assets",
@@ -376,12 +383,27 @@ async def upload_asset(
         },
     )
 
-    if use_streaming:
-        return await _upload_streaming(
-            request, client, current_user, settings.gumnut_api_base_url
+    try:
+        if use_streaming:
+            return await _upload_streaming(
+                request, client, current_user, settings.gumnut_api_base_url
+            )
+        else:
+            return await _upload_buffered(request, client, current_user)
+    except ClientDisconnect:
+        # The client hung up before finishing the upload (mobile backgrounding,
+        # cancel, network blip). The connection is gone, so there's no one to
+        # receive a response — treat it as a normal aborted upload rather than
+        # letting it surface as an unhandled 500.
+        logger.info(
+            "Client disconnected during %s upload before it completed",
+            strategy,
+            extra={"strategy": strategy},
         )
-    else:
-        return await _upload_buffered(request, client, current_user)
+        return JSONResponse(
+            content={"detail": "Client disconnected before upload completed"},
+            status_code=HTTP_499_CLIENT_CLOSED_REQUEST,
+        )
 
 
 async def _upload_buffered(
@@ -559,6 +581,10 @@ async def _upload_streaming(
         )
 
     except HTTPException:
+        raise
+    except ClientDisconnect:
+        # Let the disconnect propagate to upload_asset's handler instead of
+        # mapping it to a 500/502 — the client is already gone.
         raise
     except (ValueError, ValidationError) as e:
         raise HTTPException(

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -500,6 +500,34 @@ class TestUploadAsset:
         assert exc_info.value.status_code == 401
 
     @pytest.mark.anyio
+    async def test_upload_asset_buffered_client_disconnect(self, mock_current_user):
+        """A mid-upload client disconnect on the buffered path returns 499 instead
+        of escaping as an unhandled 500."""
+        from starlette.requests import ClientDisconnect
+
+        mock_client = Mock()
+        mock_client.assets.with_raw_response.create = AsyncMock()
+
+        request = _make_mock_request()
+        # Starlette raises ClientDisconnect from request.form() when the client
+        # hangs up while the multipart body is still being parsed.
+        form_ctx = AsyncMock()
+        form_ctx.__aenter__ = AsyncMock(side_effect=ClientDisconnect())
+        request.form = Mock(return_value=form_ctx)
+        settings = _make_mock_settings()
+
+        result = await upload_asset(
+            request=request,
+            client=mock_client,
+            current_user=mock_current_user,
+            settings=settings,
+        )
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 499
+        mock_client.assets.with_raw_response.create.assert_not_called()
+
+    @pytest.mark.anyio
     async def test_upload_asset_emits_websocket_events(
         self, sample_uuid, mock_current_user
     ):
@@ -982,6 +1010,42 @@ class TestUploadAsset:
                 )
 
         assert exc_info.value.status_code == 502
+
+    @pytest.mark.anyio
+    async def test_streaming_upload_client_disconnect(self, mock_current_user):
+        """A client disconnect on the streaming path returns 499 rather than being
+        mapped to a 500/502 by the pipeline's broad error handler."""
+        from starlette.requests import ClientDisconnect
+
+        request = Mock()
+        request.headers = {
+            "content-length": str(300 * 1024 * 1024),
+            "content-type": "multipart/form-data; boundary=---abc123",
+        }
+
+        class _State:
+            jwt_token = "test-jwt-token"
+
+        request.state = _State()
+
+        settings = _make_mock_settings(threshold=100 * 1024 * 1024)
+
+        mock_pipeline_instance = Mock()
+        mock_pipeline_instance.execute = AsyncMock(side_effect=ClientDisconnect())
+
+        with patch(
+            "routers.api.assets.StreamingUploadPipeline",
+            return_value=mock_pipeline_instance,
+        ):
+            result = await upload_asset(
+                request=request,
+                client=Mock(),
+                current_user=mock_current_user,
+                settings=settings,
+            )
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 499
 
 
 class TestUpdateAssets:


### PR DESCRIPTION
## Summary

When an Immich client hangs up mid-upload (mobile backgrounding, cancel, network blip, network switch during a large upload), Starlette raises `ClientDisconnect` while parsing the multipart request body. This was surfacing as a server error even though the client is already gone:

- **Buffered path**: the disconnect escaped `request.form()` unhandled and was recorded as a 500 (`handled: no`).
- **Streaming path**: it was caught by the broad `except Exception` handler and mapped to a 500/502.

Either way the response is never delivered — the socket is already closed — so the only effect was Sentry noise and a misleadingly inflated unhandled-error rate for the adapter (0 users actually impacted).

## Changes

- Catch `ClientDisconnect` in `upload_asset` and return **499** (client closed request), logging at `info`.
- Let `_upload_streaming` propagate `ClientDisconnect` to that handler instead of mapping it to a 500/502.
- Add regression tests for both the buffered and streaming paths.

## Impact

Internal error handling only — no API-contract or client-visible behavior change (the client has already disconnected). Two-way door.

## Testing

- `uv run ruff format` / `uv run ruff check` — clean
- `uv run pyright routers/api/assets.py` — 0 errors
- `uv run pytest tests/unit` — 892 passed

Fixes Sentry `IMMICH-ADAPTER-1H`.
