### PR TITLE
docs(references): prune bloat from evergreen reference docs

### DIFF
--- a/docs/references/development-tools.md
+++ b/docs/references/development-tools.md
@@ -1,6 +1,6 @@
 ---
 title: "Development Tools"
-last-updated: 2026-06-03
+last-updated: 2026-06-05
 ---
 
 # Development Tools
@@ -45,14 +45,7 @@ Always run linting and formatting on the generated model file before committing;
 
 ### Tag Substitution
 
-When fetching the OpenAPI spec from a GitHub URL, the generator automatically substitutes the Immich version tag from the `.immich-container-tag` file. This ensures the generated models match the specific Immich version you're targeting.
-
-**How it works:**
-
-- When using a GitHub blob URL like `https://github.com/immich-app/immich/blob/main/...`, the generator reads `.immich-container-tag` (e.g., containing `v2.2.2`)
-- It converts the URL to use the raw GitHub URL with the specific tag: `https://raw.githubusercontent.com/immich-app/immich/v2.2.2/...`
-- The generated file includes a comment header showing which version was used
-- If `.immich-container-tag` is missing or empty, it falls back to using `/main/` in the URL
+When fetching the OpenAPI spec from a GitHub blob URL, the generator substitutes the Immich version tag from the `.immich-container-tag` file so the generated models match the specific Immich version you're targeting. If the file is missing or empty, it falls back to `main`. The generated file's comment header records which version was used.
 
 ## API Compatibility Tool
 
@@ -61,30 +54,14 @@ The `validate_api_compatibility.py` tool ensures that immich-adapter correctly i
 ### Usage
 
 ```bash
-# Compare specific endpoints
+# Compare specific endpoints (omit --endpoints to compare all)
 uv run tools/validate_api_compatibility.py \
   --endpoints=server,users \
   --immich-spec=https://github.com/immich-app/immich/blob/main/open-api/immich-openapi-specs.json \
   --adapter-spec=http://localhost:3001/openapi.json
-
-# Compare all endpoints
-uv run tools/validate_api_compatibility.py \
-  --immich-spec=https://github.com/immich-app/immich/blob/main/open-api/immich-openapi-specs.json \
-  --adapter-spec=http://localhost:3001/openapi.json
-
-# Use local specification files
-uv run tools/validate_api_compatibility.py \
-  --endpoints=server \
-  --immich-spec=./immich-openapi.json \
-  --adapter-spec=./adapter-openapi.json
-
-# Show verbose output including info-level differences
-uv run tools/validate_api_compatibility.py \
-  --endpoints=server \
-  --immich-spec=https://github.com/immich-app/immich/blob/main/open-api/immich-openapi-specs.json \
-  --adapter-spec=http://localhost:3001/openapi.json \
-  --verbose
 ```
+
+Both `--immich-spec` and `--adapter-spec` accept local file paths as well as URLs. Run with `--help` for the full flag set (e.g., `--verbose` for info-level differences).
 
 ### Exit Codes
 
@@ -105,24 +82,13 @@ The workflow checks the `server` endpoint by default, but this can be customized
 
 ## OpenAPI Specification Dumper
 
-The `dump_openapi_json.py` tool dumps the OpenAPI specification from the FastAPI app:
+The `dump_openapi_json.py` tool prints the adapter's OpenAPI specification from the FastAPI app to stdout, without running a server:
 
 ```bash
-# Dump to stdout
-uv run tools/dump_openapi_json.py
-
-# Save to file
-uv run tools/dump_openapi_json.py > openapi_spec.json
-
-# Use with the compatibility validator
 uv run tools/dump_openapi_json.py > /tmp/spec.json
-uv run tools/validate_api_compatibility.py \
-  --endpoints=server \
-  --immich-spec=https://github.com/immich-app/immich/blob/main/open-api/immich-openapi-specs.json \
-  --adapter-spec=/tmp/spec.json
 ```
 
-This lets you debug or compare the adapter's OpenAPI spec without running a server.
+Redirect it to a file to feed the dumped spec into the compatibility validator via `--adapter-spec=/tmp/spec.json`.
 
 ## Dependency Update Automation
 
@@ -135,10 +101,7 @@ This lets you debug or compare the adapter's OpenAPI spec without running a serv
 
 ### Guardrails
 
