### PR TITLE
docs: validate Immich v3 API analysis against GA; resolve Sync v2 open question

### DIFF
--- a/docs/design-docs/immich-v3-api-changes.md
+++ b/docs/design-docs/immich-v3-api-changes.md
@@ -2,7 +2,7 @@
 title: "Immich v2.7.5 → v3.0 API Change Analysis"
 status: active
 created: 2026-06-16
-last-updated: 2026-06-16
+last-updated: 2026-07-02
 ---
 
 # Immich v2.7.5 → v3.0 API Change Analysis
@@ -10,9 +10,10 @@ last-updated: 2026-06-16
 ## Context
 
 The immich-adapter currently targets the Immich **v2.7.5** release (pinned in
-`.immich-container-tag`). Immich **3.0** is imminent; the current release
-candidate is **v3.0.0-rc.0**. This document is a structural diff of the two
-OpenAPI specs, scoped to what the adapter must change to retarget 3.0.
+`.immich-container-tag`). Immich **3.0** has since shipped (**v3.0.0** GA,
+2026-06-30). This document is a structural diff of the two OpenAPI specs — 2.7.5
+against **v3.0.0-rc.0**, re-validated against the GA spec (see the GA validation
+note below) — scoped to what the adapter must change to retarget 3.0.
 
 Both specs are OpenAPI 3.0.0. The diff was produced by comparing
 `immich/open-api/immich-openapi-specs.json` (2.7.5) against
@@ -29,14 +30,39 @@ Both specs are OpenAPI 3.0.0. The diff was produced by comparing
 > **codegen-only noise** (see §1) that does not change the JSON on the wire. The
 > real behavioral surface is much smaller and is captured in §2–§6.
 
-This is RC analysis — the final 3.0 spec may differ. Re-run the diff against the
-GA spec before treating any item here as final.
+> **GA validation (2026-07-02).** This analysis was produced against
+> `v3.0.0-rc.0`. The GA spec (`v3.0.0`, tagged 2026-06-30) has since been diffed
+> against `v3.0.0-rc.0`: **no material changes for the adapter.** No endpoints or
+> schemas were added, removed, or restructured, and every §2–§6 item below is
+> byte-stable between rc.0 and GA. The only spec differences are:
+>
+> - **UUID annotations** — `format: uuid` plus a strict UUID `pattern` added to
+>   ~90 ID fields. Same codegen-noise class as §1; the wire bytes are unchanged.
+> - **Datetime pattern relaxed** — the `date-time` regex now also accepts a
+>   timezone offset (`Z` → `Z | ±HH:MM`) on every datetime field. Validation
+>   annotation only; Immich still emits UTC `Z`.
+> - **Admin config validation loosened** — cron / time-of-day `pattern`s dropped
+>   from the system-config DTOs (`DatabaseBackupConfig`, integrity and
+>   library-scan job configs). Admin-only, not adapter-facing.
+> - **New optional header** — `x-immich-hls-pos` on the HLS playlist endpoint,
+>   part of the already-new-in-3.0 adaptive-streaming surface (§4).
+> - **Doc-string fixes** — face "created manually"; `AssetBulkUploadCheckItem` /
+>   `Result.id` reframed as a client-supplied echo token (not an asset ID); and
+>   `AssetBulkUpdateDto.dateTimeRelative` corrected from "seconds" to "minutes".
+>   The Immich server has always applied `dateTimeRelative` as **minutes** (the
+>   SQL adds `${delta} minute` in 2.7.5 and 3.0 alike), so the adapter's current
+>   seconds-based handling in `routers/api/assets.py` is off by 60× — a
+>   pre-existing bug the GA doc-string fix merely surfaced, independent of the
+>   v3 retarget.
+>
+> The rc.0-based plan below therefore stands unchanged for GA.
 
 ### Reproducing the diff
 
-The comparison scripts are ad hoc Python over the two JSON specs (path set diff,
-operation-signature diff, schema property diff). They are not checked in; regenerate
-against the GA spec when it lands. Key probes: path-set difference, per-operation
+The comparison scripts are ad hoc Python/jq over the two JSON specs (path set diff,
+operation-signature diff, schema property diff). They are not checked in. The same
+probes were re-run for the rc.0 → GA (`v3.0.0`) comparison behind the GA validation
+note above. Key probes: path-set difference, per-operation
 parameter/requestBody/response signature, and per-schema property/required/enum diff.
 
 ## Goals

