### PR TITLE
GUM-1015: attribute adapter Sentry spans by user.id and interface

### DIFF
--- a/routers/middleware/observability_middleware.py
+++ b/routers/middleware/observability_middleware.py
@@ -6,9 +6,9 @@ Emits two things per request:
   the request: `immich-mobile-ios`, `immich-mobile-android`, or `immich-web`.
   Answers "which Immich client is this?" Set as both a Sentry tag (so error
   events group by it) and a span attribute (so the `spans` dataset can group
-  `http.server` spans by it). Mirrors photos-api's `interface` tag (`mcp` /
-  `rest`) so usage analysis reads one field across both services instead of
-  UA-sampling Render logs for the web-vs-mobile split.
+  `http.server` spans by it). The Gumnut backend sets the same `interface` tag
+  on its own spans, so usage analysis reads one field across both services
+  instead of sampling request logs for the web-vs-mobile split.
 
   The primary mobile signal is the `deviceType` header the Immich mobile app
   attaches to every API request (`iOS` / `Android`). Native upload/download

--- a/routers/middleware/observability_middleware.py
+++ b/routers/middleware/observability_middleware.py
@@ -3,14 +3,20 @@
 Emits two things per request:
 
 - `interface` — a low-cardinality tag classifying the Immich client behind
-  the request: `immich-mobile-ios`, `immich-mobile-android`, or `immich-web`,
-  derived from the User-Agent. Answers "which Immich client is this?" Set as
-  both a Sentry tag (so error events group by it) and a span attribute (so the
-  `spans` dataset can group `http.server` spans by it). Mirrors photos-api's
-  `interface` tag (`mcp` / `rest`) so usage analysis reads one field across
-  both services instead of UA-sampling Render logs for the web-vs-mobile
-  split. Unrecognized callers (uptime probes, scanners, server-to-server)
-  leave it unset, so the aggregation buckets only contain real client traffic.
+  the request: `immich-mobile-ios`, `immich-mobile-android`, or `immich-web`.
+  Answers "which Immich client is this?" Set as both a Sentry tag (so error
+  events group by it) and a span attribute (so the `spans` dataset can group
+  `http.server` spans by it). Mirrors photos-api's `interface` tag (`mcp` /
+  `rest`) so usage analysis reads one field across both services instead of
+  UA-sampling Render logs for the web-vs-mobile split.
+
+  The primary mobile signal is the `deviceType` header the Immich mobile app
+  attaches to every API request (`iOS` / `Android`). Native upload/download
+  transfers don't send `deviceType` but do set an `immich-ios` / `immich-android`
+  User-Agent, so the UA is a fallback for the mobile split. The Immich web SPA
+  runs in the browser, so a browser User-Agent classifies as `immich-web`.
+  Everything else (uptime probes, scanners, server-to-server) stays unset, so
+  the aggregation buckets only hold real, identified client traffic.
 
 - `user_agent.original` — the raw `User-Agent` header, following the
   OpenTelemetry semantic convention. Answers "who is the caller?" The Sentry
@@ -35,36 +41,47 @@ from starlette.responses import Response
 INTERFACE_TAG = "interface"
 USER_AGENT_ATTRIBUTE = "user_agent.original"
 
-# Immich mobile UAs are `Immich_iOS_<version>` / `Immich_Android_<version>`
-# (the format the Immich clients emit). Also accept the lower-case
-# `immich-{ios,android}/<version>` form as a safety net for future clients.
+# The Immich mobile app sets `deviceType: iOS|Android` on every API request
+# (immich `mobile/.../api.service.dart::setDeviceInfoHeader`). Other values
+# (e.g. `Unknown`) fall through to the UA / browser checks below.
+_DEVICE_TYPE_PLATFORMS = {"ios": "ios", "android": "android"}
+
+# Native upload/download transfers carry no `deviceType` but do set an
+# `immich-ios/<version>` / `immich-android/<version>` User-Agent (immich
+# `mobile/ios/.../URLSessionManager.swift`, `mobile/android/.../HttpClientManager.kt`).
+# Also match the legacy `Immich_iOS_<version>` underscore form, which older
+# clients emitted and the Immich server still treats as a legacy alias.
 _IMMICH_MOBILE_RE = re.compile(
-    r"^(?:Immich_(?P<platform1>iOS|Android)_|immich-(?P<platform2>ios|android)/)",
-    re.IGNORECASE,
+    r"^immich[-_](?P<platform>ios|android)[/_]", re.IGNORECASE
 )
 # Immich web runs in the browser, so its requests carry a standard browser UA.
 _BROWSER_RE = re.compile(r"\b(?:Chrome|Safari|Firefox)\b")
 
 
