### PR TITLE
Emit asset/timeline duration as integer milliseconds (Immich v3)

### DIFF
--- a/docs/design-docs/immich-v3-api-changes.md
+++ b/docs/design-docs/immich-v3-api-changes.md
@@ -2,7 +2,7 @@
 title: "Immich v2.7.5 → v3.0 API Change Analysis"
 status: active
 created: 2026-06-16
-last-updated: 2026-07-02
+last-updated: 2026-07-06
 ---
 
 # Immich v2.7.5 → v3.0 API Change Analysis

--- a/docs/design-docs/immich-v3-api-changes.md
+++ b/docs/design-docs/immich-v3-api-changes.md
@@ -104,7 +104,7 @@ mistake it for behavioral change.
 
 | Change | Detail | Adapter impact |
 |---|---|---|
-| **`duration` string → integer ms** | `AssetResponseDto`, `TimeBucketAssetResponseDto`, `AssetMediaCreateDto`. Was `"HH:MM:SS.ffffff"` interval string, now integer **milliseconds**, nullable on `AssetResponseDto`. | `routers/utils/asset_conversion.py:format_duration` emits the interval string today — must emit int ms. Touches `routers/models.py:69`, and the `duration` fields in `routers/immich_models.py`. Affects every asset/timeline/upload response. |
+| **`duration` string → integer ms** | `AssetResponseDto`, `TimeBucketAssetResponseDto`, `AssetMediaCreateDto`. Was `"HH:MM:SS.ffffff"` interval string, now integer **milliseconds**, nullable on `AssetResponseDto`. | A `duration_ms` helper in `routers/utils/asset_conversion.py` emits int ms (null when unknown) for `AssetResponseDto` / `TimeBucketAssetResponseDto`; the interval-string `format_duration` is retained for `SyncAssetV1`, whose `duration` stays a string in v3 (`SyncAssetV2` is the int-ms sync variant — see §5). The `duration` fields live in `routers/immich_models.py`. Affects every asset/timeline/upload response. |
 | **`AlbumResponseDto` restructured** | Removed `assets`, `owner`, `ownerId`. Owner now derived from **`albumUsers[0]`** (now `minItems:1`; documented ordering: owner first, then auth user if different, rest alphabetical). `shared` now required. | Album responses no longer inline assets or owner. Album conversion must populate `albumUsers[0]` as owner and stop emitting `owner`/`ownerId`/`assets`. |
 | **`AssetResponseDto` face/device fields** | Removed `deviceAssetId`, `deviceId`, `unassignedFaces`. `people`: `PersonWithFacesResponseDto` → `PersonResponseDto` (no inline face bounding boxes). | No inline face geometry on assets. Schemas `PersonWithFacesResponseDto` and `AssetFaceWithoutPersonResponseDto` deleted. |
 | **Shared-link tokens removed** | `SharedLinkResponseDto.token` gone; `GET /shared-links/me` lost `password`/`token` query params; `SharedLinkEditDto.changeExpiryTime` gone; `PUT /albums/{id}/assets`, `PUT /shared-links/{id}/assets`, `PUT /albums/assets` lost `key`/`slug` params. | Shared-link / anonymous (key/slug) access model changed — `routers/api/shared_links.py` and key/slug access path need rework. |
@@ -248,7 +248,7 @@ RC** (no methods were added) — likely pre-announcing a future PATCH migration:
 
 ## 7. Adapter retarget plan (priority order)
 
-1. **`duration` → integer ms** (`asset_conversion.py`, `models.py`,
+1. **`duration` → integer ms** (`asset_conversion.py`,
    `immich_models.py`) — touches every asset/timeline/upload response.
 2. **`AlbumResponseDto`** — derive owner from `albumUsers[0]`, drop
    `owner`/`ownerId`/inline `assets`.

--- a/routers/api/timeline.py
+++ b/routers/api/timeline.py
@@ -14,7 +14,7 @@ from routers.immich_models import (
     TimeBucketsResponseDto,
 )
 from routers.utils.asset_conversion import (
-    format_duration,
+    duration_ms,
     mime_type_to_asset_type,
     resolve_capture_datetime,
 )
@@ -213,7 +213,7 @@ async def get_time_bucket(
     visibility_list = []
     local_offset_hours_list = []
     is_trashed_list = []
-    duration_list: list[str | None] = []
+    duration_list: list[int | None] = []
     thumbhash_list: list[str | None] = []
 
     for asset in filtered_assets:
@@ -246,10 +246,10 @@ async def get_time_bucket(
 
         is_trashed_list.append(bool(asset.trashed_at))
 
-        # Forward each asset's duration: format_duration returns the
-        # HH:MM:SS.ffffff string, or None on NULL upstream — preserving this
+        # Forward each asset's duration: duration_ms returns integer
+        # milliseconds (Immich v3), or None on NULL upstream — preserving this
         # bucket's prior all-None output for images / not-yet-extracted videos.
-        duration_list.append(format_duration(asset.duration))
+        duration_list.append(duration_ms(asset.duration))
 
         # Forward each asset's real thumbhash (base64 ThumbHash) so clients
         # render a distinct placeholder per tile. None until upstream generates

--- a/routers/utils/asset_conversion.py
+++ b/routers/utils/asset_conversion.py
@@ -102,13 +102,16 @@ def normalize_rating(rating: float | int | None) -> int | None:
 
 
 def format_duration(seconds: float | None) -> str | None:
-    """Format an upstream video duration (float seconds) as Immich's interval string.
+    """Format a video duration (float seconds) as Immich's ``HH:MM:SS.ffffff`` interval string.
 
-    Immich expresses video duration as an ``HH:MM:SS.ffffff`` string. The Gumnut
-    asset carries ``duration`` as float seconds, or ``None`` when the asset is an
-    image or its duration has not been extracted yet. Returns ``None`` for ``None``
-    so callers can preserve each emit site's existing absent-duration behavior
-    rather than fabricating a value.
+    Retained for the ``SyncAssetV1`` sync payload, whose ``duration`` field is
+    still the interval string in the Immich v3 spec. The asset/timeline REST
+    responses moved to integer milliseconds — see ``duration_ms`` — but the v1
+    sync entity did not (its int-ms successor is ``SyncAssetV2``, added by the
+    Sync v2 layer). The Gumnut asset carries ``duration`` as float seconds, or
+    ``None`` when the asset is an image or its duration has not been extracted
+    yet; ``None`` passes through so each sync emit site preserves its
+    absent-duration behavior rather than fabricating a value.
     """
     if seconds is None:
         return None
@@ -122,19 +125,21 @@ def format_duration(seconds: float | None) -> str | None:
     return f"{hours:02d}:{minutes:02d}:{secs:02d}.{micros:06d}"
 
 
-def _resolve_single_asset_duration(
-    gumnut_asset: AssetResponse, asset_type: AssetTypeEnum
-) -> str:
-    """Duration string for the single-asset ``AssetResponseDto`` (non-nullable).
+def duration_ms(seconds: float | None) -> int | None:
+    """Convert an upstream video duration (float seconds) to Immich's integer milliseconds.
 
-    Uses the upstream value when present; when absent, preserves the prior
-    placeholder — zero duration for videos, empty string for images — rather
-    than fabricating a length.
+    Immich v3 expresses ``duration`` on ``AssetResponseDto`` and
+    ``TimeBucketAssetResponseDto`` (and, via the Sync v2 layer, the
+    ``SyncAssetV2`` payload) as integer **milliseconds**, nullable — ``null``
+    for a static image or a video whose duration has not been extracted yet.
+    The Gumnut asset carries ``duration`` as float seconds, so round to whole
+    milliseconds; ``None`` passes through as ``None`` rather than fabricating a
+    length (the nullable v3 field makes the old zero/empty-string placeholders
+    unnecessary).
     """
-    formatted = format_duration(gumnut_asset.duration)
-    if formatted is not None:
-        return formatted
-    return "00:00:00.000000" if asset_type == AssetTypeEnum.VIDEO else ""
+    if seconds is None:
+        return None
+    return round(float(seconds) * 1000)
 
 
 def resolve_capture_datetime(gumnut_asset: AssetResponse) -> datetime:
@@ -530,7 +535,7 @@ def convert_gumnut_asset_to_immich(
         checksum=resolve_immich_checksum(gumnut_asset),
         exifInfo=exif_info,  # Now includes processed EXIF data
         createdAt=gumnut_asset.created_at,
-        duration=_resolve_single_asset_duration(gumnut_asset, asset_type),
+        duration=duration_ms(gumnut_asset.duration),
         hasMetadata=True,
         height=float(height) if height else None,
         isArchived=False,

--- a/tests/unit/api/test_timeline.py
+++ b/tests/unit/api/test_timeline.py
@@ -546,8 +546,8 @@ class TestGetTimeBucket:
     async def test_get_time_bucket_emits_per_asset_duration(
         self, multiple_gumnut_assets, mock_sync_cursor_page
     ):
-        """The bucket's ``duration`` array carries a real ``HH:MM:SS.ffffff``
-        string for a video whose upstream duration is populated, and stays
+        """The bucket's ``duration`` array carries Immich v3 integer
+        milliseconds for a video whose upstream duration is populated, and stays
         ``None`` for an asset whose upstream duration is NULL (image, or video
         not yet extracted) — matching the prior all-None behavior."""
         mock_client = Mock()
@@ -574,7 +574,7 @@ class TestGetTimeBucket:
                 timeBucket="2024-01-01T00:00:00", client=mock_client
             )
 
-            assert result["duration"] == ["00:01:05.250000", None]
+            assert result["duration"] == [65250, None]
 
     @pytest.mark.anyio
     async def test_get_time_bucket_emits_per_asset_thumbhash(

--- a/tests/unit/utils/test_asset_conversion.py
+++ b/tests/unit/utils/test_asset_conversion.py
@@ -21,6 +21,7 @@ from routers.api.sync.converters import gumnut_asset_to_sync_asset_v1
 from routers.utils.asset_conversion import (
     build_asset_upload_ready_payload,
     convert_gumnut_asset_to_immich,
+    duration_ms,
     extract_exif_info,
     extract_sync_exif,
     format_duration,
@@ -629,11 +630,39 @@ class TestFormatDuration:
         assert format_duration(seconds) == expected
 
 
+class TestDurationMs:
+    """``duration_ms`` turns upstream float seconds into Immich v3's integer
+    milliseconds, and ``None`` into ``None`` (the field is nullable — no
+    fabricated zero/empty placeholder)."""
+
+    def test_none_passes_through(self):
+        assert duration_ms(None) is None
+
+    @pytest.mark.parametrize(
+        "seconds, expected",
+        [
+            (0.0, 0),
+            (5.5, 5500),
+            (12.5, 12500),
+            (65.25, 65250),
+            (3661.5, 3661500),
+            (7200, 7200000),
+            # Sub-millisecond precision rounds to the nearest whole ms.
+            (1.0004, 1000),
+            (1.0006, 1001),
+        ],
+    )
+    def test_formats_seconds_as_milliseconds(self, seconds, expected):
+        assert duration_ms(seconds) == expected
+
+
 class TestDurationEmission:
-    """Every outbound converter forwards the upstream ``duration`` (float
-    seconds) as an ``HH:MM:SS.ffffff`` string. When upstream is NULL each site
-    preserves the value it emitted before this field existed — never a
-    fabricated length. Mirrors the width/height staged-rollout precedent."""
+    """Outbound duration handling, per emit site. The REST ``AssetResponseDto``
+    and the timeline bucket carry Immich v3 integer milliseconds (null when
+    unknown); the ``SyncAssetV1`` websocket/sync payloads still carry the
+    ``HH:MM:SS.ffffff`` interval string (unchanged in v3 — the int-ms sync
+    entity is ``SyncAssetV2``). Every site emits ``None`` on NULL upstream
+    rather than a fabricated length."""
 
     OWNER_ID = "22222222-2222-2222-2222-222222222222"
 
@@ -645,7 +674,7 @@ class TestDurationEmission:
 
         result = convert_gumnut_asset_to_immich(sample_gumnut_asset, mock_current_user)
 
-        assert result.duration == "00:00:12.500000"
+        assert result.duration == 12500
 
     def test_websocket_payload_formats_populated_duration(self, sample_gumnut_asset):
         sample_gumnut_asset.mime_type = "video/mp4"
@@ -667,11 +696,13 @@ class TestDurationEmission:
 
         assert result.duration == "00:00:30.000000"
 
-    def test_null_duration_preserves_prior_behavior(
+    def test_null_duration_video_emits_none(
         self, sample_gumnut_asset, mock_current_user
     ):
-        """Upstream NULL: the REST single-asset DTO keeps its zero placeholder
-        for video, while the WebSocket and sync converters keep ``None``."""
+        """Upstream NULL: every site emits ``None``. The REST DTO's ``duration``
+        is nullable in v3, so a not-yet-extracted video duration is ``null``
+        rather than the old zero placeholder; the WebSocket/sync SyncAssetV1
+        payloads keep ``None`` as before."""
         sample_gumnut_asset.mime_type = "video/mp4"
         sample_gumnut_asset.duration = None
 
@@ -683,21 +714,21 @@ class TestDurationEmission:
             sample_gumnut_asset, owner_id=self.OWNER_ID
         )
 
-        assert rest.duration == "00:00:00.000000"
+        assert rest.duration is None
         assert ws.asset.duration is None
         assert sync.duration is None
 
-    def test_null_duration_image_emits_empty_string_in_rest_dto(
+    def test_null_duration_image_emits_none_in_rest_dto(
         self, sample_gumnut_asset, mock_current_user
     ):
-        """For images (no duration concept) the REST DTO keeps its empty-string
-        placeholder rather than the video zero or a fabricated value."""
+        """For images (no duration concept) the nullable v3 REST DTO emits
+        ``null`` rather than the old empty-string placeholder."""
         sample_gumnut_asset.mime_type = "image/jpeg"
         sample_gumnut_asset.duration = None
 
         result = convert_gumnut_asset_to_immich(sample_gumnut_asset, mock_current_user)
 
-        assert result.duration == ""
+        assert result.duration is None
 
 
 class TestFileDataSourcing:


### PR DESCRIPTION
## What
- Add a `duration_ms(seconds) -> int | None` converter and emit integer **milliseconds** (null when unknown) for `AssetResponseDto.duration` and `TimeBucketAssetResponseDto.duration`, matching Immich v3's move from the `HH:MM:SS.ffffff` interval string to nullable int ms.
- Remove the `_resolve_single_asset_duration` placeholder helper — the nullable v3 field lets an unknown duration be `null` instead of the old `00:00:00.000000` (video) / `""` (image) placeholders.
- Leave `format_duration` (the interval string) unchanged for the two `SyncAssetV1` sync-payload sites, whose `duration` stays `str | None` in the v3 spec. The int-ms sync variant (`SyncAssetV2`) is a downstream step that will reuse `duration_ms`.
- Correct the v3 change-analysis design doc: drop a reference to a nonexistent `routers/models.py` and describe the as-built converter split.

## Why
- Immich v3 (GA) changed `duration` on every asset/timeline/upload response to nullable integer milliseconds. Without this, clients receive the wrong wire type for those responses.
- **Merges to `migration/immichv3`, not `main`.** This is an early step of the Immich v3 retarget; the long-lived integration branch merges to `main` once all steps land. The branch is intentionally not standalone-green — pyright and pytest carry pre-existing breakage from sibling v3 changes not yet landed (deleted `PersonWithFacesResponseDto`, removed `AssetResponseDto` device fields, `SyncAssetV1.createdAt` now required). This change was verified to add **zero** new pyright errors vs. the branch base.

## Test plan
- [ ] `TestDurationMs` covers the converter: populated values, `None` passthrough, round down/up, and the `0` floor.
- [ ] `TestDurationEmission`: the REST `AssetResponseDto` asserts integer ms (`12.5s -> 12500`), while the `SyncAssetV1` websocket/sync assertions remain the interval string (unchanged in v3).
- [ ] Timeline bucket test asserts `[65250, None]` for `65.25s` / `None`.
- [ ] Note: these unit tests cannot execute on this integration branch yet — pytest collection is blocked by a sibling v3 change that deletes `PersonWithFacesResponseDto`. Verified here by inspection, standalone arithmetic check, and a baseline pyright diff; they run green once the sibling converter issues land.

Generated by an AI coding agent.