### PR TITLE
Let backend 400 on OAuth token exchange bubble instead of returning 500

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Before starting work, read `README.md` for project setup and consult the Documentation Map below for relevant docs.
 
-**This repo is public.** Do not reference private sibling repos (e.g., `gumnut-ai/gumnut-dev-setup`, `gumnut-ai/photos`) from committed files or PR bodies — links resolve to dead ends for external readers and surface the existence of internal docs. Inline the relevant rationale or context instead. Same principle as the existing clarity rule about absolute author-machine paths in committed files.
+**This repo is public.** Do not reference private sibling repos (e.g., `gumnut-ai/gumnut-dev-setup`, `gumnut-ai/photos`) from committed files or PR bodies — links resolve to dead ends for external readers and surface the existence of internal docs. Inline the relevant rationale or context instead. Same principle as the existing clarity rule about absolute author-machine paths in committed files. Internal issue-tracker IDs (e.g., `GUM-123`) are likewise banned from anything committed — including **commit messages** and PR bodies, not just code and docs (see `docs/references/code-practices.md` § Project Conventions); let the Linear issue link to the PR instead of the other way around.
 
 Concrete violations that have actually shipped: cross-link lines like `Cross-link: gumnut-ai/photos#NNN` in a PR description (the PR number resolves to a 404 for outsiders) and "see `photos-api/services/...`" file-path references. When a Linear issue or design doc that lives in a private repo asks you to "cross-link the photos-api PR," do not copy that framing verbatim — describe what the other repo's change does instead.
 

--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -332,7 +332,7 @@ Route handlers raise `HTTPException(status_code=..., detail="...")` and a global
 
 ### Gumnut SDK error mapping
 
-A global `GumnutError` exception handler in `config/exceptions.py` (registered in `main.py`) maps any Stainless SDK exception raised during request handling to an Immich-shaped JSON response. Routes do not need per-call `try/except` for SDK errors — they bubble to the handler.
+A global `GumnutError` exception handler in `config/exceptions.py` (registered in `main.py`) maps any Stainless SDK exception raised during request handling to an Immich-shaped JSON response. Routes do not need per-call `try/except` for SDK errors — they bubble to the handler. Watch for routes with a legacy catch-all `except Exception` arm (e.g., `finish_oauth`'s 500 fallback): the catch-all swallows SDK errors before the handler sees them, and the local pattern misleads new code into hand-rolling parallel mappings. Add a re-raise arm for the SDK exception (`except BadRequestError: raise`) above the catch-all instead.
 
 Dispatch is by `isinstance` against the typed SDK hierarchy:
 

--- a/routers/api/oauth.py
+++ b/routers/api/oauth.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
-from gumnut import AsyncGumnut, omit
+from gumnut import AsyncGumnut, BadRequestError, omit
 
 from routers.immich_models import (
     LoginResponseDto,
@@ -232,6 +232,13 @@ async def finish_oauth(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="OAuth authentication failed. Please try again.",
         )
+    except BadRequestError:
+        # The backend rejected the exchange as a client error — typically a
+        # stale or replayed callback (state token already consumed or expired).
+        # Re-raise past the generic arm below so the global GumnutError handler
+        # returns the backend's 400 and message (which tells the user to restart
+        # the login flow) and logs it at warning level.
+        raise
     except Exception:
         logger.error(
             "Failed to complete OAuth authentication",

--- a/tests/unit/api/test_oauth.py
+++ b/tests/unit/api/test_oauth.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock, patch
 from uuid import UUID
 
 from fastapi import HTTPException, Request
+from gumnut import BadRequestError
 from starlette.datastructures import URL
 import pytest
 
@@ -11,6 +12,7 @@ from routers.api.oauth import finish_oauth, rewrite_redirect_uri
 from routers.immich_models import OAuthCallbackDto
 from routers.utils.gumnut_id_conversion import uuid_to_gumnut_user_id
 from services.session_store import SessionStore
+from tests.conftest import make_sdk_status_error
 
 TEST_USER_UUID = UUID("550e8400-e29b-41d4-a716-446655440000")
 TEST_GUMNUT_USER_ID = uuid_to_gumnut_user_id(TEST_USER_UUID)
@@ -273,3 +275,45 @@ class TestFinishOAuth:
 
             assert exc_info.value.status_code == 500
             assert "OAuth authentication failed" in exc_info.value.detail
+
+    @pytest.mark.anyio
+    async def test_backend_rejection_propagates_to_global_handler(
+        self, mock_request, mock_response, mock_gumnut_client, mock_session_store
+    ):
+        """A backend 400 on token exchange propagates, bypassing the 500 arm.
+
+        The backend rejects stale or replayed callbacks (state token already
+        consumed or expired) as client errors. The route must let the SDK
+        error bubble to the global GumnutError handler — which returns the
+        backend's 400 and message — instead of reporting an adapter 500.
+        """
+        mock_gumnut_client.oauth.exchange = AsyncMock(
+            side_effect=make_sdk_status_error(
+                400,
+                "Invalid or expired OAuth state token. Please restart the login flow.",
+                cls=BadRequestError,
+            )
+        )
+
+        callback_dto = OAuthCallbackDto(
+            url="http://localhost/callback?code=auth_code&state=stale_state"
+        )
+
+        with patch("routers.api.oauth.parse_callback_url") as mock_parse:
+            mock_parse.return_value = {
+                "code": "auth_code",
+                "state": "stale_state",
+                "error": None,
+            }
+
+            with pytest.raises(BadRequestError):
+                await finish_oauth(
+                    oauth_callback=callback_dto,
+                    request=mock_request,
+                    response=mock_response,
+                    client=mock_gumnut_client,
+                    session_store=mock_session_store,
+                )
+
+        # No session must be created for a rejected exchange
+        mock_session_store.create.assert_not_called()


### PR DESCRIPTION
## What
- `finish_oauth` re-raises the SDK's `BadRequestError` past its generic `except Exception` arm so it bubbles to the global `GumnutError` handler, instead of reporting an adapter 500 at ERROR level
- Adds a unit test asserting the propagation and that no session is created for a rejected exchange
- Documents the legacy-catch-all gotcha in the adapter architecture doc and surfaces the existing no-internal-IDs committed-text rule in AGENTS.md

## Why
- The backend rejects stale or replayed OAuth callbacks (state token already consumed or expired — e.g., a refresh or re-navigation of the callback URL) as client errors. The adapter's generic arm misclassified these as its own server faults, producing error-tracker noise for expected user behavior.
- Bubbling to the global handler returns the backend's 400 with its actionable message (restart the login flow) in Immich shape and logs the standard warning-level upstream record, per the documented SDK-error convention.
- Safe to deploy in either order relative to the upstream change: while the backend still returns 500 for this case, the generic arm continues to handle it.

## Test plan
- [x] `uv run pytest` — full suite passes (1034 tests)
- [x] New test: backend 400 on exchange propagates as `BadRequestError` (reaching the global handler in app context) and creates no session
- [x] `uv run ruff check` / `uv run pyright` clean

Generated by an AI coding agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)