### PR TITLE
Bump wide-landscape thumbnails to small (720) instead of preview

### DIFF
--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -1,6 +1,6 @@
 ---
 title: "Code Practices"
-last-updated: 2026-05-27
+last-updated: 2026-05-29
 ---
 
 # Code Practices
@@ -133,9 +133,9 @@ Emit all three tuple elements verbatim on the response. Do **not** re-derive ori
 
 ### Thumbnail variant selection by aspect ratio
 
-`GET /api/assets/{id}/thumbnail?size=thumbnail` normally streams the 250px `thumbnail` variant, but `_retrieve_and_stream_variant` (`routers/api/assets.py`) upgrades it to the 1440px `preview` variant for **wide-landscape** assets — `width > height` AND aspect ratio > `_LANDSCAPE_PREVIEW_ASPECT_THRESHOLD` (1.5). The Immich web timeline is a justified-rows grid that renders every row at a fixed height (~235px); a 250px-longest-edge thumbnail of a landscape asset has a height of only `250/aspect` (~140px at 16:9), so the grid upscales it and it looks blurry. Portrait assets are deliberately excluded — 250px lands on their height, which already meets the row height, so they stay crisp without paying the ~10–20× bandwidth cost of the larger variant. `preview`/`fullsize`/`original` requests and missing/zero dims pass through unchanged (the `width`/`height` `0`-means-unknown guard from *Asset dimensions and orientation* applies here too). Video upgrades resolve to `preview_image` via the existing `_image`-suffix logic. The threshold is tunable.
+`GET /api/assets/{id}/thumbnail?size=thumbnail` normally streams the 360px `thumbnail` variant, but `_retrieve_and_stream_variant` (`routers/api/assets.py`) upgrades it to the 720px `small` variant for **wide-landscape** assets — `width > height` AND aspect ratio > `_LANDSCAPE_SMALL_ASPECT_THRESHOLD` (1.5). The Immich web timeline is a justified-rows grid that renders every row at a fixed height (~235px); a 360px-longest-edge thumbnail of a landscape asset has a height of only `360/aspect` (~202px at 16:9), so the grid upscales it and it looks blurry. The 720px `small` clears the row height (even on Retina) at roughly a quarter of the pixels of the 1440px `preview`, which is far more resolution than a timeline tile needs. Portrait assets are deliberately excluded — 360px lands on their height, which already meets the row height, so they stay crisp without the extra bandwidth. `small`/`preview`/`fullsize`/`original` requests and missing/zero dims pass through unchanged (the `width`/`height` `0`-means-unknown guard from *Asset dimensions and orientation* applies here too). Video upgrades resolve to `small_image` via the existing `_image`-suffix logic — so any variant the bump can target must be a member of both the `AssetVariant` type and `_VIDEO_IMAGE_VARIANTS`, or a video upgrade resolves to a bare (non-`_image`) key that isn't in `asset_urls` and 404s. The threshold is tunable.
 
