### PR TITLE
Declare fixed Starlette dependency floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "redis~=8.0",
     "sentry-sdk[fastapi,httpx]>=2.37.1",
     "shortuuid>=1.0.13",
+    "starlette>=1.0.1",
     "user-agents>=2.2.0",
     # uvicorn 0.44.0 added keepalive pings for the websockets-sansio impl,
     # which is what we run via `--ws websockets-sansio` to avoid the legacy

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-06-10T09:07:46.980083198Z"
+exclude-newer = "2026-06-18T02:45:28.469784Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -392,6 +392,7 @@ dependencies = [
     { name = "redis" },
     { name = "sentry-sdk", extra = ["fastapi", "httpx"] },
     { name = "shortuuid" },
+    { name = "starlette" },
     { name = "user-agents" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -414,6 +415,7 @@ requires-dist = [
     { name = "redis", specifier = "~=8.0" },
     { name = "sentry-sdk", extras = ["fastapi", "httpx"], specifier = ">=2.37.1" },
     { name = "shortuuid", specifier = ">=1.0.13" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "user-agents", specifier = ">=2.2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.44.0" },
 ]


### PR DESCRIPTION
## What
- Declare a direct `starlette>=1.0.1` dependency floor.
- Refresh the lockfile metadata so the project dependency set records Starlette as an explicit requirement.

## Why
- The lockfile already resolves a newer fixed Starlette release, but the project only reached Starlette transitively through FastAPI.
- Keeping the fixed floor in `pyproject.toml` prevents future lock refreshes from resolving below the host-header advisory fix while preserving the current runtime behavior.

## Test plan
- `uv run ruff format`
- `uv run ruff check`
- `uv run pyright`
- `uv run pytest tests/unit/middleware/test_auth_middleware.py`
- `uv run pytest`

Generated by an AI coding agent.