### PR TITLE
Rework shared-links to Immich v3 token/key/slug access model

### DIFF
--- a/docs/design-docs/immich-v3-api-changes.md
+++ b/docs/design-docs/immich-v3-api-changes.md
@@ -288,6 +288,14 @@ zero-new-errors pyright diff) rather than a green suite:
   codegen/dependency fix (drop `pattern` on these fields, or pin pydantic),
   tracked separately from the per-endpoint retarget.
 
+Per-issue tests that must run despite these blockers assert on class-level
+metadata rather than building or calling the DTOs: `Model.model_fields` for
+field additions/removals, `inspect.signature(endpoint)` for query-param changes
+(when the router module imports cleanly), and `ast.parse` of the source when
+even the import is blocked (any module importing `Error1` via
+`routers/utils/bulk.py`). None of these instantiate a `pattern`-constrained DTO
+or execute the broken import, so they stay green while the suite is red.
+
 ## Open questions
 
 - ~~Does the adapter retarget 3.0 GA in one cut, or run a compatibility window

--- a/routers/api/albums.py
+++ b/routers/api/albums.py
@@ -150,8 +150,6 @@ async def create_album(
 async def add_assets_to_album(
     id: UUID,
     request: BulkIdsDto,
-    key: str = Query(default=None, alias="key"),
-    slug: str = Query(default=None, alias="slug"),
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
 ) -> List[BulkIdResponseDto]:
     """
@@ -321,8 +319,6 @@ async def delete_album(
 @router.put("/assets")
 async def add_assets_to_albums(
     request: AlbumsAddAssetsDto,
-    key: str = Query(default=None, alias="key"),
-    slug: str = Query(default=None, alias="slug"),
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
 ) -> AlbumsAddAssetsResponseDto:
     """

--- a/routers/api/shared_links.py
+++ b/routers/api/shared_links.py
@@ -51,14 +51,13 @@ async def create_shared_link(
         createdAt=now,
         description="Shared link",
         expiresAt=now,
-        id=str(uuid4()),
+        id=uuid4(),
         key="dummy-key",
         password="",
         showMetadata=True,
         slug="dummy-slug",
-        token="dummy-token",
         type=SharedLinkType.INDIVIDUAL,
-        userId=str(current_user_id),
+        userId=current_user_id,
     )
 
 
@@ -80,21 +79,18 @@ async def login_shared_link(
         createdAt=now,
         description="Shared link",
         expiresAt=now,
-        id=str(uuid4()),
+        id=uuid4(),
         key="dummy-key",
         password="",
         showMetadata=True,
         slug="dummy-slug",
-        token="dummy-token",
         type=SharedLinkType.INDIVIDUAL,
-        userId=str(current_user_id),
+        userId=current_user_id,
     )
 
 
 @router.get("/me")
 async def get_my_shared_link(
-    password: str = Query(default=None),
-    token: str = Query(default=None),
     key: str = Query(default=None),
     slug: str = Query(default=None),
     current_user_id: UUID = Depends(get_current_user_id),
@@ -112,14 +108,13 @@ async def get_my_shared_link(
         createdAt=now,
         description="My shared link",
         expiresAt=now,
-        id=str(current_user_id),
+        id=current_user_id,
         key=key or "dummy-key",
         password="",
         showMetadata=True,
         slug=slug or "dummy-slug",
-        token=token or "dummy-token",
         type=SharedLinkType.INDIVIDUAL,
-        userId=str(current_user_id),
+        userId=current_user_id,
     )
 
 
@@ -141,14 +136,13 @@ async def get_shared_link_by_id(
         createdAt=now,
         description="Shared link by ID",
         expiresAt=now,
-        id=str(id),
+        id=id,
         key="dummy-key",
         password="",
         showMetadata=True,
         slug="dummy-slug",
-        token="dummy-token",
         type=SharedLinkType.INDIVIDUAL,
-        userId=str(current_user_id),
+        userId=current_user_id,
     )
 
 
@@ -171,14 +165,13 @@ async def update_shared_link(
         createdAt=now,
         description="Updated shared link",
         expiresAt=now,
-        id=str(id),
+        id=id,
         key="dummy-key",
         password="",
         showMetadata=True,
         slug="dummy-slug",
-        token="dummy-token",
         type=SharedLinkType.INDIVIDUAL,
-        userId=str(current_user_id),
+        userId=current_user_id,
     )
 
 
@@ -195,8 +188,6 @@ async def remove_shared_link(id: UUID):
 async def add_shared_link_assets(
     id: UUID,
     request: AssetIdsDto,
-    key: str = Query(default=None),
-    slug: str = Query(default=None),
 ) -> List[AssetIdsResponseDto]:
     """
     Add assets to a shared link

--- a/tests/unit/api/test_albums_v3_params.py
+++ b/tests/unit/api/test_albums_v3_params.py
@@ -1,8 +1,10 @@
 """Immich v3 query-param conformance for the albums asset-add endpoints.
 
 Immich v3 dropped the `key`/`slug` query params from `PUT /albums/{id}/assets`
-and `PUT /albums/assets`, while KEEPING them on `GET /albums/{id}` (v3 dropped
-only `withoutAssets` there). These guard that intentional asymmetry.
+and `PUT /albums/assets`, while KEEPING them on `GET /albums/{id}` (of that
+endpoint's params, v3 dropped only `withoutAssets` — which the adapter still
+declares as a documented no-op for client compatibility, so the parsed source
+below still shows it). These guard that intentional asymmetry.
 
 `routers/api/albums.py` cannot be imported on the `migration/immichv3` branch —
 it imports `Error1`, which the v3 model regen removed, so `inspect.signature`
@@ -42,7 +44,7 @@ def test_put_albums_assets_dropped_key_and_slug():
 
 
 def test_get_album_info_retains_key_and_slug():
-    """GET /albums/{id} keeps key/slug in v3 (only withoutAssets was dropped)."""
+    """GET /albums/{id} keeps key/slug in v3."""
     params = _param_names("get_album_info")
     assert "key" in params
     assert "slug" in params

--- a/tests/unit/api/test_albums_v3_params.py
+++ b/tests/unit/api/test_albums_v3_params.py
@@ -1,0 +1,48 @@
+"""Immich v3 query-param conformance for the albums asset-add endpoints.
+
+Immich v3 dropped the `key`/`slug` query params from `PUT /albums/{id}/assets`
+and `PUT /albums/assets`, while KEEPING them on `GET /albums/{id}` (v3 dropped
+only `withoutAssets` there). These guard that intentional asymmetry.
+
+`routers/api/albums.py` cannot be imported on the `migration/immichv3` branch —
+it imports `Error1`, which the v3 model regen removed, so `inspect.signature`
+(which requires importing the module) is unavailable here. Parsing the source
+with `ast` inspects the signatures without executing the module.
+"""
+
+import ast
+from pathlib import Path
+
+_ALBUMS_SRC = Path(__file__).resolve().parents[3] / "routers" / "api" / "albums.py"
+
+
+def _param_names(func_name: str) -> set[str]:
+    tree = ast.parse(_ALBUMS_SRC.read_text())
+    node = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and n.name == func_name
+    )
+    return {a.arg for a in node.args.args + node.args.kwonlyargs}
+
+
+def test_put_album_assets_dropped_key_and_slug():
+    """PUT /albums/{id}/assets no longer declares key/slug."""
+    params = _param_names("add_assets_to_album")
+    assert "key" not in params
+    assert "slug" not in params
+
+
+def test_put_albums_assets_dropped_key_and_slug():
+    """PUT /albums/assets no longer declares key/slug."""
+    params = _param_names("add_assets_to_albums")
+    assert "key" not in params
+    assert "slug" not in params
+
+
+def test_get_album_info_retains_key_and_slug():
+    """GET /albums/{id} keeps key/slug in v3 (only withoutAssets was dropped)."""
+    params = _param_names("get_album_info")
+    assert "key" in params
+    assert "slug" in params

--- a/tests/unit/api/test_shared_links.py
+++ b/tests/unit/api/test_shared_links.py
@@ -1,0 +1,47 @@
+"""Tests for /shared-links/* Immich v3 shape conformance.
+
+Immich v3 removed the shared-link token/key/slug access surface:
+- `SharedLinkResponseDto.token` is gone (`key`/`slug`/`password` retained).
+- `GET /shared-links/me` lost its `password`/`token` query params (kept `key`/`slug`).
+- `SharedLinkEditDto.changeExpiryTime` is gone.
+- `PUT /shared-links/{id}/assets` lost its `key`/`slug` query params.
+
+These guard against re-introducing the removed surface. They assert on
+`model_fields` and `inspect.signature` rather than constructing a
+`SharedLinkResponseDto`: on the `migration/immichv3` branch the regenerated
+DTOs cannot be instantiated (their `pattern`-constrained UUID/datetime fields
+raise under the pinned pydantic), but class-level field/signature inspection
+does not instantiate anything and runs cleanly.
+"""
+
+import inspect
+
+from routers.api.shared_links import add_shared_link_assets, get_my_shared_link
+from routers.immich_models import SharedLinkEditDto, SharedLinkResponseDto
+
+
+def test_shared_link_response_dto_dropped_token():
+    """v3 removed SharedLinkResponseDto.token; key/slug remain."""
+    assert "token" not in SharedLinkResponseDto.model_fields
+    assert "key" in SharedLinkResponseDto.model_fields
+    assert "slug" in SharedLinkResponseDto.model_fields
+
+
+def test_shared_link_edit_dto_dropped_change_expiry_time():
+    """v3 removed SharedLinkEditDto.changeExpiryTime."""
+    assert "changeExpiryTime" not in SharedLinkEditDto.model_fields
+
+
+def test_get_my_shared_link_dropped_password_and_token_params():
+    """GET /shared-links/me lost password/token query params but kept key/slug."""
+    params = set(inspect.signature(get_my_shared_link).parameters)
+    assert "password" not in params
+    assert "token" not in params
+    assert {"key", "slug"} <= params
+
+
+def test_add_shared_link_assets_dropped_key_and_slug_params():
+    """PUT /shared-links/{id}/assets lost its key/slug query params."""
+    params = set(inspect.signature(add_shared_link_assets).parameters)
+    assert "key" not in params
+    assert "slug" not in params


### PR DESCRIPTION
## What
- Drop `SharedLinkResponseDto.token` from all shared-link stub responses; drop the removed `password`/`token` query params from `GET /shared-links/me` (v3 keeps `key`/`slug` there).
- Drop the removed `key`/`slug` query params from `PUT /shared-links/{id}/assets`, `PUT /albums/{id}/assets`, and `PUT /albums/assets` (they were declared but unused). `GET /albums/{id}` **keeps** `key`/`slug` — v3 dropped only `withoutAssets` there.
- Pass the already-`UUID` `id`/`userId` values directly (no `str()` wrap) so dropping `token=` doesn't unmask pre-existing `str`→`UUID` typing errors.
- Add runnable v3-conformance guards: `tests/unit/api/test_shared_links.py` (`model_fields` + `inspect.signature`) and `tests/unit/api/test_albums_v3_params.py` (`ast.parse`-based, since `albums.py` can't be imported on this branch).
- Doc: record the runnable-test technique in the design doc's "Known blockers" section.

## Why
Immich v3 removed the shared-link token/key/slug access surface. `routers/api/shared_links.py` is a pure stub (returns fake data — no real anonymous-access logic), so this is a v3 **shape-conformance** change, not an auth reimplementation. Every param/field change was verified against the fetched Immich v3.0.0 GA OpenAPI spec and the regenerated models. `SharedLinkEditDto.changeExpiryTime` was already absent after the regen; no code referenced it.

This PR merges to `migration/immichv3`, **not** `main` — it is step 4 of the Immich v3 retarget; the integration branch merges to `main` once all steps land.

## Known follow-up (out of scope)
`POST /shared-links/login` is missing v3's optional `key`/`slug` query params — a **pre-existing** (pre-v3) gap, an *addition* rather than a removal, with no functional impact (FastAPI silently ignores unknown query params on the stub). Left out to keep this PR purely subtractive; can be picked up separately.

## Test plan
The `migration/immichv3` branch is intentionally red (documented `Error1`-import and pattern-constrained-DTO instantiation blockers), so verification is scoped rather than a green suite:
- [x] `uv run ruff check` / `ruff format` — clean
- [x] `uv run pyright routers/api/shared_links.py routers/api/albums.py` — zero new errors vs. baseline (net −5: shared_links 5→0, albums unchanged)
- [x] `uv run pytest tests/unit/api/test_shared_links.py tests/unit/api/test_albums_v3_params.py` — 7 passed
- [x] Grep sweep: no `token` in `shared_links.py`, no `changeExpiryTime` references, `key`/`slug` remain only on `get_album_info`
- [x] Regression: `test_search.py` results identical with and without this change (stash diff)

Generated by an AI coding agent.