-def resolve_interface(user_agent: str) -> str | None:
-    """Classify the Immich client behind a request from its User-Agent.
+def resolve_interface(device_type: str, user_agent: str) -> str | None:
+    """Classify the Immich client behind a request.
+
+    `deviceType` (set by the mobile app on every API call) is the primary
+    mobile signal; the `immich-ios` / `immich-android` User-Agent is a fallback
+    for native transfers that omit it. A browser User-Agent classifies as web.
 
     Returns `immich-mobile-ios`, `immich-mobile-android`, or `immich-web`, or
-    `None` when the User-Agent doesn't match a known Immich client (uptime
-    probes, scanners, server-to-server) — those spans stay untagged so the
-    aggregation buckets only contain real client traffic.
+    `None` when neither signal matches a known Immich client (uptime probes,
+    scanners, server-to-server) — those spans stay untagged so the aggregation
+    buckets only contain real client traffic.
     """
-    ua = user_agent or ""
+    platform = _DEVICE_TYPE_PLATFORMS.get(device_type.strip().lower())
+    if platform is None:
+        match = _IMMICH_MOBILE_RE.match(user_agent)
+        if match:
+            platform = match.group("platform").lower()
 
-    match = _IMMICH_MOBILE_RE.match(ua)
-    if match:
-        platform = (match.group("platform1") or match.group("platform2") or "").lower()
-        if platform == "android":
-            return "immich-mobile-android"
-        if platform == "ios":
-            return "immich-mobile-ios"
+    if platform == "ios":
+        return "immich-mobile-ios"
+    if platform == "android":
+        return "immich-mobile-android"
 
-    if ua.startswith("Mozilla/") and _BROWSER_RE.search(ua):
+    if user_agent.startswith("Mozilla/") and _BROWSER_RE.search(user_agent):
         return "immich-web"
 
     return None
@@ -77,7 +94,8 @@ class ObservabilityTagsMiddleware(BaseHTTPMiddleware):
         self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
         user_agent = request.headers.get("user-agent", "")
-        interface = resolve_interface(user_agent)
+        device_type = request.headers.get("devicetype", "")
+        interface = resolve_interface(device_type, user_agent)
 
         # `interface` is low-cardinality — also set it as a scope tag so error
         # events (not just spans) can be grouped by it. UA is high-cardinality,

--- a/routers/middleware/observability_middleware.py
+++ b/routers/middleware/observability_middleware.py
@@ -1,13 +1,22 @@
 """Attach observability attributes to the active Sentry span.
 
-Currently emits one span attribute:
+Emits two things per request:
+
+- `interface` — a low-cardinality tag classifying the Immich client behind
+  the request: `immich-mobile-ios`, `immich-mobile-android`, or `immich-web`,
+  derived from the User-Agent. Answers "which Immich client is this?" Set as
+  both a Sentry tag (so error events group by it) and a span attribute (so the
+  `spans` dataset can group `http.server` spans by it). Mirrors photos-api's
+  `interface` tag (`mcp` / `rest`) so usage analysis reads one field across
+  both services instead of UA-sampling Render logs for the web-vs-mobile
+  split. Unrecognized callers (uptime probes, scanners, server-to-server)
+  leave it unset, so the aggregation buckets only contain real client traffic.
 
 - `user_agent.original` — the raw `User-Agent` header, following the
-  OpenTelemetry semantic convention. Answers "who is the caller?" The
-  Sentry SDK doesn't populate this on spans automatically (it only
-  attaches UA to error event context / session tracking), so we set it
-  explicitly. High-cardinality, so it's a span attribute rather than a
-  tag.
+  OpenTelemetry semantic convention. Answers "who is the caller?" The Sentry
+  SDK doesn't populate this on spans automatically (it only attaches UA to
+  error event context / session tracking), so we set it explicitly.
+  High-cardinality, so it's a span attribute rather than a tag.
 
 Registered last in `main.py` so it wraps outermost and attaches attributes
 even on auth 401 short-circuits from `AuthMiddleware`.
@@ -15,28 +24,79 @@ even on auth 401 short-circuits from `AuthMiddleware`.
 
 from __future__ import annotations
 
+import re
+
 import sentry_sdk
 from fastapi import Request
 from sentry_sdk.traces import StreamedSpan
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
+INTERFACE_TAG = "interface"
 USER_AGENT_ATTRIBUTE = "user_agent.original"