-The upgrade rewrites the variant **before** the `asset_urls` existence check, so it assumes the backend generates `preview`/`preview_image` whenever `thumbnail`/`thumbnail_image` exists — true today (image variants are CDN-resized URLs of the same uploaded file; a video's still-image variants materialize together). If that ever stops holding, a wide-landscape thumbnail request would 404 instead of degrading to the thumbnail. Gate the upgrade on the upgraded key's presence if that assumption breaks.
+The upgrade rewrites the variant **before** the `asset_urls` existence check, so it assumes the backend generates `small`/`small_image` whenever `thumbnail`/`thumbnail_image` exists — true today (image variants are CDN-resized URLs of the same uploaded file; a video's still-image variants materialize together). If that ever stops holding, a wide-landscape thumbnail request would 404 instead of degrading to the thumbnail. Gate the upgrade on the upgraded key's presence if that assumption breaks.
 
 ### Outbound asset checksums — emit base64 SHA-1, never the SHA-256
 

--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -91,7 +91,7 @@ router = APIRouter(
 )
 
 
-AssetVariant = Literal["thumbnail", "preview", "fullsize", "original"]
+AssetVariant = Literal["thumbnail", "small", "preview", "fullsize", "original"]
 
 _IMMICH_SIZE_TO_VARIANT: dict[AssetMediaSize, AssetVariant] = {
     AssetMediaSize.fullsize: "fullsize",
@@ -101,38 +101,41 @@ _IMMICH_SIZE_TO_VARIANT: dict[AssetMediaSize, AssetVariant] = {
 
 # Variants that get an `_image` suffix for video assets.
 _VIDEO_IMAGE_VARIANTS: frozenset[AssetVariant] = frozenset(
-    {"thumbnail", "preview", "fullsize"}
+    {"thumbnail", "small", "preview", "fullsize"}
 )
 
 # Aspect ratio (width / height) above which a landscape asset's `thumbnail`
-# request is upgraded to the larger `preview` variant. The Immich web timeline
+# request is upgraded to the larger `small` variant. The Immich web timeline
 # is a justified-rows grid where every row renders at a fixed target height
-# (~235px). A thumbnail is generated at 250px on its longest edge, so for a
-# landscape asset that 250px is the *width* and the height is only 250/aspect
-# (~140px at 16:9). The grid then upscales it to fill the row, which looks
-# blurry. Serving the 1440px `preview` keeps wide-landscape cells crisp.
-# 1.5 catches 16:9 and wider while leaving 4:3/3:2 on the cheap thumbnail.
-# Portrait assets are unaffected: 250px lands on their height, which already
+# (~235px). The `thumbnail` variant is 360px on its longest edge, so for a
+# landscape asset that 360px is the *width* and the height is only 360/aspect
+# (~202px at 16:9). The grid then upscales it to fill the row, which looks
+# blurry. Serving the 720px `small` variant keeps wide-landscape cells crisp
+# (even on Retina) at roughly a quarter of the pixels of the 1440px `preview`,
+# which is far more resolution than a timeline tile needs.
+# 1.5 catches 16:9 and wider while leaving 4:3/3:2 on the cheap thumbnail: at
+# aspect 1.5 the thumbnail height is 360/1.5 = 240px, which already meets the row.
+# Portrait assets are unaffected: 360px lands on their height, which already
 # meets the row height, so they stay sharp without the bandwidth cost. Tunable.
-_LANDSCAPE_PREVIEW_ASPECT_THRESHOLD = 1.5
+_LANDSCAPE_SMALL_ASPECT_THRESHOLD = 1.5
 
 
 def _upgrade_variant_for_aspect(
     variant: AssetVariant, width: int | None, height: int | None
 ) -> AssetVariant:
-    """Upgrade a wide-landscape `thumbnail` request to the `preview` variant.
+    """Upgrade a wide-landscape `thumbnail` request to the `small` variant.
 
-    Only `thumbnail` requests are affected; `preview`/`fullsize`/`original`
-    pass through unchanged. The upgrade applies when the asset is landscape
-    (`width > height`) and its aspect ratio exceeds
-    `_LANDSCAPE_PREVIEW_ASPECT_THRESHOLD` (see that constant for the rationale).
+    Only `thumbnail` requests are affected; `small`/`preview`/`fullsize`/
+    `original` pass through unchanged. The upgrade applies when the asset is
+    landscape (`width > height`) and its aspect ratio exceeds
+    `_LANDSCAPE_SMALL_ASPECT_THRESHOLD` (see that constant for the rationale).
     Missing or zero dimensions (photos-api stores `0` for unknown dims) fall
     back to the requested `thumbnail` — a safe default when shape is unknown.
 
     `width`/`height` are display-space dims (post-rotation), so `width > height`
     means visually landscape. The returned variant still flows through
-    `_resolve_variant_key`, so a video upgrade resolves to `preview_image`. This
-    relies on the backend generating `preview`/`preview_image` whenever
+    `_resolve_variant_key`, so a video upgrade resolves to `small_image`. This
+    relies on the backend generating `small`/`small_image` whenever
     `thumbnail`/`thumbnail_image` exists (image variants are resized URLs of the
     same file; a video's still-image variants materialize together); otherwise
     the upgraded request would 404 instead of serving the thumbnail.
@@ -141,8 +144,8 @@ def _upgrade_variant_for_aspect(
         return variant
     if not width or not height or width <= height:
         return variant
-    if width / height > _LANDSCAPE_PREVIEW_ASPECT_THRESHOLD:
-        return "preview"
+    if width / height > _LANDSCAPE_SMALL_ASPECT_THRESHOLD:
+        return "small"
     return variant
 
 
@@ -173,7 +176,7 @@ async def _retrieve_and_stream_variant(
         variant: Logical variant name (thumbnail, preview, fullsize, original).
             For video assets the still-image variants resolve to the
             `_image`-suffixed asset_urls keys. A `thumbnail` request for a
-            wide-landscape asset is upgraded to `preview` (see
+            wide-landscape asset is upgraded to `small` (see
             `_upgrade_variant_for_aspect`).
         range_header: Optional Range header for video seeking.
         forwarded_headers: Upstream headers to forward from CDN response.

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -3003,10 +3003,10 @@ class TestViewAsset:
         assert "thumbnail_image" in exc_info.value.detail
 
     @pytest.mark.anyio
-    async def test_view_asset_wide_landscape_thumbnail_upgrades_to_preview(
+    async def test_view_asset_wide_landscape_thumbnail_upgrades_to_small(
         self, sample_uuid
     ):
-        """A wide-landscape (16:9) image thumbnail request streams the preview."""
+        """A wide-landscape (16:9) image thumbnail request streams the small variant."""
         mock_client = Mock()
         mock_client.assets.retrieve = AsyncMock(
             return_value=_make_mock_asset_with_urls(
@@ -3014,6 +3014,10 @@ class TestViewAsset:
                     "thumbnail": {
                         "url": "https://cdn.example.com/thumb.webp",
                         "mimetype": "image/webp",
+                    },
+                    "small": {
+                        "url": "https://cdn.example.com/small.jpg",
+                        "mimetype": "image/jpeg",
                     },
                     "preview": {
                         "url": "https://cdn.example.com/preview.jpg",
@@ -3033,9 +3037,10 @@ class TestViewAsset:
                 sample_uuid, size=AssetMediaSize.thumbnail, client=mock_client
             )
 
-        # The 1440px preview (JPEG) is streamed in place of the 250px thumbnail.
+        # The 720px small (JPEG) is streamed in place of the 360px thumbnail —
+        # not the heavier 1440px preview, even though it is also available.
         mock_cdn.assert_called_once_with(
-            "https://cdn.example.com/preview.jpg",
+            "https://cdn.example.com/small.jpg",
             "image/jpeg",
             range_header=None,
             forwarded_headers=(
@@ -3047,10 +3052,10 @@ class TestViewAsset:
         )
 
     @pytest.mark.anyio
-    async def test_view_asset_wide_landscape_video_upgrades_to_preview_image(
+    async def test_view_asset_wide_landscape_video_upgrades_to_small_image(
         self, sample_uuid
     ):
-        """A wide-landscape video thumbnail request streams the preview_image."""
+        """A wide-landscape video thumbnail request streams the small_image."""
         mock_client = Mock()
         mock_client.assets.retrieve = AsyncMock(
             return_value=_make_mock_asset_with_urls(
@@ -3058,6 +3063,10 @@ class TestViewAsset:
                     "thumbnail_image": {
                         "url": "https://cdn.example.com/thumb_image.webp",
                         "mimetype": "image/webp",
+                    },
+                    "small_image": {
+                        "url": "https://cdn.example.com/small_image.jpg",
+                        "mimetype": "image/jpeg",
                     },
                     "preview_image": {
                         "url": "https://cdn.example.com/preview_image.jpg",
@@ -3079,7 +3088,7 @@ class TestViewAsset:
             )
 
         mock_cdn.assert_called_once_with(
-            "https://cdn.example.com/preview_image.jpg",
+            "https://cdn.example.com/small_image.jpg",
             "image/jpeg",
             range_header=None,
             forwarded_headers=(
@@ -3089,6 +3098,44 @@ class TestViewAsset:
                 "cache-control",
             ),
         )
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        ("mime_type", "present_key", "expected_missing_key"),
+        [
+            ("image/jpeg", "thumbnail", "small"),
+            ("video/mp4", "thumbnail_image", "small_image"),
+        ],
+    )
+    async def test_view_asset_wide_landscape_missing_small_returns_404(
+        self, sample_uuid, mime_type, present_key, expected_missing_key
+    ):
+        """The aspect upgrade rewrites the variant *before* the asset_urls
+        existence check, so a wide-landscape thumbnail request 404s on the
+        upgraded key (`small` / `small_image`) — not the present `thumbnail` —
+        rather than falling back, if the backend ever stops emitting it."""
+        mock_client = Mock()
+        mock_client.assets.retrieve = AsyncMock(
+            return_value=_make_mock_asset_with_urls(
+                {
+                    present_key: {
+                        "url": "https://cdn.example.com/thumb.webp",
+                        "mimetype": "image/webp",
+                    },
+                },
+                mime_type=mime_type,
+                width=1920,
+                height=1080,
+            )
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await view_asset(
+                sample_uuid, size=AssetMediaSize.thumbnail, client=mock_client
+            )
+
+        assert exc_info.value.status_code == 404
+        assert expected_missing_key in exc_info.value.detail
 
     @pytest.mark.anyio
     @pytest.mark.parametrize(
@@ -3106,7 +3153,7 @@ class TestViewAsset:
         self, sample_uuid, width, height
     ):
         """Portrait, square, near-square, boundary, and unknown-dim assets keep
-        the cheap 250px thumbnail."""
+        the cheap 360px thumbnail."""
         mock_client = Mock()
         mock_client.assets.retrieve = AsyncMock(
             return_value=_make_mock_asset_with_urls(
@@ -3115,8 +3162,8 @@ class TestViewAsset:
                         "url": "https://cdn.example.com/thumb.webp",
                         "mimetype": "image/webp",
                     },
-                    "preview": {
-                        "url": "https://cdn.example.com/preview.jpg",
+                    "small": {
+                        "url": "https://cdn.example.com/small.jpg",
                         "mimetype": "image/jpeg",
                     },
                 },


### PR DESCRIPTION
## What
- Retarget the wide-landscape `thumbnail` upgrade in `_upgrade_variant_for_aspect()` (`routers/api/assets.py`) from the 1440px `preview` variant to the new 720px `small` variant — `width > height` AND aspect ratio > 1.5 (now `_LANDSCAPE_SMALL_ASPECT_THRESHOLD`).
- Add `small` to the `AssetVariant` type and to `_VIDEO_IMAGE_VARIANTS`, so video upgrades resolve to `small_image` via the existing `_image`-suffix logic.
- `preview`/`fullsize`/`original` requests, missing/zero dims, and the explicit `?size=preview` path are unchanged.
- Refresh the rationale comment/docstrings and the "Thumbnail variant selection by aspect ratio" section in `docs/references/code-practices.md`.

## Why
- The wide-landscape bump exists because the Immich web justified-rows timeline renders every row at a fixed ~235px height; a landscape `thumbnail` (360px on its longest edge) is only ~202px tall at 16:9, so the grid upscales it and it looks blurry.
- It previously jumped straight to the 1440px `preview` — far more resolution than a timeline tile needs. A 720px variant now sits between the 360px thumbnail and the 1440px preview, and 720px comfortably clears the row height (even on Retina) at roughly a quarter of the preview's pixels. Retargeting there keeps tiles crisp while cutting transfer and client-decode cost.

## Deploy ordering
- This depends on the backend emitting the 720px `small` (and `small_image`) image variant in `asset_urls`. The upgrade rewrites the variant **before** the existence check, so a wide-landscape thumbnail request would 404 if `small` is absent. Ensure the backend change that adds the `small` rung is deployed before (or together with) this adapter in any given environment.

## Test plan
- [x] `uv run ruff format` / `uv run ruff check` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest` — 992 passed
- Updated tests in `tests/unit/api/test_assets.py`: wide-landscape image → `small` and video → `small_image` (with `preview` present in the mocks, proving the bump picks `small`, not the heavier preview); non-wide-landscape / portrait / square / 1.5-boundary / unknown-dim assets still stay on `thumbnail`; the explicit `preview`-size request is not re-upgraded; new parametrized test asserts a wide-landscape request 404s on the upgraded `small` / `small_image` key when it is absent from `asset_urls`.

Generated by an AI coding agent.