### PR TITLE
Request variants include on the image-serving retrieve

### DIFF
--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -191,7 +191,11 @@ async def _retrieve_and_stream_variant(
         StreamingResponse streaming CDN bytes to the Immich client.
     """
     gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
-    asset = await client.assets.retrieve(gumnut_asset_id)
+    # `variants` opts into the non-thumbnail asset_urls rungs (small/preview/
+    # fullsize/original and their video `_image` equivalents). Once the API
+    # trims asset_urls to the thumbnail rung for callers that omit it, every
+    # non-thumbnail size served here would 404 without this.
+    asset = await client.assets.retrieve(gumnut_asset_id, include=["variants"])
 
     variant = _upgrade_variant_for_aspect(variant, asset.width, asset.height)
     variant_key = _resolve_variant_key(asset.mime_type, variant)

--- a/routers/utils/asset_conversion.py
+++ b/routers/utils/asset_conversion.py
@@ -42,9 +42,12 @@ logger = logging.getLogger(__name__)
 # `file_modified_at` cascade; `people` feeds `AssetResponseDto.people`.
 #
 # Deliberately omitted: `faces` (the adapter reads faces from the dedicated
-# `/faces` endpoint, never off the asset), `metrics` (never read), and any
-# image-variant token — `asset_urls` is not gated and stays fully populated, so
-# the streaming/serving paths need no `include` at all.
+# `/faces` endpoint, never off the asset), `metrics` (never read), and the
+# `variants` token. `convert_gumnut_asset_to_immich` does not read `asset_urls`
+# at all, so these data-field reads need no variant token. The byte-serving
+# paths in `routers/api/assets.py` are the exception — they stream the
+# non-thumbnail rungs (gated behind `variants`) and so request
+# `include=variants` at their own call site.
 ASSET_INCLUDE: list[str] = ["metadata", "people", "file_data"]
 """For reads that feed ``convert_gumnut_asset_to_immich`` (reads ``people``)."""
 

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -2870,6 +2870,39 @@ class TestViewAsset:
         )
 
     @pytest.mark.anyio
+    async def test_view_asset_retrieve_requests_variants(self, sample_uuid):
+        """The serving retrieve() opts into the non-thumbnail asset_urls rungs.
+
+        Without include=["variants"], an API default that trims asset_urls to
+        the thumbnail rung would leave small/preview/fullsize/original absent
+        and every non-thumbnail size served here would 404 (including some
+        thumbnail requests, via the wide-landscape aspect upgrade to 'small').
+        """
+        mock_client = Mock()
+        mock_client.assets.retrieve = AsyncMock(
+            return_value=_make_mock_asset_with_urls(
+                {
+                    "thumbnail": {
+                        "url": "https://cdn.example.com/thumb.webp",
+                        "mimetype": "image/webp",
+                    }
+                }
+            )
+        )
+
+        with patch(
+            "routers.api.assets.stream_from_cdn", new_callable=AsyncMock
+        ) as mock_cdn:
+            mock_cdn.return_value = Mock()
+            await view_asset(
+                sample_uuid, size=AssetMediaSize.thumbnail, client=mock_client
+            )
+
+        await_args = mock_client.assets.retrieve.await_args
+        assert await_args is not None
+        assert await_args.kwargs["include"] == ["variants"]
+
+    @pytest.mark.anyio
     async def test_view_asset_fullsize_maps_to_fullsize_variant(self, sample_uuid):
         """Test that ?size=fullsize maps to the 'fullsize' asset_urls variant."""
         mock_client = Mock()


### PR DESCRIPTION
## What
- `_retrieve_and_stream_variant` (the function behind the thumbnail/playback/download serving endpoints) now passes `include=["variants"]` on its `client.assets.retrieve()` call.
- Adds a regression test asserting the serving `retrieve()` requests `variants`.
- Corrects a now-stale comment on `ASSET_INCLUDE` that claimed `asset_urls` is never gated.

## Why
The Gumnut API is moving the asset response to a lean default that trims `asset_urls` to a single thumbnail rung for any response that does not request `include=variants`. The image-serving path streams the `small`/`preview`/`fullsize`/`original` rungs (plus their video `_image` equivalents) straight from `asset_urls`, and a wide-landscape `thumbnail` request can even be aspect-upgraded to `small` — so without `variants`, every non-thumbnail size (and some thumbnail requests) would 404 once the trim lands.

The data-field include constants on the other call sites are unaffected: `convert_gumnut_asset_to_immich` and the sync/album/search converters never read `asset_urls`, so they need no variant token. Only the byte-serving path does.

This change is safe to merge now (the `variants` token is already accepted by the API) and must be deployed before the API trims the non-thumbnail rungs.

## Test plan
- [x] `uv run pytest tests/unit/api/test_assets.py` — 152 passed, including the new `test_view_asset_retrieve_requests_variants`.
- [x] `uv run ruff format`, `uv run ruff check`, `uv run pyright` — clean.

Generated by an AI coding agent.