+
+# Immich mobile UAs are `Immich_iOS_<version>` / `Immich_Android_<version>`
+# (the format the Immich clients emit). Also accept the lower-case
+# `immich-{ios,android}/<version>` form as a safety net for future clients.
+_IMMICH_MOBILE_RE = re.compile(
+    r"^(?:Immich_(?P<platform1>iOS|Android)_|immich-(?P<platform2>ios|android)/)",
+    re.IGNORECASE,
+)
+# Immich web runs in the browser, so its requests carry a standard browser UA.
+_BROWSER_RE = re.compile(r"\b(?:Chrome|Safari|Firefox)\b")
+
+
+def resolve_interface(user_agent: str) -> str | None:
+    """Classify the Immich client behind a request from its User-Agent.
+
+    Returns `immich-mobile-ios`, `immich-mobile-android`, or `immich-web`, or
+    `None` when the User-Agent doesn't match a known Immich client (uptime
+    probes, scanners, server-to-server) — those spans stay untagged so the
+    aggregation buckets only contain real client traffic.
+    """
+    ua = user_agent or ""
+
+    match = _IMMICH_MOBILE_RE.match(ua)
+    if match:
+        platform = (match.group("platform1") or match.group("platform2") or "").lower()
+        if platform == "android":
+            return "immich-mobile-android"
+        if platform == "ios":
+            return "immich-mobile-ios"
+
+    if ua.startswith("Mozilla/") and _BROWSER_RE.search(ua):
+        return "immich-web"
+
+    return None
 
 
 class ObservabilityTagsMiddleware(BaseHTTPMiddleware):
-    """Attach `user_agent.original` to the active Sentry span."""
+    """Attach `interface` and `user_agent.original` to the active Sentry span."""
 
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
         user_agent = request.headers.get("user-agent", "")
+        interface = resolve_interface(user_agent)
 
+        # `interface` is low-cardinality — also set it as a scope tag so error
+        # events (not just spans) can be grouped by it. UA is high-cardinality,
+        # so it stays a span attribute only.
+        if interface is not None:
+            sentry_sdk.set_tag(INTERFACE_TAG, interface)
+
+        attributes: list[tuple[str, str]] = []
+        if interface is not None:
+            attributes.append((INTERFACE_TAG, interface))
         if user_agent:
-            span = sentry_sdk.get_current_span()
-            if isinstance(span, StreamedSpan):
-                span.set_attribute(USER_AGENT_ATTRIBUTE, user_agent)
-            elif span is not None:
-                span.set_data(USER_AGENT_ATTRIBUTE, user_agent)
+            attributes.append((USER_AGENT_ATTRIBUTE, user_agent))
+
+        span = sentry_sdk.get_current_span()
+        if isinstance(span, StreamedSpan):
+            for key, value in attributes:
+                span.set_attribute(key, value)
+        elif span is not None:
+            for key, value in attributes:
+                span.set_data(key, value)
 
         return await call_next(request)

--- a/routers/utils/current_user.py
+++ b/routers/utils/current_user.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from typing import NamedTuple
 from uuid import UUID, uuid4
 
+import sentry_sdk
 from fastapi import Depends, Request
 from gumnut import AsyncGumnut
 from gumnut.types.user_response import UserResponse
