### PR TITLE
Fix red main: set checksum_sha1 on video-defer upload test mock

### DIFF
--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -707,6 +707,7 @@ class TestUploadAsset:
         mock_gumnut_asset = Mock()
         mock_gumnut_asset.id = uuid_to_gumnut_asset_id(sample_uuid)
         mock_gumnut_asset.checksum = "abc123"
+        mock_gumnut_asset.checksum_sha1 = "PaDX6+c+Lhjpm5/ciXUROL1ryaU="
         mock_gumnut_asset.original_file_name = "video.mp4"
         mock_gumnut_asset.created_at = datetime.now(timezone.utc)
         mock_gumnut_asset.updated_at = datetime.now(timezone.utc)


### PR DESCRIPTION
## What

`main` is red ([failing CI run](https://github.com/gumnut-ai/immich-adapter/actions/runs/26479768581/job/77974112647)): `test_video_upload_defers_websocket_events` fails with `assert 0 == 2`.

## Why

Two changes landed close together:

- One routed the outbound REST/WebSocket asset converters through `resolve_immich_checksum()`, which reads `AssetResponse.checksum_sha1`, and updated the existing upload-test mocks to set that attribute.
- Another added the video upload-success deferral test, which builds its own `Mock()` gumnut asset.

That new test's mock was never given `checksum_sha1`. On a bare `Mock`, the attribute resolves to an auto-generated child mock (not `None`, not a `str`), which fails the converter's `str` validation. The deferred emit task catches and logs the error ("Failed to emit WebSocket event after upload"), so `emit_user_event` is never called and the assertion expecting two emits fails. Each change was green on its own branch; they only collide on `main`.

## Fix

Set `checksum_sha1` to a valid base64 SHA-1 on the deferral test's mock, mirroring the other upload tests. Restores the converter happy path.

## Test

`uv run pytest` — 928 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)