-- Renovate is limited to the `github-actions` and `dockerfile` managers.
-- Updates must be at least **14 days old** before Renovate opens a PR (`minimumReleaseAge`).
-- Renovate runs **before 6am on Monday**, which keeps dependency churn predictable.
-- The dependency dashboard is enabled so maintainers can see pending updates in one place.
+Renovate is limited to the `github-actions` and `dockerfile` managers, and gates PRs behind a `minimumReleaseAge` and a weekly `schedule` to keep dependency churn predictable. The exact values live in [`renovate.json`](../../renovate.json) (`minimumReleaseAge`, `schedule`, `dependencyDashboard`).
 
 ### Not Managed by Renovate
 

--- a/docs/references/immich-sync-communication.md
+++ b/docs/references/immich-sync-communication.md
@@ -1,6 +1,6 @@
 ---
 title: "Immich Client<>Server Sync Communication"
-last-updated: 2026-06-03
+last-updated: 2026-06-05
 ---
 
 # Immich Client<>Server Sync Communication
@@ -38,7 +38,7 @@ On the first connection to a server, after login the client calls `/api/sync/str
 }
 ```
 
-The 20 possible values for `types` are defined in `SyncRequestType`. The Immich client is asking for all entity types to be synced.
+The 22 possible values for `types` are defined in `SyncRequestType`. The Immich client is asking for all entity types to be synced.
 
 The response is 275 lines and 140KB. Here is a subset:
 
@@ -223,7 +223,7 @@ The lines in a batch are parsed into events. The events are processed in a group
 
 ### Type Mapping
 
-The 20 SyncRequestTypes generate 45 SyncEntityTypes in specific orders.
+The 22 SyncRequestTypes generate 50 SyncEntityTypes in specific orders.
 
 | SyncRequestType | SyncEntityTypes (in order) |
 |-----------------|---------------------------|

--- a/docs/references/session-checkpoint-reference.md
+++ b/docs/references/session-checkpoint-reference.md
@@ -1,6 +1,6 @@
 ---
 title: "Session & Checkpoint Object Reference"
-last-updated: 2026-06-03
+last-updated: 2026-06-05
 ---
 
 # Session & Checkpoint Object Reference
@@ -13,12 +13,7 @@ This document describes the Redis data model for Session and Checkpoint objects 
 
 ### Overview
 
-The adapter uses Redis for session and checkpoint storage. This provides:
-
-- Fast key-value lookups for session validation
-- Atomic operations for checkpoint updates
-- Built-in TTL support for session expiration
-- Simple deployment (no separate database)
+The adapter uses Redis for session and checkpoint storage, leaning on its built-in TTL for session expiration.
 
 **Note:** This implementation uses only core Redis commands -- no RedisJSON, RediSearch, or other modules required.
 