--- a/docs/design-docs/immich-v3-api-changes.md
+++ b/docs/design-docs/immich-v3-api-changes.md
@@ -170,8 +170,42 @@ No new `/sync` paths — `/sync/stream` + `/sync/ack` now carry **V2 variants**:
   `SyncAssetOcrDeleteV1`. `SyncAssetV1` gains required `createdAt`;
   `SyncAuthUserV1`/`SyncUserV1` `avatarColor` no longer required.
 
-v3 mobile clients will negotiate V2 + OCR entities, so this is meaningful work in
-`routers/api/sync/` (converters, types, stream).
+### What V2 actually changes
+
+At the payload level, V2 adds almost nothing over V1:
+
+- `SyncAssetV2` is `SyncAssetV1` with **`duration` as integer-milliseconds**
+  instead of the interval string — the same change as §2. This is the *only*
+  payload difference between any V1 entity and its V2.
+- `SyncAlbumV2` and `SyncAssetFaceV2` are **byte-identical** to their V1 forms.
+- The `PartnerAsset*V2` and `AlbumAsset*V2` entity types reuse `SyncAssetV2`, so
+  they inherit only the int-ms `duration`.
+- `AssetOcrV1` is a genuinely new entity type (OCR text boxes), but the adapter
+  has no OCR data — it emits nothing for it and the client tolerates the absence.
+
+### Client behavior — V1 fallback is version-gated, not negotiated
+
+The mobile client picks V1 vs V2 request types purely from the version the
+adapter reports at `GET /server/version` (upstream Immich mobile
+`mobile/lib/infrastructure/repositories/sync_api.repository.dart`):
+`assetsV2` / `albumsV2` / `albumAssetsV2` / `partnerAssetsV2` and `assetOcrV1`
+only when the reported version is `>= 3.0.0`; `assetFacesV2` at `>= 2.6.0`. A
+below-client version merely sets a "server out of date" UI banner
+(`server_info.provider.dart`) — it never blocks sync. So the reported version is
+the lever: report `< 3.0.0` and the client requests the V1 surface the adapter
+already serves; report `3.0.x` and it requests V2.
+
+The adapter already runs the V1/V2 dual pattern today: it reports 2.7.5 (from
+`.immich-container-tag`), so current clients already request `assetFacesV2`, and
+`routers/api/sync/` already carries `gumnut_face_to_sync_face_v2`, the
+`AssetFacesV2` → `AssetFaceV2` stream mapping, and "skip V1 when V2 is requested"
+logic.
+
+**Conclusion:** Sync v2 is not a long pole. Reporting `3.0.x` and adding the V2
+entity mappings is small work that reuses the §2 int-ms `duration` converter —
+`AlbumV2` is identical to V1, `AssetV2` is the int-duration asset, and
+`AssetOcrV1` emits nothing. The one non-cosmetic V1 tweak to carry over is that
+v3 makes `SyncAssetV1.createdAt` required.
 
 ---
 
@@ -218,7 +252,9 @@ RC** (no methods were added) — likely pre-announcing a future PATCH migration:
    `immich_models.py`) — touches every asset/timeline/upload response.
 2. **`AlbumResponseDto`** — derive owner from `albumUsers[0]`, drop
    `owner`/`ownerId`/inline `assets`.
-3. **Sync v2** — handle V2 request/entity types + OCR in `routers/api/sync/`.
+3. **Sync v2** — small: report `3.0.x`, add the V2 entity mappings reusing the
+   §2 int-ms `duration` converter (`AlbumV2` == V1; `AssetOcrV1` emits nothing).
+   The V1/V2 dual pattern already exists in `routers/api/sync/`. See §5.
 4. **Shared links** — token/key/slug access model rework.
 5. **`AssetResponseDto`** — drop device fields + `unassignedFaces`, switch
    `people` to `PersonResponseDto`.
@@ -231,10 +267,15 @@ RC** (no methods were added) — likely pre-announcing a future PATCH migration:
 
 ## Open questions
 
-- Does the adapter retarget 3.0 GA in one cut, or run a compatibility window
-  supporting both 2.7.5 and 3.0 clients? (Affects whether removed endpoints and
-  string-duration stay as shims.)
-- Are 3.0 mobile clients hard-requiring Sync v2, or do they fall back to V1
-  entity types? Determines whether §5 is blocking or incremental.
+- ~~Does the adapter retarget 3.0 GA in one cut, or run a compatibility window
+  supporting both 2.7.5 and 3.0 clients?~~ **Resolved: clean cut to 3.0.** The
+  product is in alpha with a handful of testers, so the supported client version
+  is set by fiat (Immich mobile + web v3). No dual-support window — removed
+  endpoints and string-`duration` need not stay as shims.
+- ~~Are 3.0 mobile clients hard-requiring Sync v2, or do they fall back to V1
+  entity types?~~ **Resolved: incremental, not blocking.** The client picks V1
+  vs V2 by the adapter's reported version, and V2 adds only int-ms `duration`
+  (§5). Reporting `3.0.x` needs only a thin V2 layer that reuses the §2 duration
+  converter.
 - Which new feature areas (if any) are in scope vs. permanent intentional gaps —
   see the companion gap analysis in `immich-adapter-gap-analysis.md`.


### PR DESCRIPTION
Two doc updates to `immich-v3-api-changes.md`, which was written against `v3.0.0-rc.0` and asked a future reader to re-validate against GA and to resolve its open questions.

## 1. GA validation (rc.0 → v3.0.0)

**The GA spec introduces no material changes for the adapter.** Diffing `v3.0.0` against `v3.0.0-rc.0`:

- **0** endpoints added / removed / changed (254 path+methods in both)
- **0** schemas added / removed; no request/response body swaps
- Every §2–§6 item (duration→int-ms, `AlbumResponseDto` restructure, shared-link token removal, device-field drops, Sync v2 entity counts, `AlbumUserRole` enum, …) is **byte-stable** between rc.0 and GA.

The entire spec diff (314/127 lines) is codegen/validation noise and doc corrections:

| Difference | Nature |
|---|---|
| `format: uuid` + strict UUID `pattern` on ~90 ID fields | Same annotation-noise class as §1; wire unchanged |
| `date-time` `pattern` relaxed `Z` → `Z \| ±HH:MM` | Validation only; Immich still emits UTC `Z` |
| Cron/time `pattern`s dropped from admin system-config DTOs | Admin-only validation loosening |
| New **optional** `x-immich-hls-pos` request header on the HLS playlist endpoint | Part of the already-new-in-3.0 HLS surface (§4); adapter doesn't implement HLS |
| Doc-string fixes (face text; `AssetBulkUploadCheckItem/Result.id`; `dateTimeRelative`) | Documentation only |

Replaces the "re-run against GA" caveat with a **GA validation note** so the doc no longer reads as provisional.

## 2. Sync v2 conclusion + open questions resolved

Fold the Sync v2 analysis into §5:

- **V2 adds almost nothing over V1 at the payload level** — `SyncAssetV2` is `SyncAssetV1` with `duration` as int-ms (the same §2 change); `SyncAlbumV2` and `SyncAssetFaceV2` are **byte-identical** to V1; `AssetOcrV1` is a new type the adapter emits nothing for (no OCR data).
- **V1 fallback is version-gated, not negotiated** — the mobile client selects V1 vs V2 purely from the version reported at `GET /server/version`; a below-client version is only a soft "server out of date" banner, never a block. The adapter already runs the V1/V2 dual pattern for faces today.
- **Reclassified** §7 item 3 from long-pole to small work that reuses the §2 `duration` converter.
- **Resolved both open questions**: clean cut to 3.0 (alpha, client version set by fiat, supporting Immich mobile + web v3); Sync v2 is incremental, not blocking.

## Side-finding (not a v3 change) — tracked separately in Linear

The GA doc-string fix `dateTimeRelative` "seconds" → "minutes" exposed that the Immich server has **always** applied that field as minutes (`+ ${delta} ' minute'::interval` in v2.7.5, rc.0, and GA), while the adapter implements it as a **seconds**-shift in `routers/api/assets.py` — a latent ~60× discrepancy independent of the v3 retarget. Recorded in the doc's GA validation note and filed separately.

Doc-only change — no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