@@ -72,6 +73,13 @@ async def get_current_user_admin(
 
     # Fetch from Gumnut backend (SDK errors bubble to the global GumnutError handler)
     user = await client.users.me()
+
+    # Attribute this request to the Gumnut user in Sentry as early as the
+    # intuser_* id is known, so the active transaction and any error events
+    # group per-user. Mirror photos-api (GUM-399): the intuser_* id only,
+    # never email/PII. This dependency is cached per request, so set_user runs
+    # once when the user is first resolved.
+    sentry_sdk.set_user({"id": user.id})
 
     # Map Gumnut UserResponse to Immich UserAdminResponseDto
     # Combine first_name and last_name into Immich's single "name" field

--- a/routers/utils/current_user.py
+++ b/routers/utils/current_user.py
@@ -76,9 +76,9 @@ async def get_current_user_admin(
 
     # Attribute this request to the Gumnut user in Sentry as early as the
     # intuser_* id is known, so the active transaction and any error events
-    # group per-user. Mirror photos-api (GUM-399): the intuser_* id only,
-    # never email/PII. This dependency is cached per request, so set_user runs
-    # once when the user is first resolved.
+    # group per-user. Set the intuser_* id only, never email/PII — matching how
+    # the Gumnut backend tags its own Sentry events. This dependency is cached
+    # per request, so set_user runs once when the user is first resolved.
     sentry_sdk.set_user({"id": user.id})
 
     # Map Gumnut UserResponse to Immich UserAdminResponseDto

--- a/tests/unit/middleware/test_observability_middleware.py
+++ b/tests/unit/middleware/test_observability_middleware.py
@@ -18,52 +18,73 @@ from routers.middleware.observability_middleware import (
 
 
 class TestResolveInterface:
-    """Classification matrix for `resolve_interface`."""
+    """Classification matrix for `resolve_interface(device_type, user_agent)`."""
 
     @pytest.mark.parametrize(
-        ("user_agent", "expected"),
+        ("device_type", "user_agent", "expected"),
         [
-            # Real Immich mobile UA formats.
-            ("Immich_iOS_1.94.0", "immich-mobile-ios"),
-            ("Immich_Android_1.100.0", "immich-mobile-android"),
-            # Lower-case spec form accepted as a forward-compat safety net.
-            ("immich-ios/1.94.0", "immich-mobile-ios"),
-            ("immich-android/1.100.0", "immich-mobile-android"),
+            # Primary signal: the deviceType header the mobile app sends on
+            # every API request. Covers the bulk of mobile traffic (the Dart
+            # OpenAPI client sets no immich User-Agent).
+            ("iOS", "", "immich-mobile-ios"),
+            ("Android", "", "immich-mobile-android"),
+            ("iOS", "Dart/3.3 (dart:io)", "immich-mobile-ios"),
+            # deviceType wins over a browser UA (it's the stronger signal; a web
+            # request never carries deviceType anyway).
+            ("Android", "Mozilla/5.0 (X11) Firefox/121.0", "immich-mobile-android"),
+            # Immich's `Unknown` platform isn't a bucket — fall through.
+            ("Unknown", "", None),
+            # Fallback signal: native upload/download transfers set an
+            # immich-ios/android User-Agent but no deviceType. Real clients emit
+            # the lower-case `immich-<platform>/<version>` form...
+            ("", "immich-ios/1.94.0", "immich-mobile-ios"),
+            ("", "immich-android/1.100.0", "immich-mobile-android"),
+            # ...and the legacy `Immich_<Platform>_<version>` underscore form is
+            # still matched for older clients.
+            ("", "Immich_iOS_1.94.0", "immich-mobile-ios"),
+            ("", "Immich_Android_1.100.0", "immich-mobile-android"),
             # Immich web runs in a browser — standard browser UAs.
             (
+                "",
                 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
                 "AppleWebKit/537.36 (KHTML, like Gecko) "
                 "Chrome/120.0.0.0 Safari/537.36",
                 "immich-web",
             ),
             (
+                "",
                 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
                 "AppleWebKit/605.1.15 (KHTML, like Gecko) "
                 "Version/17.0 Safari/605.1.15",
                 "immich-web",
             ),
             (
+                "",
                 "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) "
                 "Gecko/20100101 Firefox/121.0",
                 "immich-web",
             ),
-            # Unrecognized callers stay unclassified (null bucket).
-            ("curl/8.4.0", None),
-            ("uptime-kuma/1.23.0", None),
-            ("", None),
+            # Unrecognized callers stay unclassified (null bucket): probes,
+            # scanners, and a mobile API client that somehow sent no deviceType.
+            ("", "curl/8.4.0", None),
+            ("", "uptime-kuma/1.23.0", None),
+            ("", "Dart/3.3 (dart:io)", None),
+            ("", "", None),
             # A bare `Mozilla/` without a known browser token isn't web.
-            ("Mozilla/5.0 (compatible; SomeBot/1.0)", None),
+            ("", "Mozilla/5.0 (compatible; SomeBot/1.0)", None),
         ],
     )
-    def test_resolve_interface(self, user_agent: str, expected: str | None):
-        assert resolve_interface(user_agent) == expected
+    def test_resolve_interface(
+        self, device_type: str, user_agent: str, expected: str | None
+    ):
+        assert resolve_interface(device_type, user_agent) == expected
 
 
 class TestObservabilityTagsMiddleware:
     @pytest.mark.anyio
     async def test_interface_and_user_agent_set_on_span(self):
-        """A recognized Immich client UA lands both the `interface` tag and the
-        `interface` / `user_agent.original` span attributes."""
+        """A mobile API request (deviceType header) lands both the `interface`
+        tag and the `interface` / `user_agent.original` span attributes."""
         app = FastAPI()
         app.add_middleware(ObservabilityTagsMiddleware)
 
@@ -85,18 +106,20 @@ class TestObservabilityTagsMiddleware:
                 transport=ASGITransport(app=app), base_url="http://testserver"
             ) as client:
                 response = await client.get(
-                    "/echo", headers={"user-agent": "Immich_iOS_1.94.0"}
+                    "/echo",
+                    headers={"deviceType": "iOS", "user-agent": "Dart/3.3 (dart:io)"},
                 )
 
         assert response.status_code == 200
         mock_set_tag.assert_called_once_with(INTERFACE_TAG, "immich-mobile-ios")
         mock_span.set_data.assert_any_call(INTERFACE_TAG, "immich-mobile-ios")
-        mock_span.set_data.assert_any_call(USER_AGENT_ATTRIBUTE, "Immich_iOS_1.94.0")
+        mock_span.set_data.assert_any_call(USER_AGENT_ATTRIBUTE, "Dart/3.3 (dart:io)")
 
     @pytest.mark.anyio
     async def test_attributes_set_on_streamed_span(self):
         """Streamed spans receive OpenTelemetry-style attributes via
-        `set_attribute` for both `interface` and the UA."""
+        `set_attribute` for both `interface` and the UA. Uses a native-transfer
+        UA (no deviceType) to exercise the UA fallback path."""
         app = FastAPI()
         app.add_middleware(ObservabilityTagsMiddleware)
 
@@ -124,19 +147,19 @@ class TestObservabilityTagsMiddleware:
                 transport=ASGITransport(app=app), base_url="http://testserver"
             ) as client:
                 response = await client.get(
-                    "/echo", headers={"user-agent": "Immich_Android_1.100.0"}
+                    "/echo", headers={"user-agent": "immich-android/1.100.0"}
                 )
 
         assert response.status_code == 200
         mock_span.set_attribute.assert_any_call(INTERFACE_TAG, "immich-mobile-android")
         mock_span.set_attribute.assert_any_call(
-            USER_AGENT_ATTRIBUTE, "Immich_Android_1.100.0"
+            USER_AGENT_ATTRIBUTE, "immich-android/1.100.0"
         )
 
     @pytest.mark.anyio
     async def test_unrecognized_ua_sets_user_agent_only(self):
-        """An unrecognized UA emits the `user_agent.original` attribute but no
-        `interface` tag or span attribute — the interface bucket stays null."""
+        """An unrecognized request emits the `user_agent.original` attribute but
+        no `interface` tag or span attribute — the interface bucket stays null."""
         app = FastAPI()
         app.add_middleware(ObservabilityTagsMiddleware)
 
@@ -167,8 +190,9 @@ class TestObservabilityTagsMiddleware:
 
     @pytest.mark.anyio
     async def test_nothing_set_when_header_missing(self):
-        """A missing User-Agent emits neither attribute nor tag — skip the calls
-        so Sentry queries can distinguish "absent" from "empty"."""
+        """A missing User-Agent (and no deviceType) emits neither attribute nor
+        tag — skip the calls so Sentry queries can distinguish "absent" from
+        "empty"."""
         app = FastAPI()
         app.add_middleware(ObservabilityTagsMiddleware)
 
@@ -215,9 +239,7 @@ class TestObservabilityTagsMiddleware:
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://testserver"
             ) as client:
-                response = await client.get(
-                    "/echo", headers={"user-agent": "Immich_Android_1.100.0"}
-                )
+                response = await client.get("/echo", headers={"deviceType": "Android"})
 
         assert response.status_code == 200
 
@@ -257,9 +279,10 @@ class TestObservabilityTagsMiddleware:
                 transport=ASGITransport(app=app), base_url="http://testserver"
             ) as client:
                 response = await client.get(
-                    "/api/protected", headers={"user-agent": "Immich_iOS_1.94.0"}
+                    "/api/protected",
+                    headers={"deviceType": "iOS", "user-agent": "Dart/3.3 (dart:io)"},
                 )
 
         assert response.status_code == 401
         mock_set_tag.assert_called_once_with(INTERFACE_TAG, "immich-mobile-ios")
-        mock_span.set_data.assert_any_call(USER_AGENT_ATTRIBUTE, "Immich_iOS_1.94.0")
+        mock_span.set_data.assert_any_call(USER_AGENT_ATTRIBUTE, "Dart/3.3 (dart:io)")

--- a/tests/unit/middleware/test_observability_middleware.py
+++ b/tests/unit/middleware/test_observability_middleware.py
@@ -10,16 +10,60 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
 from routers.middleware.observability_middleware import (
+    INTERFACE_TAG,
     USER_AGENT_ATTRIBUTE,
     ObservabilityTagsMiddleware,
+    resolve_interface,
 )
+
+
+class TestResolveInterface:
+    """Classification matrix for `resolve_interface`."""
+
+    @pytest.mark.parametrize(
+        ("user_agent", "expected"),
+        [
+            # Real Immich mobile UA formats.
+            ("Immich_iOS_1.94.0", "immich-mobile-ios"),
+            ("Immich_Android_1.100.0", "immich-mobile-android"),
+            # Lower-case spec form accepted as a forward-compat safety net.
+            ("immich-ios/1.94.0", "immich-mobile-ios"),
+            ("immich-android/1.100.0", "immich-mobile-android"),
+            # Immich web runs in a browser — standard browser UAs.
+            (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/120.0.0.0 Safari/537.36",
+                "immich-web",
+            ),
+            (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/605.1.15 (KHTML, like Gecko) "
+                "Version/17.0 Safari/605.1.15",
+                "immich-web",
+            ),
+            (
+                "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) "
+                "Gecko/20100101 Firefox/121.0",
+                "immich-web",
+            ),
+            # Unrecognized callers stay unclassified (null bucket).
+            ("curl/8.4.0", None),
+            ("uptime-kuma/1.23.0", None),
+            ("", None),
+            # A bare `Mozilla/` without a known browser token isn't web.
+            ("Mozilla/5.0 (compatible; SomeBot/1.0)", None),
+        ],
+    )
+    def test_resolve_interface(self, user_agent: str, expected: str | None):
+        assert resolve_interface(user_agent) == expected
 
 
 class TestObservabilityTagsMiddleware:
     @pytest.mark.anyio
-    async def test_user_agent_is_set_on_span(self):
-        """A populated User-Agent header should land on the span as
-        `user_agent.original` (OpenTelemetry semantic convention)."""
+    async def test_interface_and_user_agent_set_on_span(self):
+        """A recognized Immich client UA lands both the `interface` tag and the
+        `interface` / `user_agent.original` span attributes."""
         app = FastAPI()
         app.add_middleware(ObservabilityTagsMiddleware)
 
@@ -28,9 +72,14 @@ class TestObservabilityTagsMiddleware:
             return {"ok": True}
 
         mock_span = MagicMock()
-        with patch(
-            "routers.middleware.observability_middleware.sentry_sdk.get_current_span",
-            return_value=mock_span,
+        with (
+            patch(
+                "routers.middleware.observability_middleware.sentry_sdk.get_current_span",
+                return_value=mock_span,
+            ),
+            patch(
+                "routers.middleware.observability_middleware.sentry_sdk.set_tag"
+            ) as mock_set_tag,
         ):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://testserver"
@@ -40,13 +89,14 @@ class TestObservabilityTagsMiddleware:
                 )
 
         assert response.status_code == 200
-        mock_span.set_data.assert_called_once_with(
-            USER_AGENT_ATTRIBUTE, "Immich_iOS_1.94.0"
-        )
+        mock_set_tag.assert_called_once_with(INTERFACE_TAG, "immich-mobile-ios")
+        mock_span.set_data.assert_any_call(INTERFACE_TAG, "immich-mobile-ios")
+        mock_span.set_data.assert_any_call(USER_AGENT_ATTRIBUTE, "Immich_iOS_1.94.0")
 
     @pytest.mark.anyio
-    async def test_user_agent_is_set_on_streamed_span(self):
-        """Streamed spans should receive an OpenTelemetry-style attribute."""
+    async def test_attributes_set_on_streamed_span(self):
+        """Streamed spans receive OpenTelemetry-style attributes via
+        `set_attribute` for both `interface` and the UA."""
         app = FastAPI()
         app.add_middleware(ObservabilityTagsMiddleware)
 
@@ -68,24 +118,25 @@ class TestObservabilityTagsMiddleware:
                 "routers.middleware.observability_middleware.sentry_sdk.get_current_span",
                 return_value=mock_span,
             ),
+            patch("routers.middleware.observability_middleware.sentry_sdk.set_tag"),
         ):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://testserver"
             ) as client:
                 response = await client.get(
-                    "/echo", headers={"user-agent": "Immich_iOS_1.94.0"}
+                    "/echo", headers={"user-agent": "Immich_Android_1.100.0"}
                 )
 
         assert response.status_code == 200
-        mock_span.set_attribute.assert_called_once_with(
-            USER_AGENT_ATTRIBUTE, "Immich_iOS_1.94.0"
+        mock_span.set_attribute.assert_any_call(INTERFACE_TAG, "immich-mobile-android")
+        mock_span.set_attribute.assert_any_call(
+            USER_AGENT_ATTRIBUTE, "Immich_Android_1.100.0"
         )
 
     @pytest.mark.anyio
-    async def test_user_agent_not_set_when_header_missing(self):
-        """Missing User-Agent header should not emit an empty
-        `user_agent.original` attribute — skip the call entirely so Sentry
-        queries can distinguish "attribute absent" from "attribute empty"."""
+    async def test_unrecognized_ua_sets_user_agent_only(self):
+        """An unrecognized UA emits the `user_agent.original` attribute but no
+        `interface` tag or span attribute — the interface bucket stays null."""
         app = FastAPI()
         app.add_middleware(ObservabilityTagsMiddleware)
 
@@ -94,9 +145,46 @@ class TestObservabilityTagsMiddleware:
             return {"ok": True}
 
         mock_span = MagicMock()
-        with patch(
-            "routers.middleware.observability_middleware.sentry_sdk.get_current_span",
-            return_value=mock_span,
+        with (
+            patch(
+                "routers.middleware.observability_middleware.sentry_sdk.get_current_span",
+                return_value=mock_span,
+            ),
+            patch(
+                "routers.middleware.observability_middleware.sentry_sdk.set_tag"
+            ) as mock_set_tag,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://testserver"
+            ) as client:
+                response = await client.get(
+                    "/echo", headers={"user-agent": "curl/8.4.0"}
+                )
+
+        assert response.status_code == 200
+        mock_set_tag.assert_not_called()
+        mock_span.set_data.assert_called_once_with(USER_AGENT_ATTRIBUTE, "curl/8.4.0")
+
+    @pytest.mark.anyio
+    async def test_nothing_set_when_header_missing(self):
+        """A missing User-Agent emits neither attribute nor tag — skip the calls
+        so Sentry queries can distinguish "absent" from "empty"."""
+        app = FastAPI()
+        app.add_middleware(ObservabilityTagsMiddleware)
+
+        @app.get("/echo")
+        async def _echo():
+            return {"ok": True}
+
+        mock_span = MagicMock()
+        with (
+            patch(
+                "routers.middleware.observability_middleware.sentry_sdk.get_current_span",
+                return_value=mock_span,
+            ),
+            patch(
+                "routers.middleware.observability_middleware.sentry_sdk.set_tag"
+            ) as mock_set_tag,
         ):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://testserver"
@@ -104,6 +192,7 @@ class TestObservabilityTagsMiddleware:
                 response = await client.get("/echo", headers={"user-agent": ""})
 
         assert response.status_code == 200
+        mock_set_tag.assert_not_called()
         mock_span.set_data.assert_not_called()
 
     @pytest.mark.anyio
@@ -116,9 +205,12 @@ class TestObservabilityTagsMiddleware:
         async def _echo():
             return {"ok": True}
 
-        with patch(
-            "routers.middleware.observability_middleware.sentry_sdk.get_current_span",
-            return_value=None,
+        with (
+            patch(
+                "routers.middleware.observability_middleware.sentry_sdk.get_current_span",
+                return_value=None,
+            ),
+            patch("routers.middleware.observability_middleware.sentry_sdk.set_tag"),
         ):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://testserver"
@@ -130,10 +222,10 @@ class TestObservabilityTagsMiddleware:
         assert response.status_code == 200
 
     @pytest.mark.anyio
-    async def test_attribute_set_before_early_rejection(self):
-        """Verify ObservabilityTagsMiddleware runs outermost, so responses
-        from a downstream middleware that short-circuits (e.g., auth 401)
-        still have the UA attribute attached."""
+    async def test_attributes_set_before_early_rejection(self):
+        """Verify ObservabilityTagsMiddleware runs outermost, so responses from
+        a downstream middleware that short-circuits (e.g., auth 401) still have
+        the `interface` tag and UA attribute attached."""
 
         class _ShortCircuit401(BaseHTTPMiddleware):
             async def dispatch(
@@ -152,9 +244,14 @@ class TestObservabilityTagsMiddleware:
             return {"ok": True}
 
         mock_span = MagicMock()
-        with patch(
-            "routers.middleware.observability_middleware.sentry_sdk.get_current_span",
-            return_value=mock_span,
+        with (
+            patch(
+                "routers.middleware.observability_middleware.sentry_sdk.get_current_span",
+                return_value=mock_span,
+            ),
+            patch(
+                "routers.middleware.observability_middleware.sentry_sdk.set_tag"
+            ) as mock_set_tag,
         ):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://testserver"
@@ -164,6 +261,5 @@ class TestObservabilityTagsMiddleware:
                 )
 
         assert response.status_code == 401
-        mock_span.set_data.assert_called_once_with(
-            USER_AGENT_ATTRIBUTE, "Immich_iOS_1.94.0"
-        )
+        mock_set_tag.assert_called_once_with(INTERFACE_TAG, "immich-mobile-ios")
+        mock_span.set_data.assert_any_call(USER_AGENT_ATTRIBUTE, "Immich_iOS_1.94.0")

--- a/tests/unit/utils/test_current_user.py
+++ b/tests/unit/utils/test_current_user.py
@@ -65,9 +65,8 @@ class TestGetCurrentUserAdmin:
 
     @pytest.mark.anyio
     async def test_get_current_user_admin_sets_sentry_user(self):
-        """The resolved intuser_* id is set on the Sentry scope (GUM-399 /
-        GUM-1015) so adapter transactions and errors group per-user — id only,
-        no email/PII."""
+        """The resolved intuser_* id is set on the Sentry scope so adapter
+        transactions and errors group per-user — id only, no email/PII."""
         # Setup
         mock_request = Mock()
         mock_request.state = type("obj", (object,), {})()

--- a/tests/unit/utils/test_current_user.py
+++ b/tests/unit/utils/test_current_user.py
@@ -2,7 +2,7 @@
 
 import pytest
 import shortuuid
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 from uuid import UUID, uuid4
 from datetime import datetime, timezone
 
@@ -62,6 +62,37 @@ class TestGetCurrentUserAdmin:
         assert result.quotaSizeInBytes == 100 * 1000**3
         assert result.quotaUsageInBytes == 5 * 1000**3
         mock_client.users.me.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_get_current_user_admin_sets_sentry_user(self):
+        """The resolved intuser_* id is set on the Sentry scope (GUM-399 /
+        GUM-1015) so adapter transactions and errors group per-user — id only,
+        no email/PII."""
+        # Setup
+        mock_request = Mock()
+        mock_request.state = type("obj", (object,), {})()
+
+        mock_client = Mock()
+        mock_user = Mock()
+        test_uuid = uuid4()
+        intuser_id = f"intuser_{shortuuid.encode(test_uuid)}"
+        mock_user.id = intuser_id
+        mock_user.email = "test@example.com"
+        mock_user.first_name = "Test"
+        mock_user.last_name = "User"
+        mock_user.is_active = True
+        mock_user.created_at = datetime.now(timezone.utc)
+        mock_user.updated_at = datetime.now(timezone.utc)
+        mock_user.storage_limit_bytes = 100 * 1000**3
+        mock_user.storage_used_bytes = 5 * 1000**3
+        mock_client.users.me = AsyncMock(return_value=mock_user)
+
+        # Execute
+        with patch("routers.utils.current_user.sentry_sdk.set_user") as mock_set_user:
+            await get_current_user_admin(mock_request, mock_client)
+
+        # Assert - only the intuser_* id, no email/other PII
+        mock_set_user.assert_called_once_with({"id": intuser_id})
 
     @pytest.mark.anyio
     async def test_get_current_user_admin_caching(self):


### PR DESCRIPTION
## What
- Set `sentry_sdk.set_user({"id": <user-id>})` in `get_current_user_admin` so adapter transactions and error events group per-user. Uses the internal user id only (no email/PII), set as early as the id is resolved (the cached auth dependency — one call per request, no extra backend round-trip).
- Add an `interface` tag + span attribute to `ObservabilityTagsMiddleware`, classifying each request as `immich-web` / `immich-mobile-ios` / `immich-mobile-android`. Primary signal is the `deviceType: iOS|Android` header the Immich mobile app sends on every API request; the native-transfer `immich-ios`/`immich-android` User-Agent is a fallback, and browser User-Agents classify as web. Unrecognized callers (uptime probes, scanners) stay null.

## Why
- Adapter spans were unattributable: `user.id` was never set (all `null`), so Immich traffic couldn't be grouped per-user in Sentry; and there was no queryable channel tag, so the web-vs-mobile split had to be inferred by sampling request logs.
- A prior attempt to land the channel tag was closed without merging, so nothing shipped. It also relied on User-Agent alone — but the mobile app's main API client sends no `immich-*` User-Agent (only native upload/download transfers do), so a UA-only tag would leave most mobile API traffic in the null bucket. Keying primarily off `deviceType` (sent on every mobile API call) captures the full web-vs-mobile + iOS/Android split. The tag name matches the companion backend service's existing `interface` tag so one field works across both.

## Test plan
- [x] `uv run ruff format` / `uv run ruff check` clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest` — full unit suite passes (1004), incl. a `resolve_interface` classification matrix (deviceType primary, UA fallback incl. legacy form, browser, null buckets) and the set_user id-only behavior
- [ ] After deploy: group adapter `http.server` spans by `interface` and by `user.id` — expect non-null buckets for real Immich sessions (null remains expected for pre-auth handshakes / uptime probes)

## Linear
https://linear.app/gumnut-ai/issue/GUM-1015

Generated by an AI coding agent.