@@ -123,11 +118,7 @@ Each field is an entity type, and the value is a pipe-delimited string:
 AssetV1: "2025-01-20T10:30:45.123456+00:00|2025-01-20T10:30:45+00:00"
 ```
 
-**Why pipe-delimited instead of JSON?**
-
-- Simpler parsing (no JSON library needed for basic ops)
-- Smaller payload
-- Both timestamps are fixed format, easy to split
+Both timestamps are fixed ISO 8601 format, so the value is split on the single `|` rather than carrying a JSON wrapper.
 
 **Why checkpoints are tied to sessions:**
 
@@ -162,10 +153,10 @@ last_synced_at, updated_at = checkpoint_value.split("|")
 **Why needed:**
 
 - **Session activity tracking** - Know when each session last acknowledged data
-- **Cleanup operations** - Delete checkpoints for sessions inactive > 90 days
+- **Cleanup operations** - Delete checkpoints for sessions that have been inactive past the cleanup threshold
 - **Monitoring** - Alert if a session stops syncing
 
-**How it's used:** The cleanup job range-queries `sessions:by_updated_at` (a sorted set scored by `updated_at`) for sessions whose score is older than 90 days, then deletes each stale session and its associated data.
+**How it's used:** `cleanup_stale_sessions` (in `services/session_store.py`) range-queries `sessions:by_updated_at` (a sorted set scored by `updated_at`) for sessions whose score is older than its `days` threshold, then deletes each stale session and its associated data.
 
 **Difference from `last_synced_at`:**
 
@@ -190,54 +181,4 @@ Enables efficient queries for:
 
 ## Session Dataclass
 
-```python
-from dataclasses import dataclass
-from datetime import datetime
-from uuid import UUID
-
-
-@dataclass
-class Session:
-    """Session data stored in Redis."""
-
-    id: UUID                      # The session token (what client sends as accessToken)
-    user_id: str                  # Gumnut user ID (UUID format)
-    library_id: str               # User's default library (or empty string)
-    stored_jwt: str               # Encrypted Gumnut JWT
-    device_type: str              # "iOS", "Android", "Chrome", etc.
-    device_os: str                # "iOS", "macOS", "Android", etc.
-    app_version: str              # "1.94.0" or empty for web
-    created_at: datetime          # When session was created
-    updated_at: datetime          # Last activity timestamp
-    is_pending_sync_reset: bool   # True = client should full re-sync
-
-    def to_dict(self) -> dict[str, str]:
-        """Convert to Redis hash format (all values as strings)."""
-        return {
-            "user_id": self.user_id,
-            "library_id": self.library_id,
-            "stored_jwt": self.stored_jwt,
-            "device_type": self.device_type,
-            "device_os": self.device_os,
-            "app_version": self.app_version,
-            "created_at": self.created_at.isoformat(),
-            "updated_at": self.updated_at.isoformat(),
-            "is_pending_sync_reset": "1" if self.is_pending_sync_reset else "0",
-        }
-
-    @classmethod
-    def from_dict(cls, session_id: UUID, data: dict[str, str]) -> "Session":
-        """Create from Redis hash data."""
-        return cls(
-            id=session_id,
-            user_id=data["user_id"],
-            library_id=data["library_id"],
-            stored_jwt=data["stored_jwt"],
-            device_type=data["device_type"],
-            device_os=data["device_os"],
-            app_version=data["app_version"],
-            created_at=datetime.fromisoformat(data["created_at"]),
-            updated_at=datetime.fromisoformat(data["updated_at"]),
-            is_pending_sync_reset=data["is_pending_sync_reset"] == "1",
-        )
-```
+The `Session` dataclass (in `services/session_store.py`) carries the fields documented in the [Sessions](#sessions) table, plus the `id` (the session UUID). Its `to_dict` / `from_dict` methods round-trip the dataclass to and from the Redis hash, serializing every value as a string (timestamps as ISO 8601, `is_pending_sync_reset` as `"0"`/`"1"`).

--- a/docs/references/uvicorn-settings.md
+++ b/docs/references/uvicorn-settings.md
@@ -1,6 +1,6 @@
 ---
 title: "Uvicorn Server Settings"
-last-updated: 2026-06-03
+last-updated: 2026-06-05
 ---
 
 # Uvicorn Server Settings Explained
@@ -14,7 +14,7 @@ This document covers the uvicorn server settings used by `immich-adapter`:
 
 These settings control how uvicorn (the ASGI server running our FastAPI application) handles HTTP and WebSocket connections, which is critical for mobile clients that make rapid successive requests and for the Socket.IO sync stream that backs the live Immich web/mobile UIs.
 
-For the generic definition of each flag, see the official [uvicorn settings reference](https://www.uvicorn.org/settings/). This doc is not a restatement of that page — it records the **non-default values we run and why** (mobile keep-alive matching, the legacy-`websockets` shielded-future leak, the `uvicorn[standard]>=0.44.0` pin, the macOS `somaxconn` gotcha), which the upstream reference does not cover.
+For the generic definition of each flag, see the official [uvicorn settings reference](https://www.uvicorn.org/settings/). This doc is not a restatement of that page — it records the **non-default values we run and why** (the mobile keep-alive floor, the legacy-`websockets` shielded-future leak, the `uvicorn[standard]>=0.44.0` pin, the macOS `somaxconn` gotcha), which the upstream reference does not cover.
 
 The adapter launches uvicorn from the `Dockerfile` CMD. Each HTTP-tier value is overridable via an environment variable, with the defaults shown below:
 
@@ -33,7 +33,7 @@ uvicorn main:app --host 0.0.0.0 --port ${PORT:-8080} --log-level ${LOG_LEVEL} \
 |---------|-------|------------------|-----------|
 | `--ws` | `websockets-sansio` | — | Avoid the legacy `websockets` shielded-future leak (see below). |
 | `--timeout-graceful-shutdown` | `60` | — | Give in-flight requests time to finish on redeploy. |
-| `--timeout-keep-alive` | `75` | `TIMEOUT_KEEP_ALIVE` | Match the ~75s keep-alive that iOS/Android HTTP clients use. |
+| `--timeout-keep-alive` | `75` | `TIMEOUT_KEEP_ALIVE` | Hold idle HTTP connections well above mobile-client idle gaps (uvicorn default is 5s, far too short for mobile reuse). |
 | `--limit-concurrency` | `200` | `LIMIT_CONCURRENCY` | Cap concurrent connections; excess gets HTTP 503 (not a connection refusal). |
 | `--backlog` | `2048` | `BACKLOG` | OS accept-queue depth; overflow is a connection refusal (not a 503). |
 
@@ -82,21 +82,15 @@ The sansio impl shipped in uvicorn 0.35.0, but it didn't gain WebSocket keepaliv
 
 ## timeout-keep-alive
 
-The number of seconds uvicorn keeps an idle HTTP connection open before closing it (uvicorn default: 5). We set **75**.
+The number of seconds uvicorn keeps an idle HTTP connection open before closing it. The uvicorn default of 5s is far too short for mobile clients, which hold connections idle between bursts of requests and then try to reuse them: if the server closes the connection first, the client sees truncated-reuse errors (e.g. `"Connection closed before full header was received"`) and pays for a fresh TCP+TLS handshake on the next request — expensive on cellular.
 
-HTTP keep-alive lets a client reuse one TCP connection for multiple requests. If the server's keep-alive window is shorter than the client's, the client tries to reuse a connection the server has already closed and sees errors like `"Connection closed before full header was received"`.
-
-Mobile HTTP clients drive the value: iOS `URLSession` and Android `OkHttp` both default to roughly **75 seconds** of keep-alive. Setting `timeout-keep-alive=75` to match avoids the truncated-reuse errors and the cost of a fresh TCP (and TLS) handshake on every request — handshakes are especially expensive on cellular networks.
-
-The shorter the timeout, the fewer idle connections held open (less memory), at the cost of more handshakes and more connection-reuse errors for mobile clients.
+`75` is the Gumnut-chosen value: long enough to sit above the idle gaps a mobile client leaves between request bursts (so connections survive to be reused), without holding idle sockets open indefinitely. It's not tied to a specific iOS/Android client default — treat it as a tunable floor, raised if reuse errors reappear, lowered if idle-connection memory becomes a concern.
 
 ---
 
 ## limit-concurrency
 
-Maximum number of concurrent connections uvicorn will handle (uvicorn default: `None`, i.e. unlimited). We set **200**.
-
-When the limit is reached, uvicorn rejects new requests with `HTTP/1.1 503 Service Unavailable` and a `Retry-After` header — a hard cap with no queuing. This protects the process from resource exhaustion under load: excess traffic fails fast and explicitly (503) while accepted requests keep processing normally (graceful degradation) instead of every request slowing down.
+Caps concurrent connections (uvicorn default: unlimited); excess gets HTTP 503 rather than a connection refusal. See the Settings Summary table for the value and failure mode.
 
 Raise it (via the `LIMIT_CONCURRENCY` env var) if legitimate traffic is being rejected with 503s; lower it if the process is running out of memory or saturating CPU.
 
@@ -104,22 +98,9 @@ Raise it (via the `LIMIT_CONCURRENCY` env var) if legitimate traffic is being re
 
 ## backlog
 
-The maximum number of fully-established connections that can wait in the socket's OS-level accept queue before uvicorn calls `accept()` on them (uvicorn default and our value: **2048**). It maps to the `backlog` argument of the socket `listen()` call.
-
-When the accept queue is full, the OS rejects or drops new connections and the client sees **"Connection refused"** or a timeout — this happens *before* uvicorn ever sees the connection. The effective queue depth is `min(backlog, os_somaxconn)`, so the OS limit can cap it (see the macOS gotcha below).
+OS-level accept-queue depth; overflow is a connection refusal (not a 503), before uvicorn ever sees the connection. See the Settings Summary table for the value and failure mode. The effective depth is `min(backlog, os_somaxconn)`, so the OS limit can cap it (see the macOS gotcha below).
 
 Raise it (via the `BACKLOG` env var) if clients report "Connection refused" during connection bursts and the OS limit allows it.
-
-### Backlog vs limit-concurrency
-
-These cap two different stages and fail differently:
-
-| Setting | What It Limits | When It Applies | Failure Mode |
-|---------|---------------|-----------------|--------------|
-| `backlog` | Pending connections in the OS accept queue | Before `accept()` | Connection refused |
-| `limit-concurrency` | Active connections inside the app | After `accept()` | HTTP 503 |
-
-A connection passes through the `backlog` queue first, then counts against `limit-concurrency` once uvicorn accepts it.
 
 ---
 

--- a/docs/references/websocket-events-reference.md
+++ b/docs/references/websocket-events-reference.md
@@ -1,6 +1,6 @@
 ---
 title: "Immich WebSocket Events Reference"
-last-updated: 2026-06-04
+last-updated: 2026-06-05
 ---
 
 # Immich WebSocket Events Reference
@@ -11,7 +11,7 @@ This document describes the WebSocket events emitted by the Immich server and ho
 
 | Event | Trigger | Payload | Web Client | Mobile Client |
 |-------|---------|---------|------------|---------------|
-| `on_upload_success` | Images: upload write completes; videos: 3s deferred emit to wait for still-image variants | `AssetResponseDto` | Global listener | Legacy listener |
+| `on_upload_success` | Images: upload write completes; videos: deferred emit to wait for still-image variants | `AssetResponseDto` | Global listener | Legacy listener |
 | `AssetUploadReadyV1` | Emitted alongside `on_upload_success` with the same image/video timing split | `SyncAssetV1` + `SyncAssetExifV1` | Not used | v2 sync protocol |
 | `on_asset_delete` | Asset permanently deleted | `assetId: string` | Global listener | Listener |
 | `on_asset_trash` | Asset moved to trash | `assetIds: string[]` | Global listener | Listener |
@@ -40,21 +40,7 @@ This document describes the WebSocket events emitted by the Immich server and ho
 - **Videos**: emission is **deferred** by `_VIDEO_EMIT_DELAY_SECONDS` (3.0s, defined in `routers/api/assets.py`) via a detached `asyncio.create_task`. Video still-image variants (`thumbnail_image`, `preview_image`, `fullsize_image`) live at a separate `derived_path` that only exists after photos-api's ffmpeg extraction finishes — without the delay, the Immich web client receives `on_upload_success`, inserts the asset into the timeline grid, then renders "Error loading image" because the thumbnail URL still 404s. The HTTP `POST /api/assets` 201 response is **not** delayed; only the WebSocket emission waits.
 
 **Sent to**: Asset owner (by userId)
-**Payload**: Full `AssetResponseDto`
-
-```typescript
-AssetResponseDto {
-  id: string;
-  ownerId: string;
-  originalFileName: string;
-  thumbhash: string | null;
-  fileCreatedAt: string;
-  fileModifiedAt: string;
-  localDateTime: string;
-  type: AssetType;
-  // ... full asset details
-}
-```
+**Payload**: Full `AssetResponseDto` (see `routers/immich_models.py`)
 
 **Client handling**:
 - **Web**: Global listener via `websocketEvents`
@@ -66,52 +52,15 @@ AssetResponseDto {
 
 ### `AssetUploadReadyV1`
 
-**Upstream trigger**: Emitted alongside `on_upload_success` when thumbnail generation completes (`job.service.ts:369`).
+**Upstream trigger**: Emitted alongside `on_upload_success` when thumbnail generation completes (`job.service.ts`).
 
 **Adapter trigger**:
 - Emitted from the same helper as `on_upload_success`, so the timing stays aligned across both upload-success events.
 - **Images**: emitted synchronously from the upload handler.
-- **Videos**: emitted after the same `_VIDEO_EMIT_DELAY_SECONDS` (3.0s) deferral used for `on_upload_success`, so mobile clients do not hear about a new upload before the video's still-image variants usually exist.
+- **Videos**: emitted after the same `_VIDEO_EMIT_DELAY_SECONDS` deferral used for `on_upload_success`, so mobile clients do not hear about a new upload before the video's still-image variants usually exist.
 
 **Sent to**: Asset owner (by userId)
-**Payload**: Compact sync format
-
-```typescript
-{
-  asset: SyncAssetV1 {
-    id: string;
-    ownerId: string;
-    originalFileName: string;
-    thumbhash: string | null;
-    checksum: string;
-    fileCreatedAt: string;
-    fileModifiedAt: string;
-    localDateTime: string;
-    duration: string;
-    type: AssetType;
-    deletedAt: string | null;
-    isFavorite: boolean;
-    visibility: AssetVisibility;
-    livePhotoVideoId: string | null;
-    stackId: string | null;
-    libraryId: string | null;
-  };
-  exif: SyncAssetExifV1 {
-    assetId: string;
-    description: string | null;
-    exifImageWidth: number | null;
-    exifImageHeight: number | null;
-    fileSizeInByte: number | null;
-    orientation: string | null;
-    dateTimeOriginal: string | null;
-    modifyDate: string | null;
-    timeZone: string | null;
-    latitude: number | null;
-    longitude: number | null;
-    // ... additional EXIF fields
-  };
-}
-```
+**Payload**: Compact sync format — `SyncAssetV1` asset + `SyncAssetExifV1` exif (see `routers/immich_models.py`)
 
 **Client handling**:
 - **Web**: Not used
@@ -239,20 +188,7 @@ When received, the client updates `person.updatedAt` to force the browser to fet
 
 **Trigger**: Emitted when in-app notification is created (`notification.service.ts`).
 **Sent to**: Notification recipient (by userId)
-**Payload**:
-
-```typescript
-NotificationDto {
-  id: string;
-  createdAt: Date;
-  level: 'success' | 'error' | 'warning' | 'info';
-  type: 'JobFailed' | 'BackupFailed' | 'SystemMessage' | 'AlbumInvite' | 'AlbumUpdate' | 'Custom';
-  title: string;
-  description?: string;
-  data?: any;       // e.g., { albumId: "uuid" } for album notifications
-  readAt?: Date;
-}
-```
+**Payload**: `NotificationDto` (see `routers/immich_models.py`)
 
 **Notification triggers**:
 
@@ -284,16 +220,7 @@ NotificationDto {
 
 **Trigger**: Emitted when background job detects new GitHub release (`version.service.ts`).
 **Sent to**: All connected clients (broadcast)
-**Payload**:
-
-```typescript
-ReleaseNotification {
-  isAvailable: boolean;
-  checkedAt: string;  // ISO8601
-  serverVersion: ServerVersionResponseDto;
-  releaseVersion: ServerVersionResponseDto;
-}
-```
+**Payload**: `ReleaseNotification` (see `routers/immich_models.py`)
 
 **Client handling**:
 - **Web**: Global listener. Updates `websocketStore.release`.


### PR DESCRIPTION
## Summary

Prunes bloat from five evergreen reference docs in `docs/references/`, targeting generic/tutorial content, code-owned values restated in prose, verbose enumerations, line-number pins, and unverified rationale — while preserving every adapter-specific gotcha. Each fact-changing cut was verified against source.

Net: **+32 / −220 lines.**

## Per-file

- **uvicorn-settings**: cut the generic HTTP keep-alive / `limit-concurrency` / `backlog` networking tutorial and the prose duplicates of the settings table. The grounded WebSocket-sansio incident rationale and the macOS `somaxconn` gotcha are untouched.
- **immich-sync-communication**: corrected the sync-type counts (**22** request types generate **50** entity types, not 20/45). The verbatim captured JSON payloads and request-sequence tables are **retained** — they're useful as replay/debugging fixtures.
- **websocket-events-reference**: cut the verbatim TypeScript DTO field dumps (the summary table already names each payload type) and a line-number ref into the upstream tree; the restated `3.0s` literal now points to `_VIDEO_EMIT_DELAY_SECONDS`.
- **development-tools**: collapsed near-duplicate CLI usage permutations to one example + `--help`; the Renovate guardrail values now point to `renovate.json` instead of restating them.
- **session-checkpoint-reference**: cut the `Session` dataclass dump (the field table already documents every field) and the generic Redis property lists; the cleanup threshold points to the cleanup-job source.

## Fact corrections

- **uvicorn-settings** — the asserted "iOS `URLSession` / Android `OkHttp` default to ~75s keep-alive" was unverifiable and contradicted by OkHttp's documented 300s default. Reframed 75s as the chosen tunable floor (above typical mobile idle gaps) rather than a vendor default.
- **immich-sync-communication** — the "20 → 45" sync-type counts were wrong; the live enums have 22 request types and 50 entity types.

All captured example payloads use placeholder PII; `last-updated` bumped to 2026-06-05.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
