### PR TITLE
Document daemons dir; tune codebase-maintainer cadence and cooldown

### DIFF
--- a/.agents/daemons/AGENTS.md
+++ b/.agents/daemons/AGENTS.md
@@ -1,0 +1,30 @@
+# Daemons
+
+This directory holds **daemons** — repo-defined operating roles that give recurring
+operational debt an explicit owner instead of handling it ad hoc. Each daemon runs
+bounded maintenance work triggered by events or a schedule.
+
+Each daemon is one subdirectory with a single `DAEMON.md`:
+
+```
+.agents/daemons/<daemon-id>/DAEMON.md
+```
+
+The format of `DAEMON.md` — frontmatter fields, activation, and body conventions — is
+defined by the spec. Follow it as the source of truth rather than relying on the
+fields used by daemons already in this directory, since the spec may change over time:
+
+**https://docs.charlielabs.ai/daemons**
+
+## Repo conventions
+
+- Keep `<daemon-id>` and the frontmatter `id` in sync with each other.
+- Keep each daemon to a single, well-bounded role. Split unrelated concerns into
+  separate daemons rather than overloading one.
+- Prefer the smallest safe change, and state explicit limits (open-PR caps,
+  commits-per-activation, one concern per PR) so activations stay bounded.
+
+## Current daemons
+
+- `codebase-maintainer/` — keeps dependencies current and the codebase clean.
+- `librarian/` — keeps this repo's documentation current and complete.

--- a/.agents/daemons/CLAUDE.md
+++ b/.agents/daemons/CLAUDE.md
@@ -1,0 +1,1 @@
+Refer to @AGENTS.md for instructions.

--- a/.agents/daemons/codebase-maintainer/DAEMON.md
+++ b/.agents/daemons/codebase-maintainer/DAEMON.md
@@ -14,20 +14,27 @@ deny:
   - change Immich-compatibility endpoint shapes (path, method, request body, response body) without escalation
   - delete, skip, xfail, or weaken tests to make a build pass
   - 'add type-suppression comments (`# type: ignore`, `# pyright: ignore`, `# noqa`) or relax lint / type-check configuration to make a build pass'
-  - relax or remove the `exclude-newer` supply-chain guard in pyproject.toml
+  - 'relax, remove, or bypass the `exclude-newer` supply-chain guard in `pyproject.toml`, or propose/lock a non-exempt dependency at a version published less than 14 days ago (the `gumnut-sdk` exemption is declared in `pyproject.toml`)'
   - bump `gumnut-sdk` outside the exemption already declared in pyproject.toml (it tracks the upstream API surface — pin moves require human review)
   - push commits directly to main
   - approve or merge pull requests
-schedule: "0 */6 * * *"
+# Daily, not every 6h: dependency upgrades (gated on "2+ minor versions behind"
+# and the 14-day cooldown) and dead-code cleanup are low-urgency maintenance, so
+# four scheduled passes a day mostly re-evaluate unchanged state and churn CI on
+# the open PRs. Security advisories are NOT gated by this cron — they fire on the
+# `when a security advisory is published` watch above (24h SLA), so the slower
+# cadence doesn't slow the urgent path.
+schedule: "0 9 * * *"
 ---
 
 ## Policy
 - Prefer the smallest safe change. A dependency bump, not a rewrite.
 - Every upgrade PR must include passing tests.
+- Every dependency upgrade PR description must summarize what changed in the dependency between the old and new version — pull from the dependency's release notes / changelog (e.g. GitHub Releases, `CHANGELOG.md`) for the bumped range. Call out behavior changes, deprecations, and breaking changes relevant to how this repo uses the dependency, and link the upstream changelog/release. If no changelog is available, say so and link the version-diff (e.g. the compare view between the two tags) instead.
 - Respect the `exclude-newer = "14 days"` supply-chain guard in `pyproject.toml` — only consider package versions that satisfy it.
 
 ## Verification
-Before opening a PR, run:
+Resolve each dependency bump by re-locking with `uv lock` (it honors `exclude-newer`) — never hand-edit `uv.lock`. Then, before opening a PR, run:
 - `uv sync --locked`
 - `uv run ruff format && uv run ruff check`
 - `uv run pyright`


### PR DESCRIPTION
## What
- Add `.agents/daemons/AGENTS.md` documenting the daemon directory layout and repo conventions, deferring the `DAEMON.md` format to the spec at https://docs.charlielabs.ai/daemons, plus a `CLAUDE.md` pointer matching the repo's existing pattern.
- Reduce the codebase-maintainer cron from every-6h to daily (`0 9 * * *`), with an inline comment explaining why the slower cadence doesn't affect the security-advisory path (it rides the event-driven watch, not the cron).
- Require dependency upgrade PR descriptions to summarize what changed in the dependency, sourced from its changelog/release notes (or a version-diff link when none exists).
- Strengthen cooldown enforcement: the deny list now also forbids *bypassing* `exclude-newer` or proposing/locking a non-exempt dependency younger than 14 days, and Verification now resolves bumps via `uv lock` (which honors `exclude-newer`) instead of relying on `uv sync --locked`, which never re-resolves.

## Why
- The daemons directory had no authoring conventions; new daemon work had to reverse-engineer the format from existing files. Pointing at the spec keeps the docs from drifting as the spec evolves.
- Dependency upgrades are gated on "2+ minor versions behind" plus the 14-day cooldown, so four scheduled passes a day mostly re-evaluated unchanged state and churned CI on open daemon PRs.
- Upgrade PRs that only say "bump X from a to b" force reviewers to go dig up the changelog themselves.
- `exclude-newer` only constrains resolution — a bump locked without re-resolving (or a hand-edited `uv.lock`) silently defeats the guard, so the daemon instructions now name the enforcing path explicitly.

The librarian daemon is unchanged — its current config is intentional for this repo.

## Linear
https://linear.app/gumnut-ai/issue/GUM-1047/add-agentsdaemons-agentsmdclaudemd-to-immich-adapter-and-sync-daemon

## Test plan
- [x] YAML frontmatter of both `DAEMON.md` files parses (PyYAML), `schedule` and deny list intact
- [x] Claims verified against `pyproject.toml`: `exclude-newer = "14 days"`, `gumnut-sdk` exemption via `exclude-newer-package`
- [x] `uv run ruff format --check`, `uv run ruff check`, `uv run pyright`, `uv run pytest` (1033 passed)

Generated by an AI coding agent.