### PR TITLE
Implement /search/random and /search/explore

### DIFF
--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -380,7 +380,7 @@ The adapter implements a subset of Immich's API surface. Unimplemented endpoints
 | People | CRUD, list with pagination/sort/filter, thumbnails, statistics, merge | |
 | Faces | List, create, delete, reassign | Create draws a user-specified box on an asset and links it to a person (Immich's "create a face on-the-fly" flow) |
 | Timeline | Time buckets (monthly), bucket contents | Date-range filtering with timezone handling, including `isTrashed=true` |
-| Search | Smart search, metadata search, person search, statistics | Places, suggestions, explore are stubs |
+| Search | Smart search, metadata search, person search, statistics, random sampling, explore (cities + recents) | Places, suggestions are stubs |
 | Sync | Full sync, delta sync, stream, ack | Two-phase ordering, checkpoint management |
 | Auth | OAuth login/callback, logout, session management | Clerk OAuth via the Gumnut API |
 | WebSockets | Real-time upload/trash/restore/delete notifications | Socket.IO with room-based messaging |

--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Immich Adapter Architecture"
-last-updated: 2026-06-25
+last-updated: 2026-07-03
 ---
 
 # Immich Adapter Architecture
@@ -380,7 +380,7 @@ The adapter implements a subset of Immich's API surface. Unimplemented endpoints
 | People | CRUD, list with pagination/sort/filter, thumbnails, statistics, merge | |
 | Faces | List, create, delete, reassign | Create draws a user-specified box on an asset and links it to a person (Immich's "create a face on-the-fly" flow) |
 | Timeline | Time buckets (monthly), bucket contents | Date-range filtering with timezone handling, including `isTrashed=true` |
-| Search | Smart search, metadata search, person search, statistics, random sampling, explore (cities + recents) | Places, suggestions are stubs |
+| Search | Smart search, metadata search, person search, statistics, random sampling, explore (cities + recents) | Places, cities, suggestions, and large-assets are stubs |
 | Sync | Full sync, delta sync, stream, ack | Two-phase ordering, checkpoint management |
 | Auth | OAuth login/callback, logout, session management | Clerk OAuth via the Gumnut API |
 | WebSockets | Real-time upload/trash/restore/delete notifications | Socket.IO with room-based messaging |

--- a/docs/design-docs/immich-adapter-gap-analysis.md
+++ b/docs/design-docs/immich-adapter-gap-analysis.md
@@ -242,28 +242,28 @@ Immich has an in-app notification system for events like album sharing invitatio
 
 ---
 
-### 12. Search Gaps (6 stub endpoints within search module)
+### 12. Search Gaps (4 stub endpoints within search module)
 
-The search module has 3 real implementations (metadata, smart, person) and 6 stubs.
+The search module has 5 real implementations (metadata, smart, person, random, explore) and 4 stubs.
 
 | Endpoint | Current behavior | Impact |
 |----------|-----------------|--------|
-| `GET /search/explore` | Empty list | **Low** — Curated categories, rarely used |
+| ~~`GET /search/explore`~~ | Closed — cities (`exifInfo.city`) + recents (`createdAt`) groups derived from recent assets | — |
 | `POST /search/large-assets` | Empty list | **Low** — Storage management tool |
 | `GET /search/places` | Empty list | **Medium** — Location search, tied to map/EXIF |
 | `GET /search/suggestions` | Empty list | **Medium** — Autocomplete for search bar |
 | `GET /search/cities` | Empty list | **Low** — City list for location filtering |
-| `POST /search/random` | Empty list | **Low** — Random photo selection |
+| ~~`POST /search/random`~~ | Closed — uniform random sample via month-bucket counts | — |
 
 **Dependency**: Per-endpoint breakdown:
 - **Places/cities**: Need reverse geocoding for human-readable place names — tied to gap #3b, not #3a (GPS coordinates alone don't provide place names).
 - **Suggestions**: In v2.7.5, `SearchSuggestionType` includes `country`, `state`, `city` (location-based, tied to #3b) and `camera-make`, `camera-model` (EXIF-based, potentially adapter-only if EXIF data is already in the backend).
-- **Random/explore**: Adapter-only with existing asset APIs.
+- **Random/explore**: Closed — implemented adapter-only on existing asset APIs (random via month-bucket count sampling, explore via a recent-asset scan grouped by `metadata.city`).
 - **Large-assets**: Needs file size data from backend.
 
-**Effort**: **M** total for the adapter-implementable ones (random, explore, camera suggestions). Location-based search is tied to reverse geocoding (#3b).
+**Effort**: **S** for the remaining adapter-implementable one (camera suggestions). Location-based search is tied to reverse geocoding (#3b).
 
-**Recommendation**: **Close** random and explore (S each, adapter-only). Camera suggestions may be closeable independently (S, adapter-only if EXIF data available). Location-based endpoints close when reverse geocoding (#3b) closes.
+**Recommendation**: Camera suggestions may be closeable independently (S, adapter-only if EXIF data available). Location-based endpoints close when reverse geocoding (#3b) closes.
 
 ---
 
@@ -625,7 +625,7 @@ These are architectural limitations documented in `docs/architecture/adapter-arc
 | Gap | Effort | Dependency | Rationale |
 |-----|--------|------------|-----------|
 | ~~#21 Face create~~ | — | — | Closed — `POST /api/faces` draws a user box and links it to a person; needed `gumnut-sdk >= 0.116.0` |
-| #12 Search random/explore | S | Adapter-only | Easy adapter-only work |
+| ~~#12 Search random/explore~~ | — | — | Closed — random samples uniformly via month-bucket counts; explore returns cities + recents groups |
 | #5 Download / archive | M | Adapter-only | Pure adapter work, clear user value |
 | ~~#33 Video playback (mobile)~~ | — | — | Closed — CDN streaming with Range support; advertises `Accept-Ranges: bytes` on 200 for iOS AVPlayer |
 

--- a/docs/design-docs/immich-adapter-gap-analysis.md
+++ b/docs/design-docs/immich-adapter-gap-analysis.md
@@ -17,8 +17,8 @@ Today, the core photo workflow works: upload, browse timeline, organize into alb
 
 | Category | Endpoint count | Status |
 |----------|---------------|--------|
-| Fully implemented (real SDK calls) | ~77 | Assets (including video playback), albums, people, faces, timeline, sync, OAuth, search (partial), sessions (partial) |
-| Stubs (empty/fake responses) | ~114 | Tags, shared links, stacks, activities, admin, server info, etc. |
+| Fully implemented (real SDK calls) | ~79 | Assets (including video playback), albums, people, faces, timeline, sync, OAuth, search (partial), sessions (partial) |
+| Stubs (empty/fake responses) | ~112 | Tags, shared links, stacks, activities, admin, server info, etc. |
 | Total in adapter | ~192 | |
 | Not routed (no adapter endpoint) | ~52 | Immich endpoints with no adapter route at all (e.g., asset edits, database backups, workflows, plugins, some auth/admin endpoints) |
 | Total in Immich v2.7.5 spec | 244 | |

--- a/docs/design-docs/immich-adapter-gap-analysis.md
+++ b/docs/design-docs/immich-adapter-gap-analysis.md
@@ -2,7 +2,7 @@
 title: "Immich Adapter Gap Analysis"
 status: active
 created: 2026-04-15
-last-updated: 2026-06-16
+last-updated: 2026-07-03
 ---
 
 # Immich Adapter Gap Analysis

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -1,6 +1,6 @@
 ---
 title: "Code Practices"
-last-updated: 2026-07-02
+last-updated: 2026-07-03
 ---
 
 # Code Practices
@@ -118,6 +118,7 @@ The SDK is auto-generated (Stainless), so a version bump can add **newly-require
    - `PUT /people/{id}/reassign` — `{id}` is the target person (reassign TO); body items are sources.
    - `PUT /faces/{id}` — `{id}` is the target person (reassign TO); body `FaceDto.id` is the face being reassigned.
    - When fixing a path/body or ID-decoding bug in one handler, audit sibling handlers in the same router (and adjacent routers) for the same trap before closing the fix. A one-line search (`grep -rn` for the pattern) is cheap insurance against the same class-of-bug recurring.
+   - For loosely-specified response values (free-form strings, group/field names), also check how the Immich **clients** consume the response (`immich/web/src/` and `immich/mobile/lib/`) — clients hard-match values the OpenAPI spec doesn't constrain. E.g., the explore page renders only the group with `fieldName == "exifInfo.city"`, so a spec-valid response with different group names would silently render nothing.
 5. **Validate compatibility**: Run `validate_api_compatibility.py` to ensure correct implementation
 6. **Test endpoints**: Verify responses match Immich API expectations
 7. **Audit `/me/preferences` for a gating boolean**: Many client UI features (memories, tags, ratings, folders, people, shared links, email notifications, cast) are gated client-side on a flag in `UserPreferencesResponseDto`. The default in `routers/api/users.py::userPreferencesResponse` ships most of these as `enabled=False`, which silently hides the corresponding UI even after the backing endpoints are wired up. When implementing an endpoint that backs a client UI feature, grep `routers/api/users.py` for the matching preference field and flip its `enabled` to `True`. The Immich web client checks these via `$preferences?.<area>?.enabled`; missing the flip means the new endpoints become dead code on the client.

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -302,6 +302,8 @@ async for asset in client.assets.list(local_datetime_after=..., limit=N):
 
 Without the break, a `limit=1` "is this non-empty?" probe on a busy day burns one round-trip per matching asset.
 
+The `local_datetime_after` / `local_datetime_before` list filters are **exclusive on both ends**. Don't pass a month start directly as the after-bound — an asset captured exactly at month-start midnight is counted in that month's `counts` bucket but excluded from the listing. Build month windows with `month_query_bounds` in `routers/api/timeline.py`, which backs the after-bound off by one microsecond.
+
 ### Parallel Fan-Out with `asyncio.gather`
 
 For endpoints that fan out N parallel backend calls where partial results are friendlier than a 500 (e.g., the OnThisDay memories carousel — N-1 years still produces a useful response), pass `return_exceptions=True` so a single transient failure doesn't cancel the others. Filter on `Exception`, not `BaseException`, so `asyncio.CancelledError` (which inherits from `BaseException`) propagates instead of being swallowed as a backend error:

--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -34,7 +34,7 @@ from routers.immich_models import (
     StatisticsSearchDto,
     UserResponseDto,
 )
-from routers.api.timeline import fetch_asset_counts, month_window
+from routers.api.timeline import fetch_asset_counts, month_query_bounds
 from routers.utils.concurrency import gather_with_concurrency
 from routers.utils.asset_conversion import (
     ASSET_INCLUDE,
@@ -354,13 +354,13 @@ async def _fetch_month_assets_at_offsets(
     the end of the month are silently skipped, so the sample may come up
     short rather than erroring.
     """
-    month_start, next_month_start = month_window(time_bucket)
+    after_bound, before_bound = month_query_bounds(time_bucket)
     wanted = set(offsets)
     max_offset = max(offsets)
 
     list_kwargs: dict[str, Any] = {
-        "local_datetime_after": month_start.isoformat(),
-        "local_datetime_before": next_month_start.isoformat(),
+        "local_datetime_after": after_bound,
+        "local_datetime_before": before_bound,
         "state": "live",
         "limit": GUMNUT_API_MAX_PAGE_SIZE,
         "include": ASSET_INCLUDE,
@@ -381,7 +381,7 @@ async def _fetch_month_assets_at_offsets(
     if len(picked) < len(wanted):
         logger.debug(
             "random sample month %s yielded %d of %d requested offsets",
-            month_start.isoformat(),
+            time_bucket.isoformat(),
             len(picked),
             len(wanted),
         )
@@ -402,15 +402,18 @@ async def search_random(
     only the months containing sampled indices.
 
     Supported filters: `size` (defaults to `RANDOM_DEFAULT_SIZE`, matching the
-    Immich server), and single-element `albumIds` / `personIds`. Any other
-    restricting filter (asset type, date bounds, location/camera metadata,
-    tags, rating, etc.) has no Gumnut API translation and returns an empty
-    list rather than silently sampling assets the caller filtered out — the
-    same posture the timeline endpoint takes for favorites and non-timeline
-    visibility. Response-shape hints (`withExif`, `withPeople`, `withStacked`)
-    are always satisfied (the sample converts with the full include set), and
-    `withDeleted` is ignored: it *widens* the requested set to include trashed
-    assets, so a live-only sample still matches the filter.
+    Immich server), single-element `albumIds` / `personIds`, and `type`.
+    `type` is applied to the drawn sample (the Gumnut API cannot filter by
+    asset type server-side), so each matching asset is equally likely but the
+    response may hold fewer than `size` items when the library is sparse in
+    that type. Any other restricting filter (date bounds, location/camera
+    metadata, tags, rating, etc.) has no Gumnut API translation and returns
+    an empty list rather than silently sampling assets the caller filtered
+    out — the same posture the timeline endpoint takes for favorites and
+    non-timeline visibility. Response-shape hints (`withExif`, `withPeople`,
+    `withStacked`) are always satisfied (the sample converts with the full
+    include set), and `withDeleted` is ignored: it *widens* the requested set
+    to include trashed assets, so a live-only sample still matches the filter.
     """
     if request.isFavorite or (
         request.visibility is not None
@@ -445,7 +448,6 @@ async def search_random(
         request.model,
         request.ocr,
         request.rating,
-        request.type,
     )
     unsupported_flag_filters = (
         request.isEncoded,
@@ -505,5 +507,14 @@ async def search_random(
     )
 
     sampled = [asset for month_assets in month_results for asset in month_assets]
+    if request.type is not None:
+        # Post-sample filtering keeps the sample uniform over matching assets
+        # (the Gumnut API has no server-side type filter) at the cost of
+        # under-filling `size` when the library is sparse in the type.
+        sampled = [
+            asset
+            for asset in sampled
+            if mime_type_to_asset_type(asset.mime_type) == request.type
+        ]
     random.shuffle(sampled)
     return [convert_gumnut_asset_to_immich(asset, current_user) for asset in sampled]

--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -402,11 +402,15 @@ async def search_random(
     only the months containing sampled indices.
 
     Supported filters: `size` (defaults to `RANDOM_DEFAULT_SIZE`, matching the
-    Immich server), and single-element `albumIds` / `personIds`. Requests for
-    favorites or non-timeline visibility return an empty list (Gumnut does not
-    support favorites, hidden, archived or locked assets), as do multi-element
-    `albumIds` / `personIds` (no Gumnut API for those combinations). Other
-    metadata filters are not supported and are ignored.
+    Immich server), and single-element `albumIds` / `personIds`. Any other
+    restricting filter (asset type, date bounds, location/camera metadata,
+    tags, rating, etc.) has no Gumnut API translation and returns an empty
+    list rather than silently sampling assets the caller filtered out — the
+    same posture the timeline endpoint takes for favorites and non-timeline
+    visibility. Response-shape hints (`withExif`, `withPeople`, `withStacked`)
+    are always satisfied (the sample converts with the full include set), and
+    `withDeleted` is ignored: it *widens* the requested set to include trashed
+    assets, so a live-only sample still matches the filter.
     """
     if request.isFavorite or (
         request.visibility is not None
@@ -416,6 +420,44 @@ async def search_random(
     if request.albumIds and len(request.albumIds) > 1:
         return []
     if request.personIds and len(request.personIds) > 1:
+        return []
+    # Restricting filters with no Gumnut API translation. Sampling without
+    # applying them would return assets the caller explicitly filtered out,
+    # so return empty instead. Booleans count only when truthy: `False` on
+    # flags like isMotion/isEncoded matches effectively every Gumnut asset
+    # (the backing features don't exist), so it doesn't restrict the sample.
+    unsupported_value_filters = (
+        request.city,
+        request.country,
+        request.state,
+        request.createdAfter,
+        request.createdBefore,
+        request.takenAfter,
+        request.takenBefore,
+        request.trashedAfter,
+        request.trashedBefore,
+        request.updatedAfter,
+        request.updatedBefore,
+        request.deviceId,
+        request.lensModel,
+        request.libraryId,
+        request.make,
+        request.model,
+        request.ocr,
+        request.rating,
+        request.type,
+    )
+    unsupported_flag_filters = (
+        request.isEncoded,
+        request.isMotion,
+        request.isNotInAlbum,
+        request.isOffline,
+    )
+    if (
+        any(value is not None for value in unsupported_value_filters)
+        or any(unsupported_flag_filters)
+        or request.tagIds
+    ):
         return []
 
     album_id = (

--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -72,7 +72,9 @@ async def get_explore_data(
     """
     Return curated explore categories: one representative image per city
     ("exifInfo.city", the group the Immich web and mobile explore pages
-    render as Places) and the most recently created images ("createdAt").
+    render as Places) and a recent-images group ("createdAt"). The recents
+    group approximates the Immich server's most-recently-*uploaded* group
+    using capture-time order, the only ordering the Gumnut list API offers.
 
     Cities are derived from the `EXPLORE_SCAN_LIMIT` most recent live assets;
     only cities with at least `EXPLORE_MIN_ASSETS_PER_CITY` images in that

--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -51,10 +51,8 @@ router = APIRouter(
     responses={404: {"description": "Not found"}},
 )
 
-# Explore derives its "Places" cities from a bounded window of the most recent
-# live assets rather than a full-library scan; older cities that don't appear
-# in the window are omitted. Field limits mirror the Immich server defaults
-# (maxFields=12, minAssetsPerField=5).
+# Field limits mirror the Immich server defaults (maxFields=12,
+# minAssetsPerField=5); the derivation is described in get_explore_data.
 EXPLORE_SCAN_LIMIT = 1000
 EXPLORE_MAX_CITIES = 12
 EXPLORE_MIN_ASSETS_PER_CITY = 5
@@ -508,9 +506,7 @@ async def search_random(
 
     sampled = [asset for month_assets in month_results for asset in month_assets]
     if request.type is not None:
-        # Post-sample filtering keeps the sample uniform over matching assets
-        # (the Gumnut API has no server-side type filter) at the cost of
-        # under-filling `size` when the library is sparse in the type.
+        # Post-sample filter — rationale in the docstring's `type` note.
         sampled = [
             asset
             for asset in sampled

--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -1,18 +1,25 @@
+import asyncio
 import logging
+import random
 from typing import Any, List
 from fastapi import APIRouter, Depends, Query
 from uuid import UUID
 from datetime import datetime
 from gumnut import AsyncGumnut
+from gumnut.types.asset_response import AssetResponse
 
 from routers.api.constants import GUMNUT_API_MAX_PAGE_SIZE
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
 from routers.utils.current_user import get_current_user
-from routers.utils.gumnut_id_conversion import uuid_to_gumnut_person_id
+from routers.utils.gumnut_id_conversion import (
+    uuid_to_gumnut_album_id,
+    uuid_to_gumnut_person_id,
+)
 from routers.utils.person_conversion import convert_gumnut_person_to_immich
 from routers.immich_models import (
     PersonResponseDto,
     SearchAlbumResponseDto,
+    SearchExploreItem,
     SearchExploreResponseDto,
     AssetResponseDto,
     AssetTypeEnum,
@@ -29,7 +36,12 @@ from routers.immich_models import (
     UserResponseDto,
 )
 from routers.api.timeline import fetch_asset_counts
-from routers.utils.asset_conversion import ASSET_INCLUDE, convert_gumnut_asset_to_immich
+from routers.utils.asset_conversion import (
+    ASSET_INCLUDE,
+    ASSET_INCLUDE_METADATA_ONLY,
+    convert_gumnut_asset_to_immich,
+    mime_type_to_asset_type,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -39,17 +51,100 @@ router = APIRouter(
     responses={404: {"description": "Not found"}},
 )
 
+# Explore derives its "Places" cities from a bounded window of the most recent
+# live assets rather than a full-library scan; older cities that don't appear
+# in the window are omitted. Field limits mirror the Immich server defaults
+# (maxFields=12, minAssetsPerField=5).
+EXPLORE_SCAN_LIMIT = 1000
+EXPLORE_MAX_CITIES = 12
+EXPLORE_MIN_ASSETS_PER_CITY = 5
+EXPLORE_MAX_RECENT_ASSETS = 12
+
+# The Immich server samples 250 assets when the request doesn't specify a size.
+RANDOM_DEFAULT_SIZE = 250
+
 
 @router.get("/explore")
 async def get_explore_data(
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
+    current_user: UserResponseDto = Depends(get_current_user),
 ) -> List[SearchExploreResponseDto]:
     """
-    Return a list of map markers.
-    This is a stub implementation that returns an empty list.
-    """
+    Return curated explore categories: one representative image per city
+    ("exifInfo.city", the group the Immich web and mobile explore pages
+    render as Places) and the most recently created images ("createdAt").
 
-    return []
+    Cities are derived from the `EXPLORE_SCAN_LIMIT` most recent live assets;
+    only cities with at least `EXPLORE_MIN_ASSETS_PER_CITY` images in that
+    window are included, capped at `EXPLORE_MAX_CITIES`.
+    """
+    scanned: list[AssetResponse] = []
+    async for asset in client.assets.list(
+        state="live",
+        limit=GUMNUT_API_MAX_PAGE_SIZE,
+        include=ASSET_INCLUDE_METADATA_ONLY,
+    ):
+        scanned.append(asset)
+        if len(scanned) >= EXPLORE_SCAN_LIMIT:
+            break
+
+    # Newest-first scan order, so the first asset seen for a city is its
+    # most recent image and becomes the representative.
+    city_representative: dict[str, str] = {}
+    city_counts: dict[str, int] = {}
+    recent_ids: list[str] = []
+    for asset in scanned:
+        if mime_type_to_asset_type(asset.mime_type) != AssetTypeEnum.IMAGE:
+            continue
+        if len(recent_ids) < EXPLORE_MAX_RECENT_ASSETS:
+            recent_ids.append(asset.id)
+        city = asset.metadata.city if asset.metadata else None
+        if city:
+            city_str = str(city)
+            city_counts[city_str] = city_counts.get(city_str, 0) + 1
+            city_representative.setdefault(city_str, asset.id)
+
+    cities = [
+        city
+        for city in city_representative
+        if city_counts[city] >= EXPLORE_MIN_ASSETS_PER_CITY
+    ][:EXPLORE_MAX_CITIES]
+
+    # Re-fetch the representatives with the full include set (the scan is
+    # metadata-only) in one batched call.
+    wanted_ids = list(
+        dict.fromkeys([city_representative[city] for city in cities] + recent_ids)
+    )
+    assets_by_id: dict[str, AssetResponse] = {}
+    if wanted_ids:
+        async for asset in client.assets.list(ids=wanted_ids, include=ASSET_INCLUDE):
+            assets_by_id[asset.id] = asset
+
+    converted = {
+        asset_id: convert_gumnut_asset_to_immich(asset, current_user)
+        for asset_id, asset in assets_by_id.items()
+    }
+
+    # Assets may disappear between the scan and the batched re-fetch; skip
+    # any representative that no longer resolves.
+    city_items = [
+        SearchExploreItem(value=city, data=converted[city_representative[city]])
+        for city in cities
+        if city_representative[city] in converted
+    ]
+    recent_items = [
+        SearchExploreItem(
+            value=assets_by_id[asset_id].created_at.isoformat(),
+            data=converted[asset_id],
+        )
+        for asset_id in recent_ids
+        if asset_id in converted
+    ]
+
+    return [
+        SearchExploreResponseDto(fieldName="exifInfo.city", items=city_items),
+        SearchExploreResponseDto(fieldName="createdAt", items=recent_items),
+    ]
 
 
 @router.post("/large-assets")
@@ -242,13 +337,132 @@ async def get_assets_by_city(
     return []
 
 
+def _month_window(time_bucket: datetime) -> tuple[datetime, datetime]:
+    """Return the naive [month_start, next_month_start) window for a count bucket."""
+    month_start = time_bucket.replace(
+        tzinfo=None, day=1, hour=0, minute=0, second=0, microsecond=0
+    )
+    if month_start.month == 12:
+        next_month_start = month_start.replace(year=month_start.year + 1, month=1)
+    else:
+        next_month_start = month_start.replace(month=month_start.month + 1)
+    return month_start, next_month_start
+
+
+async def _fetch_month_assets_at_offsets(
+    client: AsyncGumnut,
+    time_bucket: datetime,
+    offsets: list[int],
+    *,
+    album_id: str | None,
+    person_id: str | None,
+) -> list[AssetResponse]:
+    """Fetch the assets at the given newest-first offsets within a month bucket.
+
+    Pages through the month only as far as the largest requested offset. If
+    the library changed between the counts call and this fetch, offsets past
+    the end of the month are silently skipped, so the sample may come up
+    short rather than erroring.
+    """
+    month_start, next_month_start = _month_window(time_bucket)
+    wanted = set(offsets)
+    max_offset = max(offsets)
+
+    list_kwargs: dict[str, Any] = {
+        "local_datetime_after": month_start.isoformat(),
+        "local_datetime_before": next_month_start.isoformat(),
+        "state": "live",
+        "limit": GUMNUT_API_MAX_PAGE_SIZE,
+        "include": ASSET_INCLUDE,
+    }
+    if album_id is not None:
+        list_kwargs["album_id"] = album_id
+    if person_id is not None:
+        list_kwargs["person_id"] = person_id
+
+    picked: list[AssetResponse] = []
+    index = 0
+    async for asset in client.assets.list(**list_kwargs):
+        if index in wanted:
+            picked.append(asset)
+        index += 1
+        if index > max_offset:
+            break
+    return picked
+
+
 @router.post("/random")
 async def search_random(
     request: RandomSearchDto,
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
+    current_user: UserResponseDto = Depends(get_current_user),
 ) -> List[AssetResponseDto]:
     """
-    Get random assets.
-    This is a stub implementation that returns an empty list.
+    Return a uniform random sample of live assets.
+
+    Samples without a full-library scan: fetches the per-month asset counts,
+    draws distinct global indices across the newest-first ordering, and pages
+    only the months containing sampled indices.
+
+    Supported filters: `size` (defaults to `RANDOM_DEFAULT_SIZE`, matching the
+    Immich server), and single-element `albumIds` / `personIds`. Requests for
+    favorites or non-timeline visibility return an empty list (Gumnut does not
+    support favorites, hidden, archived or locked assets), as do multi-element
+    `albumIds` / `personIds` (no Gumnut API for those combinations). Other
+    metadata filters are not supported and are ignored.
     """
-    return []
+    if request.isFavorite or (
+        request.visibility is not None
+        and request.visibility != AssetVisibility.timeline
+    ):
+        return []
+    if request.albumIds and len(request.albumIds) > 1:
+        return []
+    if request.personIds and len(request.personIds) > 1:
+        return []
+
+    album_id = (
+        uuid_to_gumnut_album_id(request.albumIds[0]) if request.albumIds else None
+    )
+    person_id = (
+        uuid_to_gumnut_person_id(request.personIds[0]) if request.personIds else None
+    )
+
+    buckets = await fetch_asset_counts(client, album_id=album_id, person_id=person_id)
+    total = sum(bucket.count for bucket in buckets)
+    if total == 0:
+        return []
+
+    sample_size = min(
+        int(request.size) if request.size is not None else RANDOM_DEFAULT_SIZE, total
+    )
+    picks = sorted(random.sample(range(total), sample_size))
+
+    # Map sampled global indices (over the newest-first ordering the counts
+    # buckets and asset listings share) to per-month offsets.
+    months_with_offsets: list[tuple[datetime, list[int]]] = []
+    cursor = 0
+    pick_iter = iter(picks)
+    current_pick = next(pick_iter, None)
+    for bucket in buckets:
+        bucket_end = cursor + bucket.count
+        offsets: list[int] = []
+        while current_pick is not None and current_pick < bucket_end:
+            offsets.append(current_pick - cursor)
+            current_pick = next(pick_iter, None)
+        if offsets:
+            months_with_offsets.append((bucket.time_bucket, offsets))
+        cursor = bucket_end
+
+    month_results = await asyncio.gather(
+        *(
+            _fetch_month_assets_at_offsets(
+                client, time_bucket, offsets, album_id=album_id, person_id=person_id
+            )
+            for time_bucket, offsets in months_with_offsets
+        )
+    )
+
+    sampled = [asset for month_assets in month_results for asset in month_assets]
+    random.shuffle(sampled)
+    return [convert_gumnut_asset_to_immich(asset, current_user) for asset in sampled]

--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import random
 from typing import Any, List
@@ -35,7 +34,8 @@ from routers.immich_models import (
     StatisticsSearchDto,
     UserResponseDto,
 )
-from routers.api.timeline import fetch_asset_counts
+from routers.api.timeline import fetch_asset_counts, month_window
+from routers.utils.concurrency import gather_with_concurrency
 from routers.utils.asset_conversion import (
     ASSET_INCLUDE,
     ASSET_INCLUDE_METADATA_ONLY,
@@ -337,18 +337,6 @@ async def get_assets_by_city(
     return []
 
 
-def _month_window(time_bucket: datetime) -> tuple[datetime, datetime]:
-    """Return the naive [month_start, next_month_start) window for a count bucket."""
-    month_start = time_bucket.replace(
-        tzinfo=None, day=1, hour=0, minute=0, second=0, microsecond=0
-    )
-    if month_start.month == 12:
-        next_month_start = month_start.replace(year=month_start.year + 1, month=1)
-    else:
-        next_month_start = month_start.replace(month=month_start.month + 1)
-    return month_start, next_month_start
-
-
 async def _fetch_month_assets_at_offsets(
     client: AsyncGumnut,
     time_bucket: datetime,
@@ -364,7 +352,7 @@ async def _fetch_month_assets_at_offsets(
     the end of the month are silently skipped, so the sample may come up
     short rather than erroring.
     """
-    month_start, next_month_start = _month_window(time_bucket)
+    month_start, next_month_start = month_window(time_bucket)
     wanted = set(offsets)
     max_offset = max(offsets)
 
@@ -388,6 +376,13 @@ async def _fetch_month_assets_at_offsets(
         index += 1
         if index > max_offset:
             break
+    if len(picked) < len(wanted):
+        logger.debug(
+            "random sample month %s yielded %d of %d requested offsets",
+            month_start.isoformat(),
+            len(picked),
+            len(wanted),
+        )
     return picked
 
 
@@ -454,13 +449,15 @@ async def search_random(
             months_with_offsets.append((bucket.time_bucket, offsets))
         cursor = bucket_end
 
-    month_results = await asyncio.gather(
-        *(
+    # A 250-asset sample over a long-lived library can touch hundreds of
+    # months; bound the fan-out so one request can't swamp the backend.
+    month_results = await gather_with_concurrency(
+        [
             _fetch_month_assets_at_offsets(
                 client, time_bucket, offsets, album_id=album_id, person_id=person_id
             )
             for time_bucket, offsets in months_with_offsets
-        )
+        ]
     )
 
     sampled = [asset for month_assets in month_results for asset in month_assets]

--- a/routers/api/timeline.py
+++ b/routers/api/timeline.py
@@ -65,12 +65,15 @@ async def fetch_asset_counts(
 
 
 def month_window(moment: datetime) -> tuple[datetime, datetime]:
-    """Return the naive [month_start, next_month_start) window containing `moment`.
+    """Return the naive (month_start, next_month_start) window containing `moment`.
 
     Boundaries are naive on purpose: the Gumnut API counts endpoint groups by
     date_trunc("month", local_datetime) on the naive column, so month windows
     used to fetch a bucket's assets must compare wall-clock local_datetime
-    directly. Uses a half-open interval for clean boundaries.
+    directly. Note the Gumnut API treats `local_datetime_after` as exclusive,
+    so an asset captured at exactly month-start midnight is counted in the
+    bucket but skipped by a listing over this window — an accepted edge case
+    (matches the prior inline behavior of the time-bucket endpoint).
     """
     month_start = moment.replace(
         tzinfo=None, day=1, hour=0, minute=0, second=0, microsecond=0

--- a/routers/api/timeline.py
+++ b/routers/api/timeline.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, List, Literal
 from uuid import UUID
 
@@ -70,10 +70,9 @@ def month_window(moment: datetime) -> tuple[datetime, datetime]:
     Boundaries are naive on purpose: the Gumnut API counts endpoint groups by
     date_trunc("month", local_datetime) on the naive column, so month windows
     used to fetch a bucket's assets must compare wall-clock local_datetime
-    directly. Note the Gumnut API treats `local_datetime_after` as exclusive,
-    so an asset captured at exactly month-start midnight is counted in the
-    bucket but skipped by a listing over this window — an accepted edge case
-    (matches the prior inline behavior of the time-bucket endpoint).
+    directly. When building `assets.list` date bounds from this window, use
+    `month_query_bounds` — passing `month_start` directly as
+    `local_datetime_after` silently excludes month-start-midnight assets.
     """
     month_start = moment.replace(
         tzinfo=None, day=1, hour=0, minute=0, second=0, microsecond=0
@@ -83,6 +82,21 @@ def month_window(moment: datetime) -> tuple[datetime, datetime]:
     else:
         next_month_start = month_start.replace(month=month_start.month + 1)
     return month_start, next_month_start
+
+
+def month_query_bounds(moment: datetime) -> tuple[str, str]:
+    """ISO-8601 `assets.list` date bounds covering `moment`'s month.
+
+    The Gumnut API treats `local_datetime_after` as exclusive, so the lower
+    bound backs off one microsecond from month start — otherwise an asset
+    captured exactly at month-start midnight is counted in the month's bucket
+    by the counts endpoint but never returned by a listing over the window.
+    """
+    month_start, next_month_start = month_window(moment)
+    return (
+        (month_start - timedelta(microseconds=1)).isoformat(),
+        next_month_start.isoformat(),
+    )
 
 
 @router.get("/buckets")
@@ -172,12 +186,12 @@ async def get_time_bucket(
 
     # Compute month boundaries from timeBucket for server-side date filtering.
     # The Immich client may send naive ("2024-01-01T00:00:00") or UTC-aware
-    # ("2024-01-01T00:00:00.000Z") timestamps; month_window strips timezone
-    # info so boundaries are naive (see its docstring for why).
-    month_start, next_month_start = month_window(datetime.fromisoformat(timeBucket))
+    # ("2024-01-01T00:00:00.000Z") timestamps; the month helpers strip
+    # timezone info so boundaries are naive (see month_window's docstring).
+    after_bound, before_bound = month_query_bounds(datetime.fromisoformat(timeBucket))
     date_range_query = {
-        "local_datetime_after": month_start.isoformat(),
-        "local_datetime_before": next_month_start.isoformat(),
+        "local_datetime_after": after_bound,
+        "local_datetime_before": before_bound,
     }
 
     list_kwargs: dict[str, Any] = {"extra_query": date_range_query}

--- a/routers/api/timeline.py
+++ b/routers/api/timeline.py
@@ -64,6 +64,24 @@ async def fetch_asset_counts(
     return all_buckets
 
 
+def month_window(moment: datetime) -> tuple[datetime, datetime]:
+    """Return the naive [month_start, next_month_start) window containing `moment`.
+
+    Boundaries are naive on purpose: the Gumnut API counts endpoint groups by
+    date_trunc("month", local_datetime) on the naive column, so month windows
+    used to fetch a bucket's assets must compare wall-clock local_datetime
+    directly. Uses a half-open interval for clean boundaries.
+    """
+    month_start = moment.replace(
+        tzinfo=None, day=1, hour=0, minute=0, second=0, microsecond=0
+    )
+    if month_start.month == 12:
+        next_month_start = month_start.replace(year=month_start.year + 1, month=1)
+    else:
+        next_month_start = month_start.replace(month=month_start.month + 1)
+    return month_start, next_month_start
+
+
 @router.get("/buckets")
 async def get_time_buckets(
     albumId: UUID = Query(default=None),
@@ -151,16 +169,9 @@ async def get_time_bucket(
 
     # Compute month boundaries from timeBucket for server-side date filtering.
     # The Immich client may send naive ("2024-01-01T00:00:00") or UTC-aware
-    # ("2024-01-01T00:00:00.000Z") timestamps. We always strip timezone info
-    # so boundaries are naive, matching the Gumnut API counts endpoint which
-    # groups by date_trunc("month", local_datetime) on the naive column.
-    # Uses a half-open interval [month_start, next_month_start) for clean boundaries.
-    bucket_date = datetime.fromisoformat(timeBucket).replace(tzinfo=None)
-    month_start = bucket_date.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-    if month_start.month == 12:
-        next_month_start = month_start.replace(year=month_start.year + 1, month=1)
-    else:
-        next_month_start = month_start.replace(month=month_start.month + 1)
+    # ("2024-01-01T00:00:00.000Z") timestamps; month_window strips timezone
+    # info so boundaries are naive (see its docstring for why).
+    month_start, next_month_start = month_window(datetime.fromisoformat(timeBucket))
     date_range_query = {
         "local_datetime_after": month_start.isoformat(),
         "local_datetime_before": next_month_start.isoformat(),

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -14,6 +14,7 @@ from routers.api.search import (
     search_smart,
 )
 from routers.immich_models import (
+    AssetTypeEnum,
     AssetVisibility,
     MetadataSearchDto,
     RandomSearchDto,
@@ -744,6 +745,54 @@ class TestSearchRandom:
             )
             assert result == []
         mock_client.assets.counts.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_returns_empty_for_unsupported_restricting_filters(
+        self, mock_current_user
+    ):
+        """Filters with no Gumnut translation return empty, never a mis-filtered sample."""
+        mock_client = Mock()
+
+        for request in (
+            RandomSearchDto(type=AssetTypeEnum.VIDEO),
+            RandomSearchDto(takenAfter=datetime(2024, 1, 1, tzinfo=timezone.utc)),
+            RandomSearchDto(city="Sydney"),
+            RandomSearchDto(rating=0),
+            RandomSearchDto(isMotion=True),
+            RandomSearchDto(tagIds=[uuid4()]),
+        ):
+            result = await search_random(
+                request=request, client=mock_client, current_user=mock_current_user
+            )
+            assert result == []
+        mock_client.assets.counts.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_non_restricting_fields_still_sample(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """Response-shape hints, widening flags, and falsy booleans don't empty the sample."""
+        jan_assets = [_make_search_asset(datetime(2024, 1, 15, tzinfo=timezone.utc))]
+        buckets = [_make_count_bucket(1, datetime(2024, 1, 1))]
+        months = {"2024-01-01T00:00:00": jan_assets}
+        mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
+
+        result = await search_random(
+            request=RandomSearchDto(
+                size=1,
+                withExif=True,
+                withPeople=True,
+                withStacked=True,
+                withDeleted=True,
+                isMotion=False,
+                isEncoded=False,
+                isFavorite=False,
+            ),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert len(result) == 1
 
     @pytest.mark.anyio
     async def test_returns_empty_when_library_empty(self, mock_current_user):

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -767,6 +767,50 @@ class TestSearchRandom:
             assert result == []
         mock_client.assets.counts.assert_not_called()
 
+    def test_all_dto_fields_have_a_disposition(self):
+        """Force a conscious decision when the generated DTO gains fields.
+
+        The filter guard in search_random is a hand-maintained enumeration of
+        RandomSearchDto fields. immich_models.py is regenerated from the
+        Immich OpenAPI spec, so a new restricting field would otherwise be
+        silently ignored and the endpoint would sample assets the caller
+        filtered out.
+        """
+        translated = {"size", "albumIds", "personIds"}
+        guarded = {
+            "isFavorite",
+            "visibility",
+            "city",
+            "country",
+            "state",
+            "createdAfter",
+            "createdBefore",
+            "takenAfter",
+            "takenBefore",
+            "trashedAfter",
+            "trashedBefore",
+            "updatedAfter",
+            "updatedBefore",
+            "deviceId",
+            "lensModel",
+            "libraryId",
+            "make",
+            "model",
+            "ocr",
+            "rating",
+            "tagIds",
+            "type",
+            "isEncoded",
+            "isMotion",
+            "isNotInAlbum",
+            "isOffline",
+        }
+        non_restricting = {"withDeleted", "withExif", "withPeople", "withStacked"}
+
+        assert set(RandomSearchDto.model_fields) == (
+            translated | guarded | non_restricting
+        )
+
     @pytest.mark.anyio
     async def test_non_restricting_fields_still_sample(
         self, mock_sync_cursor_page, mock_current_user

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -613,6 +613,62 @@ class TestSearchExplore:
         assert all(group.items == [] for group in result)
 
     @pytest.mark.anyio
+    async def test_vanished_representative_skipped(
+        self, mock_sync_cursor_page, mock_current_user, monkeypatch
+    ):
+        """Representatives missing from the batched re-fetch are skipped, not 500s."""
+        monkeypatch.setattr("routers.api.search.EXPLORE_MIN_ASSETS_PER_CITY", 1)
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        asset = _make_search_asset(now)
+        scan_assets = [_scan_view(asset, "Darwin")]
+
+        def list_side_effect(**kwargs):
+            if "ids" in kwargs:
+                # Asset vanished between the scan and the re-fetch.
+                return mock_sync_cursor_page([])
+            return mock_sync_cursor_page(scan_assets)
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(side_effect=list_side_effect)
+
+        result = await get_explore_data(
+            client=mock_client, current_user=mock_current_user
+        )
+
+        assert all(group.items == [] for group in result)
+
+    @pytest.mark.anyio
+    async def test_city_cap_applied(
+        self, mock_sync_cursor_page, mock_current_user, monkeypatch
+    ):
+        """No more than the configured maximum number of cities is returned."""
+        monkeypatch.setattr("routers.api.search.EXPLORE_MIN_ASSETS_PER_CITY", 1)
+        monkeypatch.setattr("routers.api.search.EXPLORE_MAX_CITIES", 2)
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        full_assets = [_make_search_asset(now) for _ in range(3)]
+        scan_assets = [
+            _scan_view(asset, city)
+            for asset, city in zip(full_assets, ["Sydney", "Perth", "Hobart"])
+        ]
+
+        def list_side_effect(**kwargs):
+            if "ids" in kwargs:
+                wanted = set(kwargs["ids"])
+                return mock_sync_cursor_page([a for a in full_assets if a.id in wanted])
+            return mock_sync_cursor_page(scan_assets)
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(side_effect=list_side_effect)
+
+        result = await get_explore_data(
+            client=mock_client, current_user=mock_current_user
+        )
+
+        city_group = result[0]
+        # Newest-first scan order determines which cities make the cut.
+        assert [item.value for item in city_group.items] == ["Sydney", "Perth"]
+
+    @pytest.mark.anyio
     async def test_sdk_error_propagates(self, mock_current_user):
         """SDK errors bubble up; the global GumnutError handler maps them."""
         from gumnut import APIStatusError
@@ -811,6 +867,92 @@ class TestSearchRandom:
         )
         assert mock_client.assets.list.call_args.kwargs["album_id"] == expected_album_id
         assert len(result) == 1
+
+    @pytest.mark.anyio
+    async def test_december_rollover_month_window(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """A December bucket's window rolls over into January of the next year."""
+        dec_assets = [
+            _make_search_asset(datetime(2024, 12, 15, tzinfo=timezone.utc))
+            for _ in range(2)
+        ]
+        buckets = [_make_count_bucket(2, datetime(2024, 12, 1))]
+        months = {"2024-12-01T00:00:00": dec_assets}
+        mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
+
+        await search_random(
+            request=RandomSearchDto(size=2),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        list_kwargs = mock_client.assets.list.call_args.kwargs
+        assert list_kwargs["local_datetime_after"] == "2024-12-01T00:00:00"
+        assert list_kwargs["local_datetime_before"] == "2025-01-01T00:00:00"
+
+    @pytest.mark.anyio
+    async def test_default_size_caps_at_total(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """With no size, the default (250) is capped at the library total."""
+        jan_assets = [
+            _make_search_asset(datetime(2024, 1, 15, tzinfo=timezone.utc))
+            for _ in range(3)
+        ]
+        buckets = [_make_count_bucket(3, datetime(2024, 1, 1))]
+        months = {"2024-01-01T00:00:00": jan_assets}
+        mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
+
+        result = await search_random(
+            request=RandomSearchDto(),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        expected_uuids = {str(safe_uuid_from_asset_id(a.id)) for a in jan_assets}
+        assert {asset.id for asset in result} == expected_uuids
+
+    @pytest.mark.anyio
+    async def test_offset_mapping_across_bucket_boundary(
+        self, mock_sync_cursor_page, mock_current_user, monkeypatch
+    ):
+        """Global indices map to the correct per-month offsets across buckets."""
+        feb_assets = [
+            _make_search_asset(datetime(2024, 2, 10, tzinfo=timezone.utc))
+            for _ in range(2)
+        ]
+        jan_assets = [
+            _make_search_asset(datetime(2024, 1, 15, tzinfo=timezone.utc))
+            for _ in range(3)
+        ]
+        buckets = [
+            _make_count_bucket(2, datetime(2024, 2, 1)),
+            _make_count_bucket(3, datetime(2024, 1, 1)),
+        ]
+        months = {
+            "2024-02-01T00:00:00": feb_assets,
+            "2024-01-01T00:00:00": jan_assets,
+        }
+        mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
+
+        # Pin the draw to global indices 1 and 2: the last asset of the newer
+        # (February) bucket and the first asset of the older (January) bucket.
+        monkeypatch.setattr(
+            "routers.api.search.random.sample", lambda population, k: [1, 2]
+        )
+
+        result = await search_random(
+            request=RandomSearchDto(size=2),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        expected_uuids = {
+            str(safe_uuid_from_asset_id(feb_assets[1].id)),
+            str(safe_uuid_from_asset_id(jan_assets[0].id)),
+        }
+        assert {asset.id for asset in result} == expected_uuids
 
     @pytest.mark.anyio
     async def test_stale_counts_return_short_sample(

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -754,7 +754,6 @@ class TestSearchRandom:
         mock_client = Mock()
 
         for request in (
-            RandomSearchDto(type=AssetTypeEnum.VIDEO),
             RandomSearchDto(takenAfter=datetime(2024, 1, 1, tzinfo=timezone.utc)),
             RandomSearchDto(city="Sydney"),
             RandomSearchDto(rating=0),
@@ -767,6 +766,46 @@ class TestSearchRandom:
             assert result == []
         mock_client.assets.counts.assert_not_called()
 
+    @pytest.mark.anyio
+    async def test_type_filter_applied_to_sample(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """`type` filters the drawn sample by MIME-derived asset type."""
+        taken = datetime(2024, 1, 15, tzinfo=timezone.utc)
+        image = _make_search_asset(taken)
+        video = _make_search_asset(taken, mime_type="video/mp4")
+        buckets = [_make_count_bucket(2, datetime(2024, 1, 1))]
+        months = {"2023-12-31T23:59:59.999999": [image, video]}
+        mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
+
+        result = await search_random(
+            request=RandomSearchDto(size=2, type=AssetTypeEnum.IMAGE),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert [asset.id for asset in result] == [
+            str(safe_uuid_from_asset_id(image.id))
+        ]
+
+    @pytest.mark.anyio
+    async def test_type_filter_with_no_matches_returns_empty(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """A type with no matching assets in the sample yields an empty list."""
+        image = _make_search_asset(datetime(2024, 1, 15, tzinfo=timezone.utc))
+        buckets = [_make_count_bucket(1, datetime(2024, 1, 1))]
+        months = {"2023-12-31T23:59:59.999999": [image]}
+        mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
+
+        result = await search_random(
+            request=RandomSearchDto(size=1, type=AssetTypeEnum.VIDEO),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert result == []
+
     def test_all_dto_fields_have_a_disposition(self):
         """Force a conscious decision when the generated DTO gains fields.
 
@@ -776,7 +815,7 @@ class TestSearchRandom:
         silently ignored and the endpoint would sample assets the caller
         filtered out.
         """
-        translated = {"size", "albumIds", "personIds"}
+        translated = {"size", "albumIds", "personIds", "type"}
         guarded = {
             "isFavorite",
             "visibility",
@@ -799,7 +838,6 @@ class TestSearchRandom:
             "ocr",
             "rating",
             "tagIds",
-            "type",
             "isEncoded",
             "isMotion",
             "isNotInAlbum",
@@ -818,7 +856,7 @@ class TestSearchRandom:
         """Response-shape hints, widening flags, and falsy booleans don't empty the sample."""
         jan_assets = [_make_search_asset(datetime(2024, 1, 15, tzinfo=timezone.utc))]
         buckets = [_make_count_bucket(1, datetime(2024, 1, 1))]
-        months = {"2024-01-01T00:00:00": jan_assets}
+        months = {"2023-12-31T23:59:59.999999": jan_assets}
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
         result = await search_random(
@@ -871,8 +909,8 @@ class TestSearchRandom:
             _make_count_bucket(3, datetime(2024, 1, 1)),
         ]
         months = {
-            "2024-02-01T00:00:00": feb_assets,
-            "2024-01-01T00:00:00": jan_assets,
+            "2024-01-31T23:59:59.999999": feb_assets,
+            "2023-12-31T23:59:59.999999": jan_assets,
         }
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
@@ -897,7 +935,7 @@ class TestSearchRandom:
             for _ in range(2)
         ]
         buckets = [_make_count_bucket(2, datetime(2024, 1, 1))]
-        months = {"2024-01-01T00:00:00": jan_assets}
+        months = {"2023-12-31T23:59:59.999999": jan_assets}
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
         await search_random(
@@ -907,7 +945,7 @@ class TestSearchRandom:
         )
 
         list_kwargs = mock_client.assets.list.call_args.kwargs
-        assert list_kwargs["local_datetime_after"] == "2024-01-01T00:00:00"
+        assert list_kwargs["local_datetime_after"] == "2023-12-31T23:59:59.999999"
         assert list_kwargs["local_datetime_before"] == "2024-02-01T00:00:00"
         assert list_kwargs["state"] == "live"
 
@@ -921,7 +959,7 @@ class TestSearchRandom:
             for _ in range(5)
         ]
         buckets = [_make_count_bucket(5, datetime(2024, 1, 1))]
-        months = {"2024-01-01T00:00:00": jan_assets}
+        months = {"2023-12-31T23:59:59.999999": jan_assets}
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
         result = await search_random(
@@ -945,7 +983,7 @@ class TestSearchRandom:
         album_uuid = uuid4()
         jan_assets = [_make_search_asset(datetime(2024, 1, 15, tzinfo=timezone.utc))]
         buckets = [_make_count_bucket(1, datetime(2024, 1, 1))]
-        months = {"2024-01-01T00:00:00": jan_assets}
+        months = {"2023-12-31T23:59:59.999999": jan_assets}
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
         result = await search_random(
@@ -971,7 +1009,7 @@ class TestSearchRandom:
             for _ in range(2)
         ]
         buckets = [_make_count_bucket(2, datetime(2024, 12, 1))]
-        months = {"2024-12-01T00:00:00": dec_assets}
+        months = {"2024-11-30T23:59:59.999999": dec_assets}
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
         await search_random(
@@ -981,7 +1019,7 @@ class TestSearchRandom:
         )
 
         list_kwargs = mock_client.assets.list.call_args.kwargs
-        assert list_kwargs["local_datetime_after"] == "2024-12-01T00:00:00"
+        assert list_kwargs["local_datetime_after"] == "2024-11-30T23:59:59.999999"
         assert list_kwargs["local_datetime_before"] == "2025-01-01T00:00:00"
 
     @pytest.mark.anyio
@@ -994,7 +1032,7 @@ class TestSearchRandom:
             for _ in range(3)
         ]
         buckets = [_make_count_bucket(3, datetime(2024, 1, 1))]
-        months = {"2024-01-01T00:00:00": jan_assets}
+        months = {"2023-12-31T23:59:59.999999": jan_assets}
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
         result = await search_random(
@@ -1024,8 +1062,8 @@ class TestSearchRandom:
             _make_count_bucket(3, datetime(2024, 1, 1)),
         ]
         months = {
-            "2024-02-01T00:00:00": feb_assets,
-            "2024-01-01T00:00:00": jan_assets,
+            "2024-01-31T23:59:59.999999": feb_assets,
+            "2023-12-31T23:59:59.999999": jan_assets,
         }
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
@@ -1058,7 +1096,7 @@ class TestSearchRandom:
         ]
         # Counts claim 4 assets but the month only yields 2.
         buckets = [_make_count_bucket(4, datetime(2024, 1, 1))]
-        months = {"2024-01-01T00:00:00": jan_assets}
+        months = {"2023-12-31T23:59:59.999999": jan_assets}
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
         result = await search_random(

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 from datetime import datetime, timezone
 
 from routers.api.search import (
+    _fetch_month_assets_at_offsets,
     get_explore_data,
     search_person,
     search_assets,
@@ -20,6 +21,10 @@ from routers.immich_models import (
     RandomSearchDto,
     SmartSearchDto,
     StatisticsSearchDto,
+)
+from routers.utils.asset_conversion import (
+    ASSET_INCLUDE,
+    ASSET_INCLUDE_METADATA_ONLY,
 )
 from routers.utils.gumnut_id_conversion import (
     safe_uuid_from_asset_id,
@@ -41,6 +46,11 @@ def _make_person(
     person.created_at = datetime.now(timezone.utc)
     person.updated_at = datetime.now(timezone.utc)
     return person
+
+
+# Exclusive lower bound month_query_bounds emits for a January-2024 bucket;
+# used to key the per-month assets.list mocks in TestSearchRandom.
+JAN_2024_AFTER_BOUND = "2023-12-31T23:59:59.999999"
 
 
 def _make_count_bucket(count: int, time_bucket: datetime) -> Mock:
@@ -547,8 +557,17 @@ class TestSearchExplore:
         assert len(city_group.items) == 1
         assert city_group.items[0].value == "Sydney"
         # The representative is the newest (first-scanned) image for the city.
-        assert city_group.items[0].data.originalFileName == "photo.jpg"
+        assert city_group.items[0].data.id == str(
+            safe_uuid_from_asset_id(city_assets[0].id)
+        )
         assert len(recents_group.items) == 6
+        # The scan is metadata-only; the batched re-fetch carries the full
+        # include set the conversion needs.
+        scan_kwargs = mock_client.assets.list.call_args_list[0].kwargs
+        assert scan_kwargs["include"] == ASSET_INCLUDE_METADATA_ONLY
+        assert scan_kwargs["state"] == "live"
+        refetch_kwargs = mock_client.assets.list.call_args_list[1].kwargs
+        assert refetch_kwargs["include"] == ASSET_INCLUDE
 
     @pytest.mark.anyio
     async def test_city_below_min_threshold_excluded(
@@ -670,6 +689,63 @@ class TestSearchExplore:
         assert [item.value for item in city_group.items] == ["Sydney", "Perth"]
 
     @pytest.mark.anyio
+    async def test_scan_stops_at_scan_limit(
+        self, mock_sync_cursor_page, mock_current_user, monkeypatch
+    ):
+        """Assets past EXPLORE_SCAN_LIMIT are never considered."""
+        monkeypatch.setattr("routers.api.search.EXPLORE_SCAN_LIMIT", 2)
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        full_assets = [_make_search_asset(now) for _ in range(3)]
+        scan_assets = [_scan_view(a, None) for a in full_assets]
+
+        def list_side_effect(**kwargs):
+            if "ids" in kwargs:
+                wanted = set(kwargs["ids"])
+                return mock_sync_cursor_page([a for a in full_assets if a.id in wanted])
+            return mock_sync_cursor_page(scan_assets)
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(side_effect=list_side_effect)
+
+        result = await get_explore_data(
+            client=mock_client, current_user=mock_current_user
+        )
+
+        recents_group = result[1]
+        # Only the first two scanned assets made it into recents.
+        assert [item.data.id for item in recents_group.items] == [
+            str(safe_uuid_from_asset_id(a.id)) for a in full_assets[:2]
+        ]
+
+    @pytest.mark.anyio
+    async def test_recents_capped_at_max_recent_assets(
+        self, mock_sync_cursor_page, mock_current_user, monkeypatch
+    ):
+        """The recents group holds at most EXPLORE_MAX_RECENT_ASSETS items."""
+        monkeypatch.setattr("routers.api.search.EXPLORE_MAX_RECENT_ASSETS", 2)
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        full_assets = [_make_search_asset(now) for _ in range(3)]
+        scan_assets = [_scan_view(a, None) for a in full_assets]
+
+        def list_side_effect(**kwargs):
+            if "ids" in kwargs:
+                wanted = set(kwargs["ids"])
+                return mock_sync_cursor_page([a for a in full_assets if a.id in wanted])
+            return mock_sync_cursor_page(scan_assets)
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(side_effect=list_side_effect)
+
+        result = await get_explore_data(
+            client=mock_client, current_user=mock_current_user
+        )
+
+        recents_group = result[1]
+        assert [item.data.id for item in recents_group.items] == [
+            str(safe_uuid_from_asset_id(a.id)) for a in full_assets[:2]
+        ]
+
+    @pytest.mark.anyio
     async def test_sdk_error_propagates(self, mock_current_user):
         """SDK errors bubble up; the global GumnutError handler maps them."""
         from gumnut import APIStatusError
@@ -775,7 +851,7 @@ class TestSearchRandom:
         image = _make_search_asset(taken)
         video = _make_search_asset(taken, mime_type="video/mp4")
         buckets = [_make_count_bucket(2, datetime(2024, 1, 1))]
-        months = {"2023-12-31T23:59:59.999999": [image, video]}
+        months = {JAN_2024_AFTER_BOUND: [image, video]}
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
         result = await search_random(
@@ -795,7 +871,7 @@ class TestSearchRandom:
         """A type with no matching assets in the sample yields an empty list."""
         image = _make_search_asset(datetime(2024, 1, 15, tzinfo=timezone.utc))
         buckets = [_make_count_bucket(1, datetime(2024, 1, 1))]
-        months = {"2023-12-31T23:59:59.999999": [image]}
+        months = {JAN_2024_AFTER_BOUND: [image]}
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
         result = await search_random(
@@ -856,7 +932,7 @@ class TestSearchRandom:
         """Response-shape hints, widening flags, and falsy booleans don't empty the sample."""
         jan_assets = [_make_search_asset(datetime(2024, 1, 15, tzinfo=timezone.utc))]
         buckets = [_make_count_bucket(1, datetime(2024, 1, 1))]
-        months = {"2023-12-31T23:59:59.999999": jan_assets}
+        months = {JAN_2024_AFTER_BOUND: jan_assets}
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
         result = await search_random(
@@ -910,7 +986,7 @@ class TestSearchRandom:
         ]
         months = {
             "2024-01-31T23:59:59.999999": feb_assets,
-            "2023-12-31T23:59:59.999999": jan_assets,
+            JAN_2024_AFTER_BOUND: jan_assets,
         }
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
@@ -935,7 +1011,7 @@ class TestSearchRandom:
             for _ in range(2)
         ]
         buckets = [_make_count_bucket(2, datetime(2024, 1, 1))]
-        months = {"2023-12-31T23:59:59.999999": jan_assets}
+        months = {JAN_2024_AFTER_BOUND: jan_assets}
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
         await search_random(
@@ -948,6 +1024,7 @@ class TestSearchRandom:
         assert list_kwargs["local_datetime_after"] == "2023-12-31T23:59:59.999999"
         assert list_kwargs["local_datetime_before"] == "2024-02-01T00:00:00"
         assert list_kwargs["state"] == "live"
+        assert list_kwargs["include"] == ASSET_INCLUDE
 
     @pytest.mark.anyio
     async def test_sample_smaller_than_total(
@@ -959,7 +1036,7 @@ class TestSearchRandom:
             for _ in range(5)
         ]
         buckets = [_make_count_bucket(5, datetime(2024, 1, 1))]
-        months = {"2023-12-31T23:59:59.999999": jan_assets}
+        months = {JAN_2024_AFTER_BOUND: jan_assets}
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
         result = await search_random(
@@ -983,7 +1060,7 @@ class TestSearchRandom:
         album_uuid = uuid4()
         jan_assets = [_make_search_asset(datetime(2024, 1, 15, tzinfo=timezone.utc))]
         buckets = [_make_count_bucket(1, datetime(2024, 1, 1))]
-        months = {"2023-12-31T23:59:59.999999": jan_assets}
+        months = {JAN_2024_AFTER_BOUND: jan_assets}
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
         result = await search_random(
@@ -997,6 +1074,33 @@ class TestSearchRandom:
             mock_client.assets.counts.call_args.kwargs["album_id"] == expected_album_id
         )
         assert mock_client.assets.list.call_args.kwargs["album_id"] == expected_album_id
+        assert len(result) == 1
+
+    @pytest.mark.anyio
+    async def test_single_person_filter_forwarded(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """A single-element personIds filter is forwarded to counts and list."""
+        person_uuid = uuid4()
+        jan_assets = [_make_search_asset(datetime(2024, 1, 15, tzinfo=timezone.utc))]
+        buckets = [_make_count_bucket(1, datetime(2024, 1, 1))]
+        months = {JAN_2024_AFTER_BOUND: jan_assets}
+        mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
+
+        result = await search_random(
+            request=RandomSearchDto(personIds=[person_uuid], size=1),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        expected_person_id = uuid_to_gumnut_person_id(person_uuid)
+        assert (
+            mock_client.assets.counts.call_args.kwargs["person_id"]
+            == expected_person_id
+        )
+        assert (
+            mock_client.assets.list.call_args.kwargs["person_id"] == expected_person_id
+        )
         assert len(result) == 1
 
     @pytest.mark.anyio
@@ -1032,7 +1136,7 @@ class TestSearchRandom:
             for _ in range(3)
         ]
         buckets = [_make_count_bucket(3, datetime(2024, 1, 1))]
-        months = {"2023-12-31T23:59:59.999999": jan_assets}
+        months = {JAN_2024_AFTER_BOUND: jan_assets}
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
         result = await search_random(
@@ -1063,7 +1167,7 @@ class TestSearchRandom:
         ]
         months = {
             "2024-01-31T23:59:59.999999": feb_assets,
-            "2023-12-31T23:59:59.999999": jan_assets,
+            JAN_2024_AFTER_BOUND: jan_assets,
         }
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
@@ -1096,7 +1200,7 @@ class TestSearchRandom:
         ]
         # Counts claim 4 assets but the month only yields 2.
         buckets = [_make_count_bucket(4, datetime(2024, 1, 1))]
-        months = {"2023-12-31T23:59:59.999999": jan_assets}
+        months = {JAN_2024_AFTER_BOUND: jan_assets}
         mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
 
         result = await search_random(
@@ -1106,6 +1210,43 @@ class TestSearchRandom:
         )
 
         assert len(result) == 2
+
+    @pytest.mark.anyio
+    async def test_month_fetch_stops_at_max_offset(self):
+        """The month fetch pages only as far as the largest requested offset."""
+
+        class _TrackingPage:
+            """Async-iterable page that records how many items were consumed."""
+
+            def __init__(self, items):
+                self._items = items
+                self.consumed = 0
+
+            async def __aiter__(self):
+                for item in self._items:
+                    self.consumed += 1
+                    yield item
+
+        jan_assets = [
+            _make_search_asset(datetime(2024, 1, 15, tzinfo=timezone.utc))
+            for _ in range(10)
+        ]
+        page = _TrackingPage(jan_assets)
+        mock_client = Mock()
+        mock_client.assets.list = Mock(return_value=page)
+
+        picked = await _fetch_month_assets_at_offsets(
+            mock_client,
+            datetime(2024, 1, 1),
+            [1, 3],
+            album_id=None,
+            person_id=None,
+        )
+
+        assert picked == [jan_assets[1], jan_assets[3]]
+        # Iteration stopped right after the largest offset instead of paging
+        # the remaining six assets in the month.
+        assert page.consumed == 4
 
     @pytest.mark.anyio
     async def test_sdk_error_propagates(self, mock_current_user):

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -6,17 +6,22 @@ from uuid import uuid4
 from datetime import datetime, timezone
 
 from routers.api.search import (
+    get_explore_data,
     search_person,
     search_assets,
     search_asset_statistics,
+    search_random,
     search_smart,
 )
 from routers.immich_models import (
+    AssetVisibility,
     MetadataSearchDto,
+    RandomSearchDto,
     SmartSearchDto,
     StatisticsSearchDto,
 )
 from routers.utils.gumnut_id_conversion import (
+    safe_uuid_from_asset_id,
     safe_uuid_from_person_id,
     uuid_to_gumnut_person_id,
 )
@@ -458,3 +463,391 @@ class TestSearchSmart:
             "people",
             "file_data",
         ]
+
+
+def _make_search_asset(taken_at: datetime, mime_type: str = "image/jpeg") -> Mock:
+    """Create a mock Gumnut AssetResponse with the full include set."""
+    from routers.utils.gumnut_id_conversion import uuid_to_gumnut_asset_id
+
+    asset = Mock()
+    asset.id = uuid_to_gumnut_asset_id(uuid4())
+    asset.original_file_name = "photo.jpg"
+    asset.mime_type = mime_type
+    asset.thumbhash = None
+    asset.created_at = taken_at
+    asset.updated_at = taken_at
+    asset.local_datetime = taken_at
+    asset.width = 1920
+    asset.height = 1080
+    asset.duration = None
+    # File/provenance scalars live on the nested ``file_data`` group
+    # (requested via ``include=file_data``); the adapter reads them from there.
+    asset.file_data = Mock()
+    asset.file_data.checksum = "abc123"
+    asset.file_data.checksum_sha1 = "PaDX6+c+Lhjpm5/ciXUROL1ryaU="
+    asset.file_data.file_created_at = taken_at
+    asset.file_data.file_modified_at = taken_at
+    asset.file_data.file_size_bytes = 1024000
+    asset.metadata = None
+    asset.people = []
+    asset.trashed_at = None
+    return asset
+
+
+def _scan_view(asset: Mock, city: str | None) -> Mock:
+    """Create the metadata-only scan-time view of an asset (same id, city set)."""
+    scan = Mock()
+    scan.id = asset.id
+    scan.mime_type = asset.mime_type
+    scan.created_at = asset.created_at
+    scan.metadata = Mock()
+    scan.metadata.city = city
+    return scan
+
+
+def _counts_response(buckets: list[Mock]) -> Mock:
+    response = Mock()
+    response.data = buckets
+    response.has_more = False
+    return response
+
+
+class TestSearchExplore:
+    """Test the get_explore_data endpoint."""
+
+    @pytest.mark.anyio
+    async def test_returns_city_and_recents_groups(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """Cities with enough images produce an exifInfo.city item; recents fill createdAt."""
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        city_assets = [_make_search_asset(now) for _ in range(5)]
+        no_city_asset = _make_search_asset(now)
+        full_assets = city_assets + [no_city_asset]
+        scan_assets = [_scan_view(a, "Sydney") for a in city_assets] + [
+            _scan_view(no_city_asset, None)
+        ]
+
+        def list_side_effect(**kwargs):
+            if "ids" in kwargs:
+                wanted = set(kwargs["ids"])
+                return mock_sync_cursor_page([a for a in full_assets if a.id in wanted])
+            return mock_sync_cursor_page(scan_assets)
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(side_effect=list_side_effect)
+
+        result = await get_explore_data(
+            client=mock_client, current_user=mock_current_user
+        )
+
+        assert [group.fieldName for group in result] == ["exifInfo.city", "createdAt"]
+        city_group, recents_group = result
+        assert len(city_group.items) == 1
+        assert city_group.items[0].value == "Sydney"
+        # The representative is the newest (first-scanned) image for the city.
+        assert city_group.items[0].data.originalFileName == "photo.jpg"
+        assert len(recents_group.items) == 6
+
+    @pytest.mark.anyio
+    async def test_city_below_min_threshold_excluded(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """Cities with fewer images than the minimum don't get an explore entry."""
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        full_assets = [_make_search_asset(now) for _ in range(4)]
+        scan_assets = [_scan_view(a, "Perth") for a in full_assets]
+
+        def list_side_effect(**kwargs):
+            if "ids" in kwargs:
+                return mock_sync_cursor_page(full_assets)
+            return mock_sync_cursor_page(scan_assets)
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(side_effect=list_side_effect)
+
+        result = await get_explore_data(
+            client=mock_client, current_user=mock_current_user
+        )
+
+        city_group = result[0]
+        assert city_group.fieldName == "exifInfo.city"
+        assert city_group.items == []
+
+    @pytest.mark.anyio
+    async def test_empty_library_returns_empty_groups(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """An empty library still returns both groups (clients look them up by name)."""
+        mock_client = Mock()
+        mock_client.assets.list = Mock(return_value=mock_sync_cursor_page([]))
+
+        result = await get_explore_data(
+            client=mock_client, current_user=mock_current_user
+        )
+
+        assert [group.fieldName for group in result] == ["exifInfo.city", "createdAt"]
+        assert all(group.items == [] for group in result)
+        # No batched re-fetch when nothing was scanned.
+        assert mock_client.assets.list.call_count == 1
+
+    @pytest.mark.anyio
+    async def test_videos_are_ignored(self, mock_sync_cursor_page, mock_current_user):
+        """Only images count toward cities and recents, matching the Immich server."""
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        videos = [_make_search_asset(now, mime_type="video/mp4") for _ in range(5)]
+        scan_assets = [_scan_view(a, "Hobart") for a in videos]
+
+        def list_side_effect(**kwargs):
+            if "ids" in kwargs:
+                return mock_sync_cursor_page(videos)
+            return mock_sync_cursor_page(scan_assets)
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(side_effect=list_side_effect)
+
+        result = await get_explore_data(
+            client=mock_client, current_user=mock_current_user
+        )
+
+        assert all(group.items == [] for group in result)
+
+    @pytest.mark.anyio
+    async def test_sdk_error_propagates(self, mock_current_user):
+        """SDK errors bubble up; the global GumnutError handler maps them."""
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(side_effect=make_sdk_status_error(500, "boom"))
+
+        with pytest.raises(APIStatusError):
+            await get_explore_data(client=mock_client, current_user=mock_current_user)
+
+
+class TestSearchRandom:
+    """Test the search_random endpoint."""
+
+    def _client_with_months(
+        self,
+        mock_sync_cursor_page,
+        months: dict[str, list[Mock]],
+        buckets: list[Mock],
+    ) -> Mock:
+        """Mock counts + a per-month assets.list keyed by local_datetime_after."""
+        mock_client = Mock()
+        mock_client.assets.counts = AsyncMock(return_value=_counts_response(buckets))
+
+        def list_side_effect(**kwargs):
+            return mock_sync_cursor_page(months[kwargs["local_datetime_after"]])
+
+        mock_client.assets.list = Mock(side_effect=list_side_effect)
+        return mock_client
+
+    @pytest.mark.anyio
+    async def test_returns_empty_for_favorites(self, mock_current_user):
+        """Gumnut has no favorites, so isFavorite=True returns an empty list."""
+        mock_client = Mock()
+
+        result = await search_random(
+            request=RandomSearchDto(isFavorite=True),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert result == []
+        mock_client.assets.counts.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_returns_empty_for_non_timeline_visibility(self, mock_current_user):
+        """Gumnut has no hidden/archived/locked assets."""
+        mock_client = Mock()
+
+        result = await search_random(
+            request=RandomSearchDto(visibility=AssetVisibility.archive),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert result == []
+        mock_client.assets.counts.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_returns_empty_for_multiple_album_or_person_ids(
+        self, mock_current_user
+    ):
+        """Multi-element albumIds/personIds have no Gumnut API equivalent."""
+        mock_client = Mock()
+
+        for request in (
+            RandomSearchDto(albumIds=[uuid4(), uuid4()]),
+            RandomSearchDto(personIds=[uuid4(), uuid4()]),
+        ):
+            result = await search_random(
+                request=request, client=mock_client, current_user=mock_current_user
+            )
+            assert result == []
+        mock_client.assets.counts.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_returns_empty_when_library_empty(self, mock_current_user):
+        """No count buckets means nothing to sample."""
+        mock_client = Mock()
+        mock_client.assets.counts = AsyncMock(return_value=_counts_response([]))
+
+        result = await search_random(
+            request=RandomSearchDto(),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert result == []
+        mock_client.assets.list.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_returns_all_assets_when_size_exceeds_total(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """When size >= total, every asset comes back exactly once."""
+        feb_assets = [
+            _make_search_asset(datetime(2024, 2, 10, tzinfo=timezone.utc))
+            for _ in range(2)
+        ]
+        jan_assets = [
+            _make_search_asset(datetime(2024, 1, 15, tzinfo=timezone.utc))
+            for _ in range(3)
+        ]
+        buckets = [
+            _make_count_bucket(2, datetime(2024, 2, 1)),
+            _make_count_bucket(3, datetime(2024, 1, 1)),
+        ]
+        months = {
+            "2024-02-01T00:00:00": feb_assets,
+            "2024-01-01T00:00:00": jan_assets,
+        }
+        mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
+
+        result = await search_random(
+            request=RandomSearchDto(size=10),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        expected_uuids = {
+            str(safe_uuid_from_asset_id(a.id)) for a in feb_assets + jan_assets
+        }
+        assert {asset.id for asset in result} == expected_uuids
+
+    @pytest.mark.anyio
+    async def test_month_windows_passed_to_list(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """Sampled months are fetched with naive month-boundary date windows."""
+        jan_assets = [
+            _make_search_asset(datetime(2024, 1, 15, tzinfo=timezone.utc))
+            for _ in range(2)
+        ]
+        buckets = [_make_count_bucket(2, datetime(2024, 1, 1))]
+        months = {"2024-01-01T00:00:00": jan_assets}
+        mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
+
+        await search_random(
+            request=RandomSearchDto(size=2),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        list_kwargs = mock_client.assets.list.call_args.kwargs
+        assert list_kwargs["local_datetime_after"] == "2024-01-01T00:00:00"
+        assert list_kwargs["local_datetime_before"] == "2024-02-01T00:00:00"
+        assert list_kwargs["state"] == "live"
+
+    @pytest.mark.anyio
+    async def test_sample_smaller_than_total(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """A sample smaller than the library returns exactly `size` distinct assets."""
+        jan_assets = [
+            _make_search_asset(datetime(2024, 1, 15, tzinfo=timezone.utc))
+            for _ in range(5)
+        ]
+        buckets = [_make_count_bucket(5, datetime(2024, 1, 1))]
+        months = {"2024-01-01T00:00:00": jan_assets}
+        mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
+
+        result = await search_random(
+            request=RandomSearchDto(size=2),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert len(result) == 2
+        all_uuids = {str(safe_uuid_from_asset_id(a.id)) for a in jan_assets}
+        assert {asset.id for asset in result} <= all_uuids
+        assert len({asset.id for asset in result}) == 2
+
+    @pytest.mark.anyio
+    async def test_single_album_filter_forwarded(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """A single-element albumIds filter is forwarded to counts and list."""
+        from routers.utils.gumnut_id_conversion import uuid_to_gumnut_album_id
+
+        album_uuid = uuid4()
+        jan_assets = [_make_search_asset(datetime(2024, 1, 15, tzinfo=timezone.utc))]
+        buckets = [_make_count_bucket(1, datetime(2024, 1, 1))]
+        months = {"2024-01-01T00:00:00": jan_assets}
+        mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
+
+        result = await search_random(
+            request=RandomSearchDto(albumIds=[album_uuid], size=1),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        expected_album_id = uuid_to_gumnut_album_id(album_uuid)
+        assert (
+            mock_client.assets.counts.call_args.kwargs["album_id"] == expected_album_id
+        )
+        assert mock_client.assets.list.call_args.kwargs["album_id"] == expected_album_id
+        assert len(result) == 1
+
+    @pytest.mark.anyio
+    async def test_stale_counts_return_short_sample(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """If assets vanish between counts and fetch, the sample comes up short, not 500."""
+        jan_assets = [
+            _make_search_asset(datetime(2024, 1, 15, tzinfo=timezone.utc))
+            for _ in range(2)
+        ]
+        # Counts claim 4 assets but the month only yields 2.
+        buckets = [_make_count_bucket(4, datetime(2024, 1, 1))]
+        months = {"2024-01-01T00:00:00": jan_assets}
+        mock_client = self._client_with_months(mock_sync_cursor_page, months, buckets)
+
+        result = await search_random(
+            request=RandomSearchDto(size=4),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert len(result) == 2
+
+    @pytest.mark.anyio
+    async def test_sdk_error_propagates(self, mock_current_user):
+        """SDK errors bubble up; the global GumnutError handler maps them."""
+        from gumnut import APIStatusError
+        from tests.conftest import make_sdk_status_error
+
+        mock_client = Mock()
+        mock_client.assets.counts = AsyncMock(
+            side_effect=make_sdk_status_error(500, "boom")
+        )
+
+        with pytest.raises(APIStatusError):
+            await search_random(
+                request=RandomSearchDto(),
+                client=mock_client,
+                current_user=mock_current_user,
+            )

--- a/tests/unit/api/test_timeline.py
+++ b/tests/unit/api/test_timeline.py
@@ -9,6 +9,7 @@ from routers.api.timeline import (
     get_time_buckets,
     get_time_bucket,
     fetch_asset_counts,
+    month_window,
 )
 from routers.immich_models import (
     AssetOrder,
@@ -86,6 +87,40 @@ def call_get_time_bucket(timeBucket, **kwargs):
     }
     defaults.update(kwargs)
     return get_time_bucket(timeBucket, **defaults)  # type: ignore
+
+
+class TestMonthWindow:
+    """Test the month_window helper."""
+
+    @pytest.mark.parametrize(
+        ("moment", "expected_start", "expected_end"),
+        [
+            # Mid-month naive input truncates to the month start.
+            (
+                datetime(2024, 3, 15, 12, 30, 45),
+                datetime(2024, 3, 1),
+                datetime(2024, 4, 1),
+            ),
+            # Timezone-aware input is stripped to a naive boundary.
+            (
+                datetime(2024, 3, 15, tzinfo=timezone.utc),
+                datetime(2024, 3, 1),
+                datetime(2024, 4, 1),
+            ),
+            # December rolls over into January of the next year.
+            (
+                datetime(2024, 12, 31, 23, 59, 59),
+                datetime(2024, 12, 1),
+                datetime(2025, 1, 1),
+            ),
+        ],
+    )
+    def test_window_boundaries(self, moment, expected_start, expected_end):
+        month_start, next_month_start = month_window(moment)
+        assert month_start == expected_start
+        assert next_month_start == expected_end
+        assert month_start.tzinfo is None
+        assert next_month_start.tzinfo is None
 
 
 class TestFetchAssetCounts:

--- a/tests/unit/api/test_timeline.py
+++ b/tests/unit/api/test_timeline.py
@@ -9,6 +9,7 @@ from routers.api.timeline import (
     get_time_buckets,
     get_time_bucket,
     fetch_asset_counts,
+    month_query_bounds,
     month_window,
 )
 from routers.immich_models import (
@@ -22,9 +23,10 @@ from routers.utils.gumnut_id_conversion import (
 )
 
 # Expected date range query for January 2024 — the most common test timeBucket.
-# Half-open interval: [month_start, next_month_start)
+# The after bound backs off 1µs from month start because the Gumnut API treats
+# local_datetime_after as exclusive (see month_query_bounds).
 JANUARY_2024_DATE_RANGE = {
-    "local_datetime_after": "2024-01-01T00:00:00",
+    "local_datetime_after": "2023-12-31T23:59:59.999999",
     "local_datetime_before": "2024-02-01T00:00:00",
 }
 
@@ -121,6 +123,33 @@ class TestMonthWindow:
         assert next_month_start == expected_end
         assert month_start.tzinfo is None
         assert next_month_start.tzinfo is None
+
+
+class TestMonthQueryBounds:
+    """Test the month_query_bounds helper."""
+
+    @pytest.mark.parametrize(
+        ("moment", "expected_after", "expected_before"),
+        [
+            # The after bound backs off 1µs so exclusive comparison at the
+            # Gumnut API still includes month-start-midnight assets.
+            (
+                datetime(2024, 3, 15, 12, 30, 45),
+                "2024-02-29T23:59:59.999999",
+                "2024-04-01T00:00:00",
+            ),
+            # January backs off into the previous year.
+            (
+                datetime(2024, 1, 1),
+                "2023-12-31T23:59:59.999999",
+                "2024-02-01T00:00:00",
+            ),
+        ],
+    )
+    def test_bounds(self, moment, expected_after, expected_before):
+        after_bound, before_bound = month_query_bounds(moment)
+        assert after_bound == expected_after
+        assert before_bound == expected_before
 
 
 class TestFetchAssetCounts:
@@ -1073,7 +1102,7 @@ class TestTimezoneAwareTimeBucket:
 
             assert mock_client.assets.list.call_count == 1
             assert mock_client.assets.list.call_args.kwargs["extra_query"] == {
-                "local_datetime_after": "2025-10-01T00:00:00",
+                "local_datetime_after": "2025-09-30T23:59:59.999999",
                 "local_datetime_before": "2025-11-01T00:00:00",
             }
 
@@ -1093,7 +1122,7 @@ class TestTimezoneAwareTimeBucket:
 
             assert mock_client.assets.list.call_count == 1
             assert mock_client.assets.list.call_args.kwargs["extra_query"] == {
-                "local_datetime_after": "2024-06-01T00:00:00",
+                "local_datetime_after": "2024-05-31T23:59:59.999999",
                 "local_datetime_before": "2024-07-01T00:00:00",
             }
 
@@ -1115,7 +1144,7 @@ class TestDateRangeFiltering:
 
             mock_client.assets.list.assert_called_once_with(
                 extra_query={
-                    "local_datetime_after": "2024-02-01T00:00:00",
+                    "local_datetime_after": "2024-01-31T23:59:59.999999",
                     "local_datetime_before": "2024-03-01T00:00:00",
                 }
             )
@@ -1134,7 +1163,7 @@ class TestDateRangeFiltering:
 
             mock_client.assets.list.assert_called_once_with(
                 extra_query={
-                    "local_datetime_after": "2023-02-01T00:00:00",
+                    "local_datetime_after": "2023-01-31T23:59:59.999999",
                     "local_datetime_before": "2023-03-01T00:00:00",
                 }
             )
@@ -1153,7 +1182,7 @@ class TestDateRangeFiltering:
 
             mock_client.assets.list.assert_called_once_with(
                 extra_query={
-                    "local_datetime_after": "2024-04-01T00:00:00",
+                    "local_datetime_after": "2024-03-31T23:59:59.999999",
                     "local_datetime_before": "2024-05-01T00:00:00",
                 }
             )
@@ -1172,7 +1201,7 @@ class TestDateRangeFiltering:
 
             mock_client.assets.list.assert_called_once_with(
                 extra_query={
-                    "local_datetime_after": "2024-12-01T00:00:00",
+                    "local_datetime_after": "2024-11-30T23:59:59.999999",
                     "local_datetime_before": "2025-01-01T00:00:00",
                 }
             )


### PR DESCRIPTION
## What
- `POST /search/random` now returns a uniform random sample of live assets (default 250, matching the Immich server) instead of an empty list. Supported filters: `size`, single-element `albumIds` / `personIds`, and `type` (applied to the drawn sample via MIME mapping, since the Gumnut API has no server-side type filter — the sample stays uniform over matching assets but may hold fewer than `size` items). Restricting filters with no Gumnut API translation (date bounds, location/camera metadata, tags, rating, …) return an empty list rather than silently sampling assets the caller filtered out
- `GET /search/explore` now returns the `exifInfo.city` group (one representative image per city, the group the Immich web/mobile explore pages render as Places) plus a `createdAt` recents group
- Extracts shared `month_window` / `month_query_bounds` helpers used by both the timeline bucket endpoint and random sampling. `month_query_bounds` backs the `local_datetime_after` bound off by one microsecond (the Gumnut API treats it as exclusive), fixing a pre-existing timeline bug where an asset captured exactly at month-start midnight was counted in the month's bucket but never listed
- Updates the gap-analysis, architecture, and code-practices docs

## Why
- These were the last two search stubs closeable with adapter-only work on existing Gumnut asset APIs
- Random sampling draws distinct global indices over the per-month asset counts and fetches only the sampled months (bounded fan-out via `gather_with_concurrency`), so it stays cheap on large libraries instead of scanning everything
- Explore derives cities from a bounded scan of the 1000 most recent live assets with a batched full-include re-fetch of the representatives; both clients hard-match the `exifInfo.city` group name, which the implementation matches

## Test plan
- [x] 34 new unit tests covering both endpoints and the month helpers: filter guards (incl. a drift guard over the generated DTO's field list), the post-sample type filter, month-window boundaries (incl. December rollover and the exclusive-bound backoff), deterministic offset mapping across bucket boundaries, stale-count races, month-fetch early break, explore city threshold/cap/scan-limit/recents-cap, vanished-representative race, include-set forwarding, SDK error propagation
- [x] Full suite: 1081 passed; ruff and pyright clean

Generated by an AI coding agent.
