### PR TITLE
Retarget AssetResponseDto to Immich v3 shape

### DIFF
--- a/docs/design-docs/immich-v3-api-changes.md
+++ b/docs/design-docs/immich-v3-api-changes.md
@@ -108,7 +108,7 @@ mistake it for behavioral change.
 | **`AlbumResponseDto` restructured** | Removed `assets`, `owner`, `ownerId`. Owner now derived from **`albumUsers[0]`** (now `minItems:1`; documented ordering: owner first, then auth user if different, rest alphabetical). `shared` now required. | Album responses no longer inline assets or owner. Album conversion must populate `albumUsers[0]` as owner and stop emitting `owner`/`ownerId`/`assets`. |
 | **`AssetResponseDto` face/device fields** | Removed `deviceAssetId`, `deviceId`, `unassignedFaces`. `people`: `PersonWithFacesResponseDto` → `PersonResponseDto` (no inline face bounding boxes). | No inline face geometry on assets. Schemas `PersonWithFacesResponseDto` and `AssetFaceWithoutPersonResponseDto` deleted. |
 | **Shared-link tokens removed** | `SharedLinkResponseDto.token` gone; `GET /shared-links/me` lost `password`/`token` query params; `SharedLinkEditDto.changeExpiryTime` gone; `PUT /albums/{id}/assets`, `PUT /shared-links/{id}/assets`, `PUT /albums/assets` lost `key`/`slug` params. | Shared-link / anonymous (key/slug) access model changed — `routers/api/shared_links.py` and key/slug access path need rework. |
-| **`deviceId`/`deviceAssetId` dropped from search/upload DTOs** | `MetadataSearchDto`, `SmartSearchDto`, `RandomSearchDto`, `StatisticsSearchDto`, `AssetMediaCreateDto`. | Device-based dedup/filtering removed across search + upload. |
+| **`deviceId`/`deviceAssetId` dropped from search/upload DTOs** | `MetadataSearchDto`, `SmartSearchDto`, `RandomSearchDto`, `StatisticsSearchDto`, `AssetMediaCreateDto`. | Device-based dedup/filtering removed across search + upload. Upload still synthesizes `device_asset_id`/`device_id` (`GUMNUT_UPLOAD_DEVICE_ID` + a per-upload UUID) because the Gumnut API requires them; dedup is checksum-based. |
 | **Asset replace removed** | `AssetMediaStatus` lost `replaced`; `Permission` lost `asset.replace`; `AssetMediaReplaceDto` deleted. See also removed `PUT /assets/{id}/original` in §3. | |
 | **`LicenseResponseDto`** | Lost `activatedAt`, `activationKey`, `licenseKey`. | Licensing response shape changed. |
 
@@ -276,15 +276,17 @@ zero-new-errors pyright diff) rather than a green suite:
   regen removed from `immich_models.py`. This fails *collection* of every test
   module that imports the router layer (e.g. `test_albums.py`) until the bulk
   error enum is retargeted to its v3 name.
-- **`pattern`-constrained `UUID` fields** — the regenerated models annotate UUID
-  fields as `Annotated[UUID, Field(pattern=...)]`. Under the pinned pydantic +
-  Python 3.14, *instantiating* any such model raises `TypeError: Unable to apply
-  constraint 'pattern' … for schema of type 'uuid'`, so these DTOs cannot be
-  constructed at all — the adapter would 500 serving them, and every test that
-  builds one (or uses the `mock_current_user` fixture) errors at setup. This is
-  deeper than the collection errors above: fixing the imports alone will not
-  turn the suite green. Needs a codegen/dependency fix (drop `pattern` on UUID
-  fields, or pin pydantic), tracked separately from the per-endpoint retarget.
+- **`pattern`-constrained non-`str` fields** — the regenerated models annotate
+  UUID *and datetime* fields as `Annotated[UUID | datetime, Field(pattern=...)]`.
+  Under the pinned pydantic + Python 3.14, *instantiating* any such model raises
+  `TypeError: Unable to apply constraint 'pattern' … for schema of type 'uuid'`
+  (and the identical error `for schema of type 'datetime'` on the sync/exif
+  DTOs), so these DTOs cannot be constructed at all — the adapter would 500
+  serving them, and every test that builds one (or uses the `mock_current_user`
+  fixture) errors at setup. This is deeper than the collection errors above:
+  fixing the imports alone will not turn the suite green. Needs a
+  codegen/dependency fix (drop `pattern` on these fields, or pin pydantic),
+  tracked separately from the per-endpoint retarget.
 
 ## Open questions
 

--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -538,10 +538,8 @@ async def _upload_buffered(
                 detail=str(ve),
             )
 
-        # Gumnut's asset-create requires device_asset_id/device_id, which Immich
-        # v3 no longer sends; synthesize them (see GUMNUT_UPLOAD_DEVICE_ID). A
-        # unique device_asset_id avoids collapsing distinct assets onto one
-        # device tuple; true duplicates are still caught by checksum dedup.
+        # Synthesize the device fields the Gumnut API requires (see
+        # GUMNUT_UPLOAD_DEVICE_ID).
         device_asset_id = str(uuid4())
 
         try:

--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -27,6 +27,7 @@ from gumnut.types.asset_bulk_update_assets_params import Update, UpdateChange
 from gumnut.types.asset_response import AssetResponse
 
 from config.settings import Settings, get_settings
+from routers.api.constants import GUMNUT_UPLOAD_DEVICE_ID
 from routers.utils.cdn_client import DEFAULT_FORWARDED_HEADERS, stream_from_cdn
 from routers.utils.gumnut_client import (
     BULK_CHUNK_SIZE,
@@ -329,8 +330,6 @@ def _parse_datetime(value: str | None, fallback: datetime) -> datetime:
 
 
 class UploadFields(NamedTuple):
-    device_asset_id: str
-    device_id: str
     file_created_at: datetime
     file_modified_at: datetime
 
@@ -340,20 +339,16 @@ def _extract_upload_fields(fields: dict[str, str]) -> UploadFields:
 
     Raises ValueError if required fields are missing.
     """
-    device_asset_id = fields.get("deviceAssetId", "")
-    device_id = fields.get("deviceId", "")
     file_created_at_str = fields.get("fileCreatedAt", "")
 
-    if not device_asset_id or not device_id or not file_created_at_str:
-        raise ValueError(
-            "Missing required fields: deviceAssetId, deviceId, fileCreatedAt"
-        )
+    if not file_created_at_str:
+        raise ValueError("Missing required field: fileCreatedAt")
 
     file_modified_at_str = fields.get("fileModifiedAt") or None
     file_created_at = _parse_datetime(file_created_at_str, datetime.now(timezone.utc))
     file_modified_at = _parse_datetime(file_modified_at_str, file_created_at)
 
-    return UploadFields(device_asset_id, device_id, file_created_at, file_modified_at)
+    return UploadFields(file_created_at, file_modified_at)
 
 
 # Delay applied before emitting upload-success events for video uploads, to give
@@ -536,14 +531,18 @@ async def _upload_buffered(
         # Convert Starlette form values to plain strings for shared helper
         fields = {key: str(value) for key, value in form.items() if key != "assetData"}
         try:
-            device_asset_id, device_id, file_created_at, file_modified_at = (
-                _extract_upload_fields(fields)
-            )
+            file_created_at, file_modified_at = _extract_upload_fields(fields)
         except ValueError as ve:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail=str(ve),
             )
+
+        # Gumnut's asset-create requires device_asset_id/device_id, which Immich
+        # v3 no longer sends; synthesize them (see GUMNUT_UPLOAD_DEVICE_ID). A
+        # unique device_asset_id avoids collapsing distinct assets onto one
+        # device tuple; true duplicates are still caught by checksum dedup.
+        device_asset_id = str(uuid4())
 
         try:
             # Drop iOS live photo .MOV files — they upload as separate video files
@@ -556,8 +555,6 @@ async def _upload_buffered(
                 logger.info(
                     "Dropping iOS live photo video",
                     extra={
-                        "device_asset_id": device_asset_id,
-                        "device_id": device_id,
                         "upload_filename": asset_data.filename,
                         "content_type": asset_data.content_type,
                     },
@@ -584,7 +581,7 @@ async def _upload_buffered(
                         asset_data.content_type,
                     ),
                     device_asset_id=device_asset_id,
-                    device_id=device_id,
+                    device_id=GUMNUT_UPLOAD_DEVICE_ID,
                     file_created_at=file_created_at,
                     file_modified_at=file_modified_at,
                 )
@@ -615,7 +612,6 @@ async def _upload_buffered(
                     "upload_filename": asset_data.filename,
                     "content_type": asset_data.content_type,
                     "device_asset_id": device_asset_id,
-                    "device_id": device_id,
                     "strategy": "buffered",
                 },
                 exc_info=True,
@@ -630,10 +626,10 @@ async def _upload_streaming(
 ) -> AssetMediaResponseDto | JSONResponse:
     """Streaming upload path — pipes file data to the Gumnut API without buffering.
 
-    Note: requires multipart form fields (deviceAssetId, deviceId, fileCreatedAt)
-    to precede the file part. All known Immich clients send fields first. Clients
-    that send the file before fields will receive a 422 error; those uploads fall
-    below the streaming threshold in practice, so they use the buffered path.
+    Note: requires the multipart form field fileCreatedAt to precede the file
+    part. All known Immich clients send fields first. Clients that send the file
+    before fields will receive a 422 error; those uploads fall below the
+    streaming threshold in practice, so they use the buffered path.
     """
     jwt_token = getattr(request.state, "jwt_token", None)
     if not jwt_token:
@@ -718,10 +714,6 @@ async def _upload_streaming(
                 log_extra["upload_filename"] = form_parser.filename
             if form_parser.content_type:
                 log_extra["content_type"] = form_parser.content_type
-            if device_asset_id := form_parser.form_fields.get("deviceAssetId"):
-                log_extra["device_asset_id"] = device_asset_id
-            if device_id := form_parser.form_fields.get("deviceId"):
-                log_extra["device_id"] = device_id
 
         raise map_gumnut_error(
             e,

--- a/routers/api/constants.py
+++ b/routers/api/constants.py
@@ -2,3 +2,11 @@
 # per-page `limit` above this with a 422, so the adapter clamps to it before
 # forwarding. Keep in sync with the backend's own per-page ceiling.
 GUMNUT_API_MAX_PAGE_SIZE = 200
+
+# Placeholder device_id the adapter sends to the Gumnut API on upload. The
+# Gumnut API requires device_asset_id/device_id, but Immich v3 dropped both
+# from the upload DTO (clients no longer send them). The adapter passes this
+# constant device_id and a unique per-upload device_asset_id. Dedup-safe — the
+# backend deduplicates by checksum, not by device identifier (see
+# docs/design-docs/checksum-support.md).
+GUMNUT_UPLOAD_DEVICE_ID = "gumnut-device"

--- a/routers/api/constants.py
+++ b/routers/api/constants.py
@@ -6,7 +6,8 @@ GUMNUT_API_MAX_PAGE_SIZE = 200
 # Placeholder device_id the adapter sends to the Gumnut API on upload. The
 # Gumnut API requires device_asset_id/device_id, but Immich v3 dropped both
 # from the upload DTO (clients no longer send them). The adapter passes this
-# constant device_id and a unique per-upload device_asset_id. Dedup-safe — the
-# backend deduplicates by checksum, not by device identifier (see
-# docs/design-docs/checksum-support.md).
+# constant device_id plus a unique per-upload device_asset_id (a fresh UUID) —
+# unique so two distinct assets never collapse onto one device tuple. Dedup-safe:
+# the backend deduplicates by checksum, not by device identifier, so true
+# re-uploads are still caught (see docs/design-docs/checksum-support.md).
 GUMNUT_UPLOAD_DEVICE_ID = "gumnut-device"

--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -439,7 +439,6 @@ async def search_random(
         request.trashedBefore,
         request.updatedAfter,
         request.updatedBefore,
-        request.deviceId,
         request.lensModel,
         request.libraryId,
         request.make,

--- a/routers/utils/asset_conversion.py
+++ b/routers/utils/asset_conversion.py
@@ -25,7 +25,7 @@ from routers.immich_models import (
 )
 from services.websockets import AssetUploadReadyV1Payload
 from routers.utils.gumnut_id_conversion import safe_uuid_from_asset_id
-from routers.utils.person_conversion import convert_gumnut_person_to_immich_with_faces
+from routers.utils.person_conversion import convert_gumnut_person_to_immich
 
 logger = logging.getLogger(__name__)
 
@@ -513,7 +513,7 @@ def convert_gumnut_asset_to_immich(
     people = []
     if gumnut_asset.people:
         for person in gumnut_asset.people:
-            people.append(convert_gumnut_person_to_immich_with_faces(person))
+            people.append(convert_gumnut_person_to_immich(person))
 
     # Extract EXIF object directly from AssetResponse
     exif_info = extract_exif_info(gumnut_asset)
@@ -523,8 +523,6 @@ def convert_gumnut_asset_to_immich(
 
     return AssetResponseDto(
         id=str(safe_uuid_from_asset_id(asset_id)),
-        deviceAssetId=str(asset_id),  # Keep original Gumnut asset ID
-        deviceId="gumnut-device",  # Placeholder device ID
         type=asset_type,
         originalFileName=original_filename,
         originalMimeType=mime_type,

--- a/routers/utils/person_conversion.py
+++ b/routers/utils/person_conversion.py
@@ -8,7 +8,7 @@ to the Immich API format, including handling of datetime fields and person metad
 from datetime import datetime, date, timezone
 
 from gumnut.types.person_response import PersonResponse
-from routers.immich_models import PersonWithFacesResponseDto, PersonResponseDto
+from routers.immich_models import PersonResponseDto
 from routers.utils.gumnut_id_conversion import safe_uuid_from_person_id
 
 
@@ -94,39 +94,4 @@ def convert_gumnut_person_to_immich(
         thumbnailPath=thumbnail_path,
         updatedAt=updated_at,
         color=None,  # Gumnut doesn't have color field
-    )
-
-
-def convert_gumnut_person_to_immich_with_faces(
-    gumnut_person: PersonResponse,
-) -> PersonWithFacesResponseDto:
-    """
-    Convert a Gumnut person to PersonWithFacesResponseDto format.
-
-    Args:
-        gumnut_person: The Gumnut PersonResponse object
-
-    Returns:
-        PersonWithFacesResponseDto object with processed data
-    """
-    (
-        person_id,
-        person_name,
-        birth_date,
-        is_favorite,
-        is_hidden,
-        updated_at,
-        thumbnail_path,
-    ) = _extract_person_fields(gumnut_person)
-
-    return PersonWithFacesResponseDto(
-        id=str(safe_uuid_from_person_id(person_id)),
-        name=person_name,
-        birthDate=birth_date,
-        isFavorite=is_favorite,
-        isHidden=is_hidden,
-        thumbnailPath=thumbnail_path,
-        updatedAt=updated_at,
-        color=None,  # Gumnut doesn't have color field
-        faces=[],  # Empty faces list - would need separate API call
     )

--- a/services/streaming_form_parser.py
+++ b/services/streaming_form_parser.py
@@ -25,8 +25,10 @@ logger = logging.getLogger(__name__)
 
 MAX_FIELD_BYTES = 64 * 1024  # 64KB — cap for non-file form fields
 
-# Fields that must be present before the file part starts.
-_REQUIRED_FIELDS = {"deviceAssetId", "deviceId", "fileCreatedAt"}
+# Fields that must be present before the file part starts. Immich v3 dropped
+# deviceAssetId/deviceId from the upload DTO, so fileCreatedAt is the only
+# required pre-file field now.
+_REQUIRED_FIELDS = {"fileCreatedAt"}
 
 
 class StreamingFormParser:

--- a/services/streaming_upload.py
+++ b/services/streaming_upload.py
@@ -20,11 +20,13 @@ import queue
 import threading
 from collections.abc import Callable
 from typing import IO, Any, cast
+from uuid import uuid4
 
 import httpx
 import sentry_sdk
 from fastapi import HTTPException, Request, status
 
+from routers.api.constants import GUMNUT_UPLOAD_DEVICE_ID
 from routers.utils.error_mapping import (
     QUOTA_EXCEEDED_DETAIL,
     QUOTA_EXCEEDED_STATUS,
@@ -200,9 +202,14 @@ class StreamingUploadPipeline:
         if not filename or not content_type:
             raise ValueError("Missing file part 'assetData'")
 
-        device_asset_id, device_id, file_created_at, file_modified_at = (
-            extract_fields_fn(self._form_parser.form_fields)
+        file_created_at, file_modified_at = extract_fields_fn(
+            self._form_parser.form_fields
         )
+        # Synthesize the device fields Gumnut requires; a unique device_asset_id
+        # keeps distinct assets from collapsing onto one device tuple (see
+        # GUMNUT_UPLOAD_DEVICE_ID).
+        device_asset_id = str(uuid4())
+        device_id = GUMNUT_UPLOAD_DEVICE_ID
 
         content_length = self._request.headers.get("content-length", "unknown")
         logger.info(
@@ -213,7 +220,6 @@ class StreamingUploadPipeline:
                 "upload_filename": filename,
                 "content_type": content_type,
                 "content_length": content_length,
-                "device_asset_id": device_asset_id,
             },
         )
 

--- a/services/streaming_upload.py
+++ b/services/streaming_upload.py
@@ -205,8 +205,7 @@ class StreamingUploadPipeline:
         file_created_at, file_modified_at = extract_fields_fn(
             self._form_parser.form_fields
         )
-        # Synthesize the device fields Gumnut requires; a unique device_asset_id
-        # keeps distinct assets from collapsing onto one device tuple (see
+        # Synthesize the device fields the Gumnut API requires (see
         # GUMNUT_UPLOAD_DEVICE_ID).
         device_asset_id = str(uuid4())
         device_id = GUMNUT_UPLOAD_DEVICE_ID

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -353,11 +353,10 @@ def _make_mock_request(
 
     request.state = _State()
 
-    # Build form dict from form_data + file
+    # Build form dict from form_data + file. Immich v3 no longer sends device
+    # fields; fileCreatedAt/fileModifiedAt are the timestamps the path reads.
     if form_data is None:
         form_data = {
-            "deviceAssetId": "device-123",
-            "deviceId": "device-456",
             "fileCreatedAt": "2023-01-01T12:00:00Z",
             "fileModifiedAt": "2023-01-01T12:00:00Z",
         }
@@ -442,6 +441,11 @@ class TestUploadAsset:
         mock_client.assets.with_raw_response.create.assert_called_once()
         call_kwargs = mock_client.assets.with_raw_response.create.call_args
         assert call_kwargs.kwargs["asset_data"][1] is mock_file.file
+        # Immich v3 sends no device fields; the adapter synthesizes the values
+        # the Gumnut API requires — a unique per-upload device_asset_id and a
+        # placeholder device_id.
+        UUID(call_kwargs.kwargs["device_asset_id"])  # raises if not a valid UUID
+        assert call_kwargs.kwargs["device_id"] == "gumnut-device"
 
     @pytest.mark.anyio
     async def test_upload_asset_duplicate_returns_real_id(
@@ -2781,7 +2785,10 @@ class TestGetAssetInfo:
         # Assert
         # Result should be a real AssetResponseDto from conversion
         assert hasattr(result, "id")
-        assert hasattr(result, "deviceAssetId")
+        # Immich v3 dropped these from AssetResponseDto.
+        assert not hasattr(result, "deviceAssetId")
+        assert not hasattr(result, "deviceId")
+        assert not hasattr(result, "unassignedFaces")
         mock_client.assets.retrieve.assert_called_once()
 
     @pytest.mark.anyio
@@ -3591,25 +3598,22 @@ class TestExtractUploadFields:
     """Tests for _extract_upload_fields helper."""
 
     def test_valid_fields(self):
+        # Immich v3 no longer sends device fields; only the timestamps remain.
         fields = {
-            "deviceAssetId": "device-123",
-            "deviceId": "device-456",
             "fileCreatedAt": "2023-06-15T10:30:00Z",
             "fileModifiedAt": "2023-06-15T11:00:00Z",
         }
         result = _extract_upload_fields(fields)
-        assert result.device_asset_id == "device-123"
-        assert result.device_id == "device-456"
         assert result.file_created_at.year == 2023
+        assert result.file_modified_at.hour == 11
 
     def test_missing_required_field_raises(self):
-        with pytest.raises(ValueError, match="Missing required"):
-            _extract_upload_fields({"deviceAssetId": "x", "deviceId": "y"})
+        # fileCreatedAt is now the only required field.
+        with pytest.raises(ValueError, match="Missing required field: fileCreatedAt"):
+            _extract_upload_fields({})
 
     def test_file_modified_at_defaults_to_created(self):
         fields = {
-            "deviceAssetId": "x",
-            "deviceId": "y",
             "fileCreatedAt": "2023-06-15T10:30:00Z",
         }
         result = _extract_upload_fields(fields)

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -906,7 +906,6 @@ class TestSearchRandom:
             "trashedBefore",
             "updatedAfter",
             "updatedBefore",
-            "deviceId",
             "lensModel",
             "libraryId",
             "make",

--- a/tests/unit/services/test_streaming_form_parser.py
+++ b/tests/unit/services/test_streaming_form_parser.py
@@ -47,9 +47,9 @@ class TestStreamingFormParser:
         pipe = StreamingPipe(maxsize=64)
         parser_handler = StreamingFormParser(pipe)
 
+        # Immich v3 no longer sends device fields; fileCreatedAt is the only
+        # pre-file field the upload path requires.
         fields = {
-            "deviceAssetId": "device-123",
-            "deviceId": "device-456",
             "fileCreatedAt": "2023-01-01T12:00:00Z",
         }
         file_data = b"fake image content here"
@@ -78,8 +78,6 @@ class TestStreamingFormParser:
         assert not parser_handler.headers_ready.is_set()
 
         fields = {
-            "deviceAssetId": "dev-123",
-            "deviceId": "dev-456",
             "fileCreatedAt": "2023-01-01T12:00:00Z",
         }
         body, ct_header = _build_multipart_body(fields)
@@ -243,8 +241,6 @@ class TestStreamingFormParser:
         parser_handler = StreamingFormParser(pipe)
 
         fields = {
-            "deviceAssetId": "dev-123",
-            "deviceId": "dev-456",
             "fileCreatedAt": "2023-01-01T12:00:00Z",
         }
         file_data = b"A" * 1000
@@ -257,7 +253,7 @@ class TestStreamingFormParser:
             parser.write(body[i : i + 100])
         parser.finalize()
 
-        assert parser_handler.form_fields["deviceAssetId"] == "dev-123"
+        assert parser_handler.form_fields["fileCreatedAt"] == "2023-01-01T12:00:00Z"
         assert parser_handler.filename == "test.jpg"
 
         # Read all file data from pipe

--- a/tests/unit/services/test_streaming_upload.py
+++ b/tests/unit/services/test_streaming_upload.py
@@ -145,6 +145,33 @@ class TestStreamingUploadPipeline:
         assert sent_data["device_id"] == "gumnut-device"
 
     @pytest.mark.anyio
+    async def test_device_asset_id_unique_per_upload(self):
+        """Each upload gets a fresh device_asset_id — the whole reason it is
+        synthesized per-upload rather than shared. Guards against a regression
+        that hoisted the UUID to module scope or reused GUMNUT_UPLOAD_DEVICE_ID,
+        which would still parse as a valid UUID but collapse distinct assets."""
+        mock_client = MagicMock()
+        mock_client.post.return_value = _make_httpx_response(201)
+
+        device_asset_ids = []
+        with patch(
+            "services.streaming_upload._get_streaming_http_client",
+            return_value=mock_client,
+        ):
+            for _ in range(2):
+                body, ct_header = _build_multipart_body()
+                request = _make_mock_request(body, ct_header)
+                pipeline = StreamingUploadPipeline(
+                    request, "http://localhost:8000", "jwt"
+                )
+                await pipeline.execute(_extract_fields)
+                device_asset_ids.append(
+                    mock_client.post.call_args.kwargs["data"]["device_asset_id"]
+                )
+
+        assert device_asset_ids[0] != device_asset_ids[1]
+
+    @pytest.mark.anyio
     async def test_5xx_maps_to_502(self):
         """Test that upstream 5xx is mapped to 502."""
         body, ct_header = _build_multipart_body()

--- a/tests/unit/services/test_streaming_upload.py
+++ b/tests/unit/services/test_streaming_upload.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from typing import NamedTuple
 from unittest.mock import MagicMock, patch
+from uuid import UUID
 
 import httpx
 import pytest
@@ -11,26 +12,21 @@ from fastapi import HTTPException
 from services.streaming_upload import StreamingUploadPipeline
 
 
-# Minimal UploadFields stand-in (mirrors the real NamedTuple in assets.py)
+# Minimal UploadFields stand-in (mirrors the real NamedTuple in assets.py).
+# Immich v3 dropped the device fields; the pipeline synthesizes them internally.
 class _UploadFields(NamedTuple):
-    device_asset_id: str
-    device_id: str
     file_created_at: datetime
     file_modified_at: datetime
 
 
 def _extract_fields(fields: dict[str, str]) -> _UploadFields:
     return _UploadFields(
-        device_asset_id=fields.get("deviceAssetId", ""),
-        device_id=fields.get("deviceId", ""),
         file_created_at=datetime(2023, 1, 1),
         file_modified_at=datetime(2023, 1, 1),
     )
 
 
 _REQUIRED_FIELDS = {
-    "deviceAssetId": "dev-123",
-    "deviceId": "dev-456",
     "fileCreatedAt": "2023-01-01T00:00:00Z",
 }
 
@@ -123,6 +119,30 @@ class TestStreamingUploadPipeline:
         assert result["status"] == "created"
         assert pipeline.last_status_code == 201
         mock_client.post.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_synthesizes_device_fields_for_gumnut(self):
+        """Immich v3 sends no device fields; the pipeline synthesizes what the
+        Gumnut API requires — a unique per-upload device_asset_id and a
+        placeholder device_id — and forwards them in the upload body."""
+        body, ct_header = _build_multipart_body(filename="photo.jpg")
+        request = _make_mock_request(body, ct_header)
+        response = _make_httpx_response(201)
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = response
+
+        with patch(
+            "services.streaming_upload._get_streaming_http_client",
+            return_value=mock_client,
+        ):
+            pipeline = StreamingUploadPipeline(request, "http://localhost:8000", "jwt")
+            await pipeline.execute(_extract_fields)
+
+        sent_data = mock_client.post.call_args.kwargs["data"]
+        # A unique UUID so distinct assets never collapse onto one device tuple.
+        UUID(sent_data["device_asset_id"])  # raises if not a valid UUID
+        assert sent_data["device_id"] == "gumnut-device"
 
     @pytest.mark.anyio
     async def test_5xx_maps_to_502(self):

--- a/tests/unit/utils/test_asset_conversion.py
+++ b/tests/unit/utils/test_asset_conversion.py
@@ -12,11 +12,14 @@ The DTO conversion sites in ``routers/utils/asset_conversion.py`` must surface
 import logging
 from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock
+from uuid import uuid4
 
 import pytest
 from gumnut.types.asset_response import AssetResponse
 from gumnut.types.file_data_response import FileDataResponse
 
+from routers.immich_models import PersonResponseDto
+from routers.utils.gumnut_id_conversion import uuid_to_gumnut_person_id
 from routers.api.sync.converters import gumnut_asset_to_sync_asset_v1
 from routers.utils.asset_conversion import (
     build_asset_upload_ready_payload,
@@ -199,6 +202,44 @@ class TestConvertGumnutAssetToImmichTrashState:
         result = convert_gumnut_asset_to_immich(sample_gumnut_asset, mock_current_user)
 
         assert result.isTrashed is True
+
+
+def _make_gumnut_person() -> Mock:
+    """A minimal Gumnut person carrying the fields the converter reads."""
+    person = Mock()
+    person.id = uuid_to_gumnut_person_id(uuid4())
+    person.name = "Alice"
+    person.birth_date = None
+    person.is_favorite = False
+    person.is_hidden = False
+    person.updated_at = datetime.now(timezone.utc)
+    return person
+
+
+class TestConvertGumnutAssetToImmichV3Shape:
+    """Immich v3 dropped device fields + unassignedFaces from AssetResponseDto
+    and retyped ``people`` to ``PersonResponseDto`` (no inline face boxes)."""
+
+    def test_v3_removed_fields_absent(self, sample_gumnut_asset, mock_current_user):
+        result = convert_gumnut_asset_to_immich(sample_gumnut_asset, mock_current_user)
+
+        assert not hasattr(result, "deviceAssetId")
+        assert not hasattr(result, "deviceId")
+        assert not hasattr(result, "unassignedFaces")
+
+    def test_people_use_person_response_dto(
+        self, sample_gumnut_asset, mock_current_user
+    ):
+        sample_gumnut_asset.people = [_make_gumnut_person()]
+
+        result = convert_gumnut_asset_to_immich(sample_gumnut_asset, mock_current_user)
+
+        people = result.people
+        assert people is not None
+        assert len(people) == 1
+        assert isinstance(people[0], PersonResponseDto)
+        # v3 PersonResponseDto carries no inline face bounding boxes.
+        assert not hasattr(people[0], "faces")
 
 
 class TestBuildAssetUploadReadyPayloadTrashState:


### PR DESCRIPTION
## What
- **Asset responses (v3 shape):** the asset converter no longer emits `deviceAssetId`/`deviceId`/`unassignedFaces` and builds `people` as `PersonResponseDto` (no inline face boxes). Removed the now-dead `convert_gumnut_person_to_immich_with_faces` and the deleted `PersonWithFacesResponseDto` import.
- **Search:** `search_random` drops the removed `RandomSearchDto.deviceId` filter.
- **Upload:** the upload path no longer requires/reads device fields (v3 clients don't send them). The Gumnut API's `assets.create` still requires `device_asset_id`/`device_id`, so the adapter synthesizes them — a shared `GUMNUT_UPLOAD_DEVICE_ID` placeholder (`routers/api/constants.py`) plus a **unique per-upload `device_asset_id` (UUID)**.
- **Docs:** design-doc notes — the upload device-field synthesis, and broadening the known pydantic/3.14 pattern-constraint blocker from UUID-only to UUID/datetime fields.

## Why
Immich v3 removed these fields from `AssetResponseDto` and the search/upload DTOs (models already regenerated on this branch), so the adapter code that set/read them mismatched the generated models. The upload synthesis uses a **unique** `device_asset_id` (not the filename) so two distinct files that happen to share a name can never collapse onto one device tuple; true duplicates are still caught by the backend's checksum-based dedup.

This PR merges to **`migration/immichv3`**, not `main` — it's one step of the Immich v3 retarget; the integration branch merges to `main` once all steps land. The branch is intentionally not standalone-green (documented pattern-constraint + import blockers), so this change is verified by scoped checks (ruff, a zero-new-errors pyright diff) plus the runnable subset of tests rather than a fully green suite.

## Test plan
- [x] `uv run ruff check` / `ruff format` — clean
- [x] `uv run pyright` on changed files — no new errors vs. the branch baseline (net −1; only pre-existing branded-ID/dimension mismatches un-masked)
- [x] `uv run pytest tests/unit/services/test_streaming_upload.py tests/unit/services/test_streaming_form_parser.py` — 18 passed, incl. a new test asserting the synthesized device fields (unique UUID + placeholder `device_id`) reach the Gumnut upload
- [x] `uv run pytest tests/unit/api/test_search.py::TestSearchRandom::test_all_dto_fields_have_a_disposition` — passes (confirms the `RandomSearchDto.deviceId` removal matches the regenerated model)
- [x] Converter + buffered-upload assertions authored and verified by inspection (their modules are blocked by the branch's known `Error1` / pattern-constraint blockers; they run once those clear)

Generated by an AI coding agent.