### PR TITLE
Surface video duration through the Immich adapter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.14"
 dependencies = [
     "cryptography>=46.0.0",
     "fastapi[standard]>=0.135.2",
-    "gumnut-sdk>=0.99.0",
+    "gumnut-sdk>=0.101.0",
     "pydantic-settings>=2.10.1",
     "pytest>=8.4.2",
     "python-socketio>=5.13.0",

--- a/routers/api/sync/converters.py
+++ b/routers/api/sync/converters.py
@@ -26,6 +26,7 @@ from routers.immich_models import (
 )
 from routers.utils.asset_conversion import (
     exif_dims_and_orientation,
+    format_duration,
     mime_type_to_asset_type,
     normalize_rating,
     resolve_file_created_at,
@@ -152,7 +153,7 @@ def gumnut_asset_to_sync_asset_v1(asset: AssetResponse, owner_id: str) -> SyncAs
         localDateTime=localDateTime,
         # Optional fields - use None when not available
         deletedAt=asset.trashed_at,
-        duration=None,
+        duration=format_duration(asset.duration),
         height=asset.height if asset.height else None,
         libraryId=None,
         livePhotoVideoId=None,

--- a/routers/api/timeline.py
+++ b/routers/api/timeline.py
@@ -217,8 +217,9 @@ async def get_time_bucket(
 
         is_trashed_list.append(bool(asset.trashed_at))
 
-        # None preserves this bucket's prior all-None duration behavior;
-        # format_duration owns the NULL handling and string formatting.
+        # Forward each asset's duration: format_duration returns the
+        # HH:MM:SS.ffffff string, or None on NULL upstream — preserving this
+        # bucket's prior all-None output for images / not-yet-extracted videos.
         duration_list.append(format_duration(asset.duration))
 
     # Return as dict to bypass Pydantic validation issues with None in List[str]

--- a/routers/api/timeline.py
+++ b/routers/api/timeline.py
@@ -217,8 +217,8 @@ async def get_time_bucket(
 
         is_trashed_list.append(bool(asset.trashed_at))
 
-        # Upstream NULL (image, or video not yet extracted) stays None, matching
-        # the prior all-None behavior; a real float renders HH:MM:SS.ffffff.
+        # None preserves this bucket's prior all-None duration behavior;
+        # format_duration owns the NULL handling and string formatting.
         duration_list.append(format_duration(asset.duration))
 
     # Return as dict to bypass Pydantic validation issues with None in List[str]

--- a/routers/api/timeline.py
+++ b/routers/api/timeline.py
@@ -14,6 +14,7 @@ from routers.immich_models import (
     TimeBucketsResponseDto,
 )
 from routers.utils.asset_conversion import (
+    format_duration,
     mime_type_to_asset_type,
     resolve_capture_datetime,
 )
@@ -184,6 +185,7 @@ async def get_time_bucket(
     visibility_list = []
     local_offset_hours_list = []
     is_trashed_list = []
+    duration_list: list[str | None] = []
 
     for asset in filtered_assets:
         asset_id = asset.id
@@ -215,12 +217,16 @@ async def get_time_bucket(
 
         is_trashed_list.append(bool(asset.trashed_at))
 
+        # Upstream NULL (image, or video not yet extracted) stays None, matching
+        # the prior all-None behavior; a real float renders HH:MM:SS.ffffff.
+        duration_list.append(format_duration(asset.duration))
+
     # Return as dict to bypass Pydantic validation issues with None in List[str]
     # XXX revisit this issue later
     return {
         "city": [None] * asset_count,
         "country": [None] * asset_count,
-        "duration": [None] * asset_count,
+        "duration": duration_list,
         "livePhotoVideoId": [None] * asset_count,
         "projectionType": [None] * asset_count,
         "id": asset_ids,

--- a/routers/utils/asset_conversion.py
+++ b/routers/utils/asset_conversion.py
@@ -67,6 +67,38 @@ def normalize_rating(rating: float | int | None) -> int | None:
     return None if value == -1 else value
 
 
+def format_duration(seconds: float | None) -> str | None:
+    """Format an upstream video duration (float seconds) as Immich's interval string.
+
+    Immich expresses video duration as an ``HH:MM:SS.ffffff`` string. The Gumnut
+    asset carries ``duration`` as float seconds, or ``None`` when the asset is an
+    image or its duration has not been extracted yet. Returns ``None`` for ``None``
+    so callers can preserve each emit site's existing absent-duration behavior
+    rather than fabricating a value.
+    """
+    if seconds is None:
+        return None
+    total = float(seconds)
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    return f"{int(hours):02d}:{int(minutes):02d}:{secs:09.6f}"
+
+
+def _resolve_single_asset_duration(
+    gumnut_asset: AssetResponse, asset_type: AssetTypeEnum
+) -> str:
+    """Duration string for the single-asset ``AssetResponseDto`` (non-nullable).
+
+    Uses the upstream value when present; when absent, preserves the prior
+    placeholder — zero duration for videos, empty string for images — rather
+    than fabricating a length.
+    """
+    formatted = format_duration(gumnut_asset.duration)
+    if formatted is not None:
+        return formatted
+    return "00:00:00.000000" if asset_type == AssetTypeEnum.VIDEO else ""
+
+
 def resolve_capture_datetime(gumnut_asset: AssetResponse) -> datetime:
     """Return the Photos API-resolved capture datetime for Immich timeline fields.
 
@@ -363,7 +395,7 @@ def build_asset_upload_ready_payload(
         thumbhash=None,
         checksum=resolve_immich_checksum(gumnut_asset),
         deletedAt=gumnut_asset.trashed_at,
-        duration=None,
+        duration=format_duration(gumnut_asset.duration),
         fileCreatedAt=file_created_at,
         fileModifiedAt=file_modified_at,
         height=int(height) if height else None,
@@ -433,7 +465,7 @@ def convert_gumnut_asset_to_immich(
         checksum=resolve_immich_checksum(gumnut_asset),
         exifInfo=exif_info,  # Now includes processed EXIF data
         createdAt=gumnut_asset.created_at,
-        duration="00:00:00.000000" if asset_type == AssetTypeEnum.VIDEO else "",
+        duration=_resolve_single_asset_duration(gumnut_asset, asset_type),
         hasMetadata=True,
         height=float(height) if height else None,
         isArchived=False,

--- a/routers/utils/asset_conversion.py
+++ b/routers/utils/asset_conversion.py
@@ -78,10 +78,14 @@ def format_duration(seconds: float | None) -> str | None:
     """
     if seconds is None:
         return None
-    total = float(seconds)
-    hours, remainder = divmod(total, 3600)
+    # Round to whole microseconds first, then decompose, so a value just under a
+    # minute/hour boundary (e.g. 59.9999999) carries up to 00:01:00.000000 rather
+    # than rendering an out-of-range 00:00:60.000000.
+    micros = round(float(seconds) * 1_000_000)
+    secs_total, micros = divmod(micros, 1_000_000)
+    hours, remainder = divmod(secs_total, 3600)
     minutes, secs = divmod(remainder, 60)
-    return f"{int(hours):02d}:{int(minutes):02d}:{secs:09.6f}"
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}.{micros:06d}"
 
 
 def _resolve_single_asset_duration(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,7 +104,7 @@ def sample_gumnut_asset():
     asset.updated_at = datetime.now(timezone.utc)
     asset.mime_type = "image/jpeg"
     asset.original_file_name = "test.jpg"
-    asset.duration_in_seconds = None
+    asset.duration = None
     asset.library_id = "library-789"
     asset.checksum = "abc123"
     # Base64-encoded SHA-1 (28 chars), the Immich-facing checksum format.
@@ -154,7 +154,7 @@ def multiple_gumnut_assets():
         asset.local_datetime = now
         asset.mime_type = "image/jpeg"
         asset.original_file_name = f"test{i}.jpg"
-        asset.duration_in_seconds = None
+        asset.duration = None
         asset.library_id = "library-789"
         asset.width = 1920
         asset.height = 1080

--- a/tests/unit/api/sync/conftest.py
+++ b/tests/unit/api/sync/conftest.py
@@ -155,6 +155,7 @@ def create_mock_asset_data(updated_at: datetime) -> Mock:
     asset.checksum_sha1 = "sha1checksum"
     asset.width = 1920
     asset.height = 1080
+    asset.duration = None
     asset.file_size_bytes = 1059218
     asset.metadata = None
     asset.trashed_at = None

--- a/tests/unit/api/sync/test_datetime_conversion.py
+++ b/tests/unit/api/sync/test_datetime_conversion.py
@@ -279,6 +279,7 @@ class TestGumnutAssetToSyncAssetV1DateHandling:
         asset.checksum_sha1 = "sha1checksum"
         asset.width = 1600
         asset.height = 2400
+        asset.duration = None
         asset.trashed_at = None
         # resolve_file_modified_at reads metadata.modified_datetime; without
         # an explicit None the unset Mock attribute would silently produce a

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -403,6 +403,7 @@ class TestUploadAsset:
         mock_gumnut_asset.mime_type = "image/jpeg"
         mock_gumnut_asset.width = 1920
         mock_gumnut_asset.height = 1080
+        mock_gumnut_asset.duration = None
         mock_gumnut_asset.file_size_bytes = 1024
         mock_gumnut_asset.metadata = None
         mock_gumnut_asset.people = []
@@ -549,6 +550,7 @@ class TestUploadAsset:
         mock_gumnut_asset.mime_type = "image/jpeg"
         mock_gumnut_asset.width = 1920
         mock_gumnut_asset.height = 1080
+        mock_gumnut_asset.duration = None
         mock_gumnut_asset.file_size_bytes = 1024
         mock_gumnut_asset.metadata = None
         mock_gumnut_asset.people = []
@@ -654,6 +656,7 @@ class TestUploadAsset:
         mock_gumnut_asset.mime_type = "video/mp4"
         mock_gumnut_asset.width = 1920
         mock_gumnut_asset.height = 1080
+        mock_gumnut_asset.duration = None
         mock_gumnut_asset.file_size_bytes = 10240
         mock_gumnut_asset.metadata = None
         mock_gumnut_asset.people = []
@@ -719,6 +722,7 @@ class TestUploadAsset:
         mock_gumnut_asset.mime_type = "video/mp4"
         mock_gumnut_asset.width = 1920
         mock_gumnut_asset.height = 1080
+        mock_gumnut_asset.duration = None
         mock_gumnut_asset.file_size_bytes = 10240
         mock_gumnut_asset.metadata = None
         mock_gumnut_asset.people = []
@@ -791,6 +795,7 @@ class TestUploadAsset:
         mock_gumnut_asset.mime_type = "image/jpeg"
         mock_gumnut_asset.width = 1920
         mock_gumnut_asset.height = 1080
+        mock_gumnut_asset.duration = None
         mock_gumnut_asset.file_size_bytes = 1024
         mock_gumnut_asset.metadata = None
         mock_gumnut_asset.people = []

--- a/tests/unit/api/test_memories.py
+++ b/tests/unit/api/test_memories.py
@@ -61,7 +61,7 @@ def _make_asset(asset_id_uuid: UUID, captured_at: datetime) -> Mock:
     asset.people = []
     asset.trashed_at = None
     asset.file_size_bytes = 1000
-    asset.duration_in_seconds = None
+    asset.duration = None
     asset.library_id = "library-1"
     return asset
 

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -338,6 +338,7 @@ class TestSearchMetadata:
         gumnut_asset.file_modified_at = gumnut_asset.updated_at
         gumnut_asset.width = 1920
         gumnut_asset.height = 1080
+        gumnut_asset.duration = None
         gumnut_asset.file_size_bytes = 1024000
         gumnut_asset.metadata = None
         gumnut_asset.people = []

--- a/tests/unit/api/test_timeline.py
+++ b/tests/unit/api/test_timeline.py
@@ -479,6 +479,40 @@ class TestGetTimeBucket:
             assert result["ratio"][0] == 2268 / 4032
 
     @pytest.mark.anyio
+    async def test_get_time_bucket_emits_per_asset_duration(
+        self, multiple_gumnut_assets, mock_sync_cursor_page
+    ):
+        """The bucket's ``duration`` array carries a real ``HH:MM:SS.ffffff``
+        string for a video whose upstream duration is populated, and stays
+        ``None`` for an asset whose upstream duration is NULL (image, or video
+        not yet extracted) — matching the prior all-None behavior."""
+        mock_client = Mock()
+
+        assets = multiple_gumnut_assets
+        assets[0].id = uuid_to_gumnut_asset_id(uuid4())
+        assets[0].local_datetime = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        assets[0].created_at = assets[0].local_datetime
+        assets[0].mime_type = "video/mp4"
+        assets[0].duration = 65.25
+
+        assets[1].id = uuid_to_gumnut_asset_id(uuid4())
+        assets[1].local_datetime = datetime(2024, 1, 16, 10, 0, 0, tzinfo=timezone.utc)
+        assets[1].created_at = assets[1].local_datetime
+        assets[1].mime_type = "image/jpeg"
+        assets[1].duration = None
+
+        mock_client.assets.list.return_value = mock_sync_cursor_page(assets[:2])
+
+        with patch("routers.api.timeline.get_current_user_id") as mock_user_id:
+            mock_user_id.return_value = uuid4()
+
+            result = await call_get_time_bucket(
+                timeBucket="2024-01-01T00:00:00", client=mock_client
+            )
+
+            assert result["duration"] == ["00:01:05.250000", None]
+
+    @pytest.mark.anyio
     async def test_get_time_bucket_with_album_id(
         self, multiple_gumnut_assets, mock_sync_cursor_page, sample_uuid
     ):
@@ -577,6 +611,7 @@ class TestGetTimeBucket:
         mock_asset.mime_type = "image/jpeg"
         mock_asset.width = 1920
         mock_asset.height = 1280
+        mock_asset.duration = None
 
         mock_client.assets.list.return_value = mock_sync_cursor_page([mock_asset])
 
@@ -607,6 +642,7 @@ class TestGetTimeBucket:
         mock_asset.mime_type = ""
         mock_asset.width = None
         mock_asset.height = None
+        mock_asset.duration = None
 
         mock_client.assets.list.return_value = mock_sync_cursor_page([mock_asset])
 
@@ -679,6 +715,7 @@ class TestGetTimeBucket:
         asset1.mime_type = "image/jpeg"
         asset1.width = 1920
         asset1.height = 1080
+        asset1.duration = None
         assets.append(asset1)
 
         asset2 = Mock()
@@ -690,6 +727,7 @@ class TestGetTimeBucket:
         asset2.mime_type = "image/png"
         asset2.width = 1024
         asset2.height = 768
+        asset2.duration = None
         assets.append(asset2)
 
         asset3 = Mock()
@@ -699,6 +737,7 @@ class TestGetTimeBucket:
         asset3.mime_type = "video/mp4"
         asset3.width = 3840
         asset3.height = 2160
+        asset3.duration = None
         assets.append(asset3)
 
         asset4 = Mock()
@@ -716,6 +755,7 @@ class TestGetTimeBucket:
         asset4.mime_type = "image/jpeg"
         asset4.width = 1600
         asset4.height = 1200
+        asset4.duration = None
         assets.append(asset4)
 
         mock_client.assets.list.return_value = mock_sync_cursor_page(assets)
@@ -747,6 +787,7 @@ class TestGetTimeBucket:
         asset1.mime_type = "image/jpeg"
         asset1.width = 1920
         asset1.height = 1080
+        asset1.duration = None
         assets.append(asset1)
 
         asset2 = Mock()
@@ -756,6 +797,7 @@ class TestGetTimeBucket:
         asset2.mime_type = "image/png"
         asset2.width = 1024
         asset2.height = 768
+        asset2.duration = None
         assets.append(asset2)
 
         mock_client.assets.list.return_value = mock_sync_cursor_page(assets)
@@ -787,6 +829,7 @@ class TestGetTimeBucket:
         asset1.mime_type = "image/jpeg"
         asset1.width = 1920
         asset1.height = 1080
+        asset1.duration = None
         assets.append(asset1)
 
         asset2 = Mock()
@@ -796,6 +839,7 @@ class TestGetTimeBucket:
         asset2.mime_type = "image/png"
         asset2.width = 1024
         asset2.height = 768
+        asset2.duration = None
         assets.append(asset2)
 
         asset3 = Mock()
@@ -807,6 +851,7 @@ class TestGetTimeBucket:
         asset3.mime_type = "video/mp4"
         asset3.width = 3840
         asset3.height = 2160
+        asset3.duration = None
         assets.append(asset3)
 
         asset4 = Mock()
@@ -816,6 +861,7 @@ class TestGetTimeBucket:
         asset4.mime_type = "image/jpeg"
         asset4.width = 1600
         asset4.height = 1200
+        asset4.duration = None
         assets.append(asset4)
 
         mock_client.assets.list.return_value = mock_sync_cursor_page(assets)

--- a/tests/unit/utils/test_asset_conversion.py
+++ b/tests/unit/utils/test_asset_conversion.py
@@ -506,6 +506,10 @@ class TestFormatDuration:
             (7200, "02:00:00.000000"),
             # Long clip past 24h still renders hours without wrapping.
             (90061.0, "25:01:01.000000"),
+            # Just under a minute/hour boundary must carry up, never render
+            # an out-of-range :60 seconds field.
+            (59.9999999, "00:01:00.000000"),
+            (3599.9999999, "01:00:00.000000"),
         ],
     )
     def test_formats_seconds_as_interval(self, seconds, expected):

--- a/tests/unit/utils/test_asset_conversion.py
+++ b/tests/unit/utils/test_asset_conversion.py
@@ -21,6 +21,7 @@ from routers.utils.asset_conversion import (
     convert_gumnut_asset_to_immich,
     extract_exif_info,
     extract_sync_exif,
+    format_duration,
     resolve_capture_datetime,
 )
 
@@ -485,3 +486,98 @@ class TestChecksumEmission:
             convert_gumnut_asset_to_immich(sample_gumnut_asset, mock_current_user)
 
         assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+
+
+class TestFormatDuration:
+    """``format_duration`` turns upstream float seconds into Immich's
+    ``HH:MM:SS.ffffff`` interval string, and ``None`` into ``None`` so callers
+    can preserve their existing absent-duration behavior."""
+
+    def test_none_passes_through(self):
+        assert format_duration(None) is None
+
+    @pytest.mark.parametrize(
+        "seconds, expected",
+        [
+            (0.0, "00:00:00.000000"),
+            (5.5, "00:00:05.500000"),
+            (65.25, "00:01:05.250000"),
+            (3661.5, "01:01:01.500000"),
+            (7200, "02:00:00.000000"),
+            # Long clip past 24h still renders hours without wrapping.
+            (90061.0, "25:01:01.000000"),
+        ],
+    )
+    def test_formats_seconds_as_interval(self, seconds, expected):
+        assert format_duration(seconds) == expected
+
+
+class TestDurationEmission:
+    """Every outbound converter forwards the upstream ``duration`` (float
+    seconds) as an ``HH:MM:SS.ffffff`` string. When upstream is NULL each site
+    preserves the value it emitted before this field existed — never a
+    fabricated length. Mirrors the width/height staged-rollout precedent."""
+
+    OWNER_ID = "22222222-2222-2222-2222-222222222222"
+
+    def test_rest_converter_formats_populated_duration(
+        self, sample_gumnut_asset, mock_current_user
+    ):
+        sample_gumnut_asset.mime_type = "video/mp4"
+        sample_gumnut_asset.duration = 12.5
+
+        result = convert_gumnut_asset_to_immich(sample_gumnut_asset, mock_current_user)
+
+        assert result.duration == "00:00:12.500000"
+
+    def test_websocket_payload_formats_populated_duration(self, sample_gumnut_asset):
+        sample_gumnut_asset.mime_type = "video/mp4"
+        sample_gumnut_asset.duration = 30.0
+
+        payload = build_asset_upload_ready_payload(
+            sample_gumnut_asset, owner_id=self.OWNER_ID
+        )
+
+        assert payload.asset.duration == "00:00:30.000000"
+
+    def test_sync_converter_formats_populated_duration(self, sample_gumnut_asset):
+        sample_gumnut_asset.mime_type = "video/mp4"
+        sample_gumnut_asset.duration = 30.0
+
+        result = gumnut_asset_to_sync_asset_v1(
+            sample_gumnut_asset, owner_id=self.OWNER_ID
+        )
+
+        assert result.duration == "00:00:30.000000"
+
+    def test_null_duration_preserves_prior_behavior(
+        self, sample_gumnut_asset, mock_current_user
+    ):
+        """Upstream NULL: the REST single-asset DTO keeps its zero placeholder
+        for video, while the WebSocket and sync converters keep ``None``."""
+        sample_gumnut_asset.mime_type = "video/mp4"
+        sample_gumnut_asset.duration = None
+
+        rest = convert_gumnut_asset_to_immich(sample_gumnut_asset, mock_current_user)
+        ws = build_asset_upload_ready_payload(
+            sample_gumnut_asset, owner_id=self.OWNER_ID
+        )
+        sync = gumnut_asset_to_sync_asset_v1(
+            sample_gumnut_asset, owner_id=self.OWNER_ID
+        )
+
+        assert rest.duration == "00:00:00.000000"
+        assert ws.asset.duration is None
+        assert sync.duration is None
+
+    def test_null_duration_image_emits_empty_string_in_rest_dto(
+        self, sample_gumnut_asset, mock_current_user
+    ):
+        """For images (no duration concept) the REST DTO keeps its empty-string
+        placeholder rather than the video zero or a fabricated value."""
+        sample_gumnut_asset.mime_type = "image/jpeg"
+        sample_gumnut_asset.duration = None
+
+        result = convert_gumnut_asset_to_immich(sample_gumnut_asset, mock_current_user)
+
+        assert result.duration == ""

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-05-07T22:04:11.706214Z"
+exclude-newer = "2026-05-13T17:37:12.590728Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -302,7 +302,7 @@ wheels = [
 
 [[package]]
 name = "gumnut-sdk"
-version = "0.100.0"
+version = "0.101.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -312,9 +312,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/43/2edc72e951aa1b05e54357183b8a338b85f2a7af21a359823c6b982bde34/gumnut_sdk-0.100.0.tar.gz", hash = "sha256:5524dd80ad8c32e96aed8791279427d4938a0b8f17391f22b3851eacaa89a613", size = 297152, upload-time = "2026-05-21T18:26:13.302Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/c5/a1a98416c7b259ecf6cdd3bfb9a8da55d26fe061000605992de19524bf1c/gumnut_sdk-0.101.0.tar.gz", hash = "sha256:64ac4931aea50275301d09e6e73ba90a9c69fddb4f727ce9725c063a69a17770", size = 297251, upload-time = "2026-05-27T17:26:09.804Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/80/77b73d39b881c69be738489398f5d69010e4f3854a5984c98ff7debf3d1f/gumnut_sdk-0.100.0-py3-none-any.whl", hash = "sha256:5258d86da1c4b7a6ca13c2726fe647d482f6f769e8cffdad75cbd9ecb9f643f1", size = 169358, upload-time = "2026-05-21T18:26:14.636Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b9/6fda206ee7e975e102392103789fd963092cdf979d6628c490a208629210/gumnut_sdk-0.101.0-py3-none-any.whl", hash = "sha256:32068fae858a5967cb49cb0e4af1f2046f48a6fa11295201a222fc6a18f03011", size = 169409, upload-time = "2026-05-27T17:26:11.198Z" },
 ]
 
 [[package]]
@@ -407,7 +407,7 @@ dev = [
 requires-dist = [
     { name = "cryptography", specifier = ">=46.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.2" },
-    { name = "gumnut-sdk", specifier = ">=0.99.0" },
+    { name = "gumnut-sdk", specifier = ">=0.101.0" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "python-socketio", specifier = ">=5.13.0" },


### PR DESCRIPTION
## What
- Forward the upstream nullable float-seconds `duration` (asset response, gumnut-sdk 0.101.0) through all four sites that emit an Immich duration: the single-asset `AssetResponseDto`, the upload-ready WebSocket payload, the sync v1 stream converter, and the timeline-bucket array.
- Add `format_duration(seconds) -> "HH:MM:SS.ffffff" | None` (decomposed from rounded integer microseconds so a value just under a minute/hour boundary carries up rather than rendering an out-of-range `:60`).
- Bump `gumnut-sdk` to `>=0.101.0`.

## Why
- Immich clients render `0:00` for every video because the adapter hardcodes a zero/empty duration at each emit site. Now that the asset response carries a real `duration`, the adapter forwards it so video tiles and the single-asset view show the correct length.
- When upstream `duration` is NULL (an image, or a video whose duration hasn't been extracted yet) each site preserves exactly what it emitted before — video zero / image empty-string for the non-nullable single-asset DTO, `None` everywhere else — rather than fabricating a value. This mirrors how the adapter already handles unknown width/height: forward what upstream provides, never guess. Videos stay `0:00` until extraction and backfill populate real values.

## Notes
- Fixed asset test mocks that set a nonexistent `duration_in_seconds`: a bare `unittest.mock.Mock` auto-vivifies a truthy child for any unset attribute, so once converters read `.duration` the NULL path would break. Shared fixtures and inline mocks now set `duration` explicitly.

## Test plan
- [x] `uv run pytest` (980 passing, incl. new formatter/converter/timeline-bucket tests covering populated durations, NULL fallback per site, and minute/hour rounding boundaries)
- [x] `uv run ruff format` / `uv run ruff check`
- [x] `uv run pyright` (0 errors)

Generated by an AI coding agent.