### PR TITLE
Restructure AlbumResponseDto to Immich v3 shape (albumUsers[0])

### DIFF
--- a/docs/design-docs/immich-v3-api-changes.md
+++ b/docs/design-docs/immich-v3-api-changes.md
@@ -265,6 +265,27 @@ RC** (no methods were added) — likely pre-announcing a future PATCH migration:
 
 ---
 
+## Known blockers on the integration branch
+
+`migration/immichv3` is intentionally red until the API-shape work lands. Two
+blockers keep the test suite un-runnable independent of any single issue, so
+per-issue changes are verified by inspection plus scoped checks (ruff, a
+zero-new-errors pyright diff) rather than a green suite:
+
+- **`Error1` import** — `routers/utils/bulk.py` imports `Error1`, which the v3
+  regen removed from `immich_models.py`. This fails *collection* of every test
+  module that imports the router layer (e.g. `test_albums.py`) until the bulk
+  error enum is retargeted to its v3 name.
+- **`pattern`-constrained `UUID` fields** — the regenerated models annotate UUID
+  fields as `Annotated[UUID, Field(pattern=...)]`. Under the pinned pydantic +
+  Python 3.14, *instantiating* any such model raises `TypeError: Unable to apply
+  constraint 'pattern' … for schema of type 'uuid'`, so these DTOs cannot be
+  constructed at all — the adapter would 500 serving them, and every test that
+  builds one (or uses the `mock_current_user` fixture) errors at setup. This is
+  deeper than the collection errors above: fixing the imports alone will not
+  turn the suite green. Needs a codegen/dependency fix (drop `pattern` on UUID
+  fields, or pin pydantic), tracked separately from the per-endpoint retarget.
+
 ## Open questions
 
 - ~~Does the adapter retarget 3.0 GA in one cut, or run a compatibility window

--- a/routers/api/albums.py
+++ b/routers/api/albums.py
@@ -32,7 +32,6 @@ from routers.utils.gumnut_id_conversion import (
     uuid_to_gumnut_album_id,
     uuid_to_gumnut_asset_id,
 )
-from routers.utils.asset_conversion import ASSET_INCLUDE, convert_gumnut_asset_to_immich
 from routers.utils.album_conversion import convert_gumnut_album_to_immich
 from pydantic.json_schema import SkipJsonSchema
 
@@ -108,32 +107,21 @@ async def get_album_info(
 ) -> AlbumResponseDto:
     """
     Fetch a specific album from Gumnut and convert to AlbumResponseDto format.
-    If withoutAssets is False, also fetch and include the album's assets.
+
+    Immich v3's AlbumResponseDto no longer inlines assets, so the album's
+    assets are not fetched here — clients load them separately via the timeline
+    API. The `withoutAssets` query param is retained for client compatibility
+    but no longer affects the response.
     """
 
     gumnut_album_id = uuid_to_gumnut_album_id(id)
 
-    # Retrieve the specific album from Gumnut
+    # SDK raises NotFoundError on missing album → handled by global handler.
     gumnut_album = await client.albums.retrieve(gumnut_album_id)
-
-    immich_assets = []
-    if not withoutAssets:
-        async for gumnut_asset in client.assets.list(
-            album_id=gumnut_album_id, include=ASSET_INCLUDE
-        ):
-            try:
-                immich_assets.append(
-                    convert_gumnut_asset_to_immich(gumnut_asset, current_user)
-                )
-            except Exception as convert_error:
-                logger.warning(
-                    f"Warning: Could not convert asset {gumnut_asset}: {convert_error}"
-                )
 
     return convert_gumnut_album_to_immich(
         gumnut_album,
         current_user,
-        assets=immich_assets,
         asset_count=gumnut_album.asset_count,
     )
 

--- a/routers/utils/album_conversion.py
+++ b/routers/utils/album_conversion.py
@@ -8,8 +8,9 @@ to the Immich API format, including handling of datetime fields and album metada
 from gumnut.types.album_response import AlbumResponse
 from routers.immich_models import (
     AlbumResponseDto,
+    AlbumUserResponseDto,
+    AlbumUserRole,
     AssetOrder,
-    AssetResponseDto,
     UserResponseDto,
 )
 from routers.utils.datetime_utils import to_immich_local_datetime
@@ -22,7 +23,6 @@ from routers.utils.gumnut_id_conversion import (
 def convert_gumnut_album_to_immich(
     gumnut_album: AlbumResponse,
     current_user: UserResponseDto,
-    assets: list[AssetResponseDto] | None = None,
     asset_count: int | None = None,
 ) -> AlbumResponseDto:
     """
@@ -31,8 +31,7 @@ def convert_gumnut_album_to_immich(
     Args:
         gumnut_album: The Gumnut AlbumResponse object
         current_user: The current user's UserResponseDto
-        assets: Optional list of AssetResponseDto objects to include
-        asset_count: Optional asset count (if None, will use len(assets) or album's asset_count)
+        asset_count: Asset count (defaults to 0 if None)
 
     Returns:
         AlbumResponseDto object with processed data
@@ -43,16 +42,7 @@ def convert_gumnut_album_to_immich(
     created_at = gumnut_album.created_at
     updated_at = gumnut_album.updated_at
 
-    # Determine asset count
-    if asset_count is not None:
-        final_asset_count = asset_count
-    elif assets is not None:
-        final_asset_count = len(assets)
-    else:
-        final_asset_count = 0
-
-    # Use provided assets or empty list
-    final_assets = assets or []
+    final_asset_count = asset_count if asset_count is not None else 0
 
     return AlbumResponseDto(
         id=str(safe_uuid_from_album_id(album_id)),
@@ -74,12 +64,12 @@ def convert_gumnut_album_to_immich(
         startDate=to_immich_local_datetime(gumnut_album.start_date),
         endDate=to_immich_local_datetime(gumnut_album.end_date),
         lastModifiedAssetTimestamp=None,
-        ownerId=current_user.id,
-        owner=current_user,
-        albumUsers=[],
+        # Immich v3 derives the album owner from albumUsers[0] and no longer
+        # carries owner/ownerId or inline assets. Gumnut has no album sharing,
+        # so this is always exactly the single owner entry.
+        albumUsers=[AlbumUserResponseDto(role=AlbumUserRole.owner, user=current_user)],
         shared=False,
         hasSharedLink=False,
-        assets=final_assets,
         assetCount=final_asset_count,
         isActivityEnabled=True,
         order=AssetOrder.desc,

--- a/tests/unit/api/test_albums.py
+++ b/tests/unit/api/test_albums.py
@@ -23,6 +23,7 @@ from routers.api.albums import (
     add_assets_to_albums,
 )
 from routers.immich_models import (
+    AlbumUserRole,
     CreateAlbumDto,
     UpdateAlbumDto,
     BulkIdsDto,
@@ -82,6 +83,11 @@ class TestGetAllAlbums:
         # Verify the real conversion happened by checking result structure
         assert all(hasattr(album, "id") for album in result)
         assert all(hasattr(album, "albumName") for album in result)
+        # v3: owner is carried in albumUsers[0]; owner/ownerId/assets are gone.
+        assert all(
+            album.albumUsers[0].user.id == mock_current_user.id for album in result
+        )
+        assert all(album.albumUsers[0].role == AlbumUserRole.owner for album in result)
 
     @pytest.mark.anyio
     async def test_get_all_albums_includes_asset_count(
@@ -347,18 +353,18 @@ class TestGetAlbumInfo:
     async def test_get_album_info_success(
         self,
         sample_gumnut_album,
-        multiple_gumnut_assets,
-        mock_sync_cursor_page,
         sample_uuid,
         mock_current_user,
     ):
-        """Test successful retrieval of album info."""
+        """Test successful retrieval of album info.
+
+        Immich v3's AlbumResponseDto no longer inlines assets, so the endpoint
+        must not fetch the album's assets. The owner is carried in
+        albumUsers[0].
+        """
         # Setup - create mock client
         mock_client = Mock()
         mock_client.albums.retrieve = AsyncMock(return_value=sample_gumnut_album)
-        mock_client.assets.list.return_value = mock_sync_cursor_page(
-            multiple_gumnut_assets
-        )
 
         # Execute
         result = await get_album_info(
@@ -374,16 +380,16 @@ class TestGetAlbumInfo:
         assert hasattr(result, "albumName")
         assert result.albumName == "Test Album"  # From sample_gumnut_album.name
         mock_client.albums.retrieve.assert_called_once()
-        mock_client.assets.list.assert_called_once_with(
-            album_id=uuid_to_gumnut_album_id(sample_uuid),
-            include=["metadata", "people", "file_data"],
-        )
+        # v3 no longer inlines assets — the endpoint must not fetch them.
+        mock_client.assets.list.assert_not_called()
+        # Owner is derived from albumUsers[0].
+        assert result.albumUsers[0].user.id == mock_current_user.id
+        assert result.albumUsers[0].role == AlbumUserRole.owner
 
     @pytest.mark.anyio
     async def test_get_album_info_uses_gumnut_asset_count(
         self,
         sample_gumnut_album,
-        mock_sync_cursor_page,
         sample_uuid,
         mock_current_user,
     ):
@@ -393,8 +399,6 @@ class TestGetAlbumInfo:
 
         mock_client = Mock()
         mock_client.albums.retrieve = AsyncMock(return_value=sample_gumnut_album)
-        # Return empty assets list
-        mock_client.assets.list.return_value = mock_sync_cursor_page([])
 
         # Execute
         result = await get_album_info(
@@ -409,7 +413,7 @@ class TestGetAlbumInfo:
 
     @pytest.mark.anyio
     async def test_get_album_info_with_album_cover_asset_id(
-        self, sample_gumnut_album, mock_sync_cursor_page, sample_uuid, mock_current_user
+        self, sample_gumnut_album, sample_uuid, mock_current_user
     ):
         """Test that album_cover_asset_id is converted to albumThumbnailAssetId in get_album_info."""
         # Setup - set album_cover_asset_id on the album
@@ -418,7 +422,6 @@ class TestGetAlbumInfo:
 
         mock_client = Mock()
         mock_client.albums.retrieve = AsyncMock(return_value=sample_gumnut_album)
-        mock_client.assets.list.return_value = mock_sync_cursor_page([])
 
         # Execute
         result = await get_album_info(
@@ -436,7 +439,11 @@ class TestGetAlbumInfo:
     async def test_get_album_info_without_assets(
         self, sample_gumnut_album, sample_uuid, mock_current_user
     ):
-        """Test retrieval of album info without assets."""
+        """The vestigial withoutAssets=True is still accepted and returns the album.
+
+        Assets are never inlined in v3 regardless of this param, so it no longer
+        gates anything, but clients may still send it.
+        """
         # Setup - create mock client
         mock_client = Mock()
         mock_client.albums.retrieve = AsyncMock(return_value=sample_gumnut_album)
@@ -454,7 +461,7 @@ class TestGetAlbumInfo:
         assert hasattr(result, "id")
         assert result.albumName == "Test Album"  # From sample_gumnut_album.name
         mock_client.albums.retrieve.assert_called_once()
-        # withoutAssets=True skips the assets.list call entirely
+        # Assets are never fetched in v3 (no longer inlined in the response).
         mock_client.assets.list.assert_not_called()
 
     @pytest.mark.anyio

--- a/tests/unit/utils/test_album_conversion.py
+++ b/tests/unit/utils/test_album_conversion.py
@@ -1,0 +1,63 @@
+"""Tests for album conversion utilities — focused on the Immich v3 shape.
+
+``convert_gumnut_album_to_immich`` builds ``AlbumResponseDto``, which in Immich
+v3 no longer carries ``owner``/``ownerId`` or inline ``assets``. The owner is
+instead derived from ``albumUsers[0]`` (``minItems: 1``), and ``shared`` is
+required. Gumnut has no album sharing, so ``albumUsers`` is always exactly the
+single owner entry.
+"""
+
+import pytest
+
+from routers.immich_models import AlbumUserRole
+from routers.utils.album_conversion import convert_gumnut_album_to_immich
+
+
+class TestConvertGumnutAlbumToImmich:
+    def test_owner_carried_in_album_users(self, sample_gumnut_album, mock_current_user):
+        """The current user is the sole albumUsers[0] entry, with the owner role."""
+        result = convert_gumnut_album_to_immich(
+            sample_gumnut_album, mock_current_user, asset_count=5
+        )
+
+        assert len(result.albumUsers) == 1
+        assert result.albumUsers[0].role == AlbumUserRole.owner
+        assert result.albumUsers[0].user.id == mock_current_user.id
+        assert result.albumUsers[0].user == mock_current_user
+
+    def test_removed_v3_fields_absent(self, sample_gumnut_album, mock_current_user):
+        """owner/ownerId/assets were dropped from the v3 DTO — none are emitted."""
+        result = convert_gumnut_album_to_immich(
+            sample_gumnut_album, mock_current_user, asset_count=5
+        )
+
+        assert not hasattr(result, "owner")
+        assert not hasattr(result, "ownerId")
+        assert not hasattr(result, "assets")
+
+    def test_shared_flags_false(self, sample_gumnut_album, mock_current_user):
+        """Gumnut has no sharing, so shared/hasSharedLink are always False.
+
+        ``shared`` is required in v3; it must be present (not omitted).
+        """
+        result = convert_gumnut_album_to_immich(
+            sample_gumnut_album, mock_current_user, asset_count=5
+        )
+
+        assert result.shared is False
+        assert result.hasSharedLink is False
+
+    @pytest.mark.parametrize("count", [0, 5, 42])
+    def test_asset_count_forwarded(self, sample_gumnut_album, mock_current_user, count):
+        """The passed asset_count is echoed onto the DTO."""
+        result = convert_gumnut_album_to_immich(
+            sample_gumnut_album, mock_current_user, asset_count=count
+        )
+
+        assert result.assetCount == count
+
+    def test_asset_count_defaults_to_zero(self, sample_gumnut_album, mock_current_user):
+        """A missing asset_count falls back to 0 rather than erroring."""
+        result = convert_gumnut_album_to_immich(sample_gumnut_album, mock_current_user)
+
+        assert result.assetCount == 0

--- a/tests/unit/utils/test_album_conversion.py
+++ b/tests/unit/utils/test_album_conversion.py
@@ -22,7 +22,6 @@ class TestConvertGumnutAlbumToImmich:
 
         assert len(result.albumUsers) == 1
         assert result.albumUsers[0].role == AlbumUserRole.owner
-        assert result.albumUsers[0].user.id == mock_current_user.id
         assert result.albumUsers[0].user == mock_current_user
 
     def test_removed_v3_fields_absent(self, sample_gumnut_album, mock_current_user):


### PR DESCRIPTION
## What
- Populate `albumUsers[0]` as the album owner and stop emitting the v3-removed `owner`/`ownerId`/inline `assets`; keep `shared`/`hasSharedLink`. Drop the now-unused `assets` parameter from the album converter (every caller already passes `asset_count`).
- `GET /albums/{id}` no longer fetches + converts every album asset (they are no longer inlined in v3) — a net perf win. The `withoutAssets` query param is retained for client compatibility but is now a no-op.
- Add `tests/unit/utils/test_album_conversion.py` for the v3 shape; fix the `get_album_info` tests that expected an asset fetch.

## Why
Immich v3's `AlbumResponseDto` removed `assets`/`owner`/`ownerId`, made `albumUsers` required (`min_length=1`, owner first), and made `shared` required. The prior conversion still passed the removed fields and `albumUsers=[]`, which violates the new `min_length=1` at runtime. Gumnut has no album sharing, so `albumUsers` is always exactly the single owner entry.

## Base branch
Targets `migration/immichv3`, **not `main`** — step 2 of the Immich v3 retarget. The integration branch merges to `main` once all steps land.

## Test plan
- [ ] New/updated unit tests assert the v3 shape: owner in `albumUsers[0]` with the owner role, `shared` present, no `owner`/`ownerId`/`assets`, `assetCount` forwarded (incl. `None → 0`), and `GET /albums/{id}` performs no asset fetch.
- [ ] `migration/immichv3` is intentionally red — the suite can't run yet (pre-existing removed-`Error1` import + pydantic `pattern`-on-`UUID` instantiation blockers, now documented in the v3 API analysis doc). Verified for this change: ruff clean; scoped pyright adds zero new errors.

Generated by an AI coding agent.