### PR TITLE
Add Immich v3 Sync-v2 entity mappings to the sync stream

### DIFF
--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -31,11 +31,13 @@ Event types are classified into `_DELETE_EVENT_TYPES` (construct delete sync eve
 
 When the same gumnut entity type maps to multiple Immich sync versions (e.g., AssetFacesV2 alongside V1), update these files in coordination:
 
-1. `stream.py`: Add V2 entry to `_SYNC_TYPE_ORDER` (after V1, same gumnut entity type). Add a guard in the stream loop to skip V1 when V2 is also requested (prevents duplicate events). Update face/entity-specific event handling to match both V1 and V2 sync entity types.
-2. `fk_integrity.py`: Add V2 to the entity's list in `_GUMNUT_TYPE_TO_SYNC_TYPES` so FK checkpoint lookups match regardless of which version was synced.
+1. `stream.py`: Add the V2 entry to `_SYNC_TYPE_ORDER` (after V1, same gumnut entity type) and a `_V1_SUPERSEDED_BY_V2` entry so V1 is skipped when V2 is also requested (prevents duplicate events). **Extend every `sync_entity_type`-gated payload override in `_stream_entity_type` to also match the V2 type** — the "Face person_id Handling" and "Album Cover Handling" overlays above are gated on the sync entity type, and a V2 type left off silently drops that FK-safety guarantee on the v3 client path (the client streams that entity exclusively as V2).
+2. `fk_integrity.py`: Add V2 to the entity's list in `_GUMNUT_TYPE_TO_SYNC_TYPES` so FK checkpoint lookups match regardless of which version was synced — a client that checkpointed under the V2 type otherwise misses the "synced in a prior cycle" skip and logs spurious FK warnings.
 3. `converters.py`: Write a V2 converter function alongside the V1 one.
 4. `events.py`: Update the converter dispatch in `convert_entity_to_sync_event` to select V1 vs V2 converter based on `sync_entity_type`.
 5. `test_sync_stream_ordering.py`: Verify the consistency test handles one-to-many gumnut-type-to-sync-type mappings.
+
+The invariant tests in `test_sync_v2.py` assert that every V2 type in `_SYNC_TYPE_ORDER` is wired into the event dispatch (step 4), the FK checkpoint map (step 2), and — for albums — the cover override (step 1), so a half-wired addition fails a test instead of shipping. Extend them when adding a version.
 
 ## No-Op Request Types
 

--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Sync Stream Architecture"
-last-updated: 2026-04-16
+last-updated: 2026-07-07
 ---
 
 # Sync Stream Architecture

--- a/docs/design-docs/immich-v3-api-changes.md
+++ b/docs/design-docs/immich-v3-api-changes.md
@@ -2,7 +2,7 @@
 title: "Immich v2.7.5 → v3.0 API Change Analysis"
 status: active
 created: 2026-06-16
-last-updated: 2026-07-06
+last-updated: 2026-07-07
 ---
 
 # Immich v2.7.5 → v3.0 API Change Analysis
@@ -172,12 +172,19 @@ No new `/sync` paths — `/sync/stream` + `/sync/ack` now carry **V2 variants**:
 
 ### What V2 actually changes
 
-At the payload level, V2 adds almost nothing over V1:
+At the payload level, V2 adds almost nothing over V1 (this list is the canonical
+V2-vs-V1 delta; later sections reference it rather than restate it). Verified
+against the v3.0.0 GA models, not the RC — an earlier draft called `SyncAlbumV2`
+byte-identical, but GA dropped a field:
 
 - `SyncAssetV2` is `SyncAssetV1` with **`duration` as integer-milliseconds**
-  instead of the interval string — the same change as §2. This is the *only*
-  payload difference between any V1 entity and its V2.
-- `SyncAlbumV2` and `SyncAssetFaceV2` are **byte-identical** to their V1 forms.
+  instead of the interval string — the same change as §2. This is the only
+  payload difference for the *asset* entity.
+- `SyncAlbumV2` is `SyncAlbumV1` **minus `ownerId`** (the GA model dropped it);
+  otherwise identical.
+- `SyncAssetFaceV2` is `SyncAssetFaceV1` **plus `deletedAt` / `isVisible`**
+  (both constant for the adapter — Gumnut has no face soft-delete or visibility;
+  already handled by the pre-existing faces V2 converter).
 - The `PartnerAsset*V2` and `AlbumAsset*V2` entity types reuse `SyncAssetV2`, so
   they inherit only the int-ms `duration`.
 - `AssetOcrV1` is a genuinely new entity type (OCR text boxes), but the adapter
@@ -203,9 +210,10 @@ logic.
 
 **Conclusion:** Sync v2 is not a long pole. Reporting `3.0.x` and adding the V2
 entity mappings is small work that reuses the §2 int-ms `duration` converter —
-`AlbumV2` is identical to V1, `AssetV2` is the int-duration asset, and
-`AssetOcrV1` emits nothing. The one non-cosmetic V1 tweak to carry over is that
-v3 makes `SyncAssetV1.createdAt` required.
+the per-entity deltas are small (see the "What V2 actually changes" list above),
+`AssetV2` is the int-duration asset, and `AssetOcrV1` emits nothing. The one
+non-cosmetic V1 tweak to carry over is that v3 makes `SyncAssetV1.createdAt`
+required.
 
 ---
 
@@ -305,7 +313,7 @@ or execute the broken import, so they stay green while the suite is red.
   endpoints and string-`duration` need not stay as shims.
 - ~~Are 3.0 mobile clients hard-requiring Sync v2, or do they fall back to V1
   entity types?~~ **Resolved: incremental, not blocking.** The client picks V1
-  vs V2 by the adapter's reported version, and V2 adds only int-ms `duration`
+  vs V2 by the adapter's reported version, and the V2 payload deltas are small
   (§5). Reporting `3.0.x` needs only a thin V2 layer that reuses the §2 duration
   converter.
 - Which new feature areas (if any) are in scope vs. permanent intentional gaps —

--- a/routers/api/sync/converters.py
+++ b/routers/api/sync/converters.py
@@ -178,8 +178,8 @@ def gumnut_asset_to_sync_asset_v2(asset: AssetResponse, owner_id: str) -> SyncAs
     """Convert Gumnut AssetResponse to Immich SyncAssetV2 format.
 
     SyncAssetV2 is SyncAssetV1 with ``duration`` as integer milliseconds instead
-    of the interval string — the only payload difference between the two (Immich
-    v3 §5). Delegate to V1 and swap that one field.
+    of the interval string — the only payload difference between the two (see the
+    ``immich-v3-api-changes.md`` design doc, §5). Delegate to V1 and swap it.
     """
     fields = gumnut_asset_to_sync_asset_v1(asset, owner_id).model_dump()
     fields["duration"] = duration_ms(asset.duration)

--- a/routers/api/sync/converters.py
+++ b/routers/api/sync/converters.py
@@ -295,8 +295,8 @@ def gumnut_album_to_sync_album_v2(album: AlbumResponse, owner_id: str) -> SyncAl
     """Convert Gumnut AlbumResponse to Immich SyncAlbumV2 format.
 
     In the Immich v3 GA model SyncAlbumV2 is SyncAlbumV1 without ``ownerId``
-    (the design doc's "byte-identical to V1" predates the GA drop of that field).
-    Delegate to V1 and drop the field V2 no longer carries.
+    (see the ``immich-v3-api-changes.md`` design doc, §5). Delegate to V1 and
+    drop the field V2 no longer carries.
     """
     fields = gumnut_album_to_sync_album_v1(album, owner_id).model_dump()
     fields.pop("ownerId", None)

--- a/routers/api/sync/converters.py
+++ b/routers/api/sync/converters.py
@@ -16,15 +16,18 @@ from routers.immich_models import (
     AssetVisibility,
     SyncAlbumToAssetV1,
     SyncAlbumV1,
+    SyncAlbumV2,
     SyncAssetExifV1,
     SyncAssetFaceV1,
     SyncAssetFaceV2,
     SyncAssetV1,
+    SyncAssetV2,
     SyncAuthUserV1,
     SyncPersonV1,
     SyncUserV1,
 )
 from routers.utils.asset_conversion import (
+    duration_ms,
     exif_dims_and_orientation,
     format_duration,
     mime_type_to_asset_type,
@@ -148,6 +151,8 @@ def gumnut_asset_to_sync_asset_v1(asset: AssetResponse, owner_id: str) -> SyncAs
     return SyncAssetV1(
         id=str(safe_uuid_from_asset_id(asset.id)),
         checksum=resolve_immich_checksum(asset),
+        # "Uploaded to Immich at" — required on SyncAssetV1 in Immich v3.
+        createdAt=asset.created_at,
         isFavorite=False,  # Gumnut doesn't track favorites
         isEdited=False,
         originalFileName=asset.original_file_name,
@@ -167,6 +172,18 @@ def gumnut_asset_to_sync_asset_v1(asset: AssetResponse, owner_id: str) -> SyncAs
         thumbhash=asset.thumbhash,
         width=asset.width if asset.width else None,
     )
+
+
+def gumnut_asset_to_sync_asset_v2(asset: AssetResponse, owner_id: str) -> SyncAssetV2:
+    """Convert Gumnut AssetResponse to Immich SyncAssetV2 format.
+
+    SyncAssetV2 is SyncAssetV1 with ``duration`` as integer milliseconds instead
+    of the interval string — the only payload difference between the two (Immich
+    v3 §5). Delegate to V1 and swap that one field.
+    """
+    fields = gumnut_asset_to_sync_asset_v1(asset, owner_id).model_dump()
+    fields["duration"] = duration_ms(asset.duration)
+    return SyncAssetV2(**fields)
 
 
 def gumnut_metadata_to_sync_exif_v1(asset: AssetResponse) -> SyncAssetExifV1:
@@ -272,6 +289,18 @@ def gumnut_album_to_sync_album_v1(album: AlbumResponse, owner_id: str) -> SyncAl
         isActivityEnabled=True,
         order=AssetOrder.desc,
     )
+
+
+def gumnut_album_to_sync_album_v2(album: AlbumResponse, owner_id: str) -> SyncAlbumV2:
+    """Convert Gumnut AlbumResponse to Immich SyncAlbumV2 format.
+
+    In the Immich v3 GA model SyncAlbumV2 is SyncAlbumV1 without ``ownerId``
+    (the design doc's "byte-identical to V1" predates the GA drop of that field).
+    Delegate to V1 and drop the field V2 no longer carries.
+    """
+    fields = gumnut_album_to_sync_album_v1(album, owner_id).model_dump()
+    fields.pop("ownerId", None)
+    return SyncAlbumV2(**fields)
 
 
 def gumnut_face_to_sync_face_v1(face: FaceResponse) -> SyncAssetFaceV1:

--- a/routers/api/sync/events.py
+++ b/routers/api/sync/events.py
@@ -29,7 +29,9 @@ from routers.utils.gumnut_id_conversion import (
 from routers.api.sync.converters import (
     gumnut_album_asset_to_sync_album_to_asset_v1,
     gumnut_album_to_sync_album_v1,
+    gumnut_album_to_sync_album_v2,
     gumnut_asset_to_sync_asset_v1,
+    gumnut_asset_to_sync_asset_v2,
     gumnut_face_to_sync_face_v1,
     gumnut_face_to_sync_face_v2,
     gumnut_metadata_to_sync_exif_v1,
@@ -276,13 +278,23 @@ def convert_entity_to_sync_event(
     """
     sync_model: Any
     if gumnut_entity_type == "asset":
-        sync_model = gumnut_asset_to_sync_asset_v1(
-            cast(AssetResponse, entity), owner_id
-        )
+        if sync_entity_type == SyncEntityType.AssetV2:
+            sync_model = gumnut_asset_to_sync_asset_v2(
+                cast(AssetResponse, entity), owner_id
+            )
+        else:
+            sync_model = gumnut_asset_to_sync_asset_v1(
+                cast(AssetResponse, entity), owner_id
+            )
     elif gumnut_entity_type == "album":
-        sync_model = gumnut_album_to_sync_album_v1(
-            cast(AlbumResponse, entity), owner_id
-        )
+        if sync_entity_type == SyncEntityType.AlbumV2:
+            sync_model = gumnut_album_to_sync_album_v2(
+                cast(AlbumResponse, entity), owner_id
+            )
+        else:
+            sync_model = gumnut_album_to_sync_album_v1(
+                cast(AlbumResponse, entity), owner_id
+            )
     elif gumnut_entity_type == "person":
         sync_model = gumnut_person_to_sync_person_v1(
             cast(PersonResponse, entity), owner_id

--- a/routers/api/sync/fk_integrity.py
+++ b/routers/api/sync/fk_integrity.py
@@ -66,8 +66,8 @@ PAYLOAD_FK_OVERRIDES: dict[str, list[PayloadFKOverride]] = {
 # Entity types with multiple versions (e.g., face V1/V2) list all variants
 # so checkpoint lookups match regardless of which version the client synced.
 _GUMNUT_TYPE_TO_SYNC_TYPES: dict[str, list[SyncEntityType]] = {
-    "asset": [SyncEntityType.AssetV1],
-    "album": [SyncEntityType.AlbumV1],
+    "asset": [SyncEntityType.AssetV1, SyncEntityType.AssetV2],
+    "album": [SyncEntityType.AlbumV1, SyncEntityType.AlbumV2],
     "album_asset": [SyncEntityType.AlbumToAssetV1],
     "metadata": [SyncEntityType.AssetExifV1],
     "person": [SyncEntityType.PersonV1],

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -339,7 +339,7 @@ async def _stream_entity_type(
                 # reference an asset added after the event was recorded
                 # — potentially outside the client's sync window.
                 if (
-                    sync_entity_type == SyncEntityType.AlbumV1
+                    sync_entity_type in (SyncEntityType.AlbumV1, SyncEntityType.AlbumV2)
                     and event.event_type == "album_updated"
                     and isinstance(entity, AlbumResponse)
                     and isinstance(event.payload, dict)

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -71,13 +71,25 @@ _SKIPPED_EVENT_TYPES: frozenset[str] = frozenset()
 # This ordering ensures FK parents are streamed before children during upserts.
 _SYNC_TYPE_ORDER: list[tuple[SyncRequestType, str, SyncEntityType]] = [
     (SyncRequestType.AssetsV1, "asset", SyncEntityType.AssetV1),
+    (SyncRequestType.AssetsV2, "asset", SyncEntityType.AssetV2),
     (SyncRequestType.AlbumsV1, "album", SyncEntityType.AlbumV1),
+    (SyncRequestType.AlbumsV2, "album", SyncEntityType.AlbumV2),
     (SyncRequestType.AlbumToAssetsV1, "album_asset", SyncEntityType.AlbumToAssetV1),
     (SyncRequestType.AssetExifsV1, "metadata", SyncEntityType.AssetExifV1),
     (SyncRequestType.PeopleV1, "person", SyncEntityType.PersonV1),
     (SyncRequestType.AssetFacesV1, "face", SyncEntityType.AssetFaceV1),
     (SyncRequestType.AssetFacesV2, "face", SyncEntityType.AssetFaceV2),
 ]
+
+# When a client requests a V2 request type, skip its V1 counterpart: both map to
+# the same Gumnut entity type, so streaming both would duplicate every event. The
+# mobile client version-gates V1-vs-V2 and sends only one, but a non-standard
+# client could request both — this keeps the stream single-emission.
+_V1_SUPERSEDED_BY_V2: dict[SyncRequestType, SyncRequestType] = {
+    SyncRequestType.AssetsV1: SyncRequestType.AssetsV2,
+    SyncRequestType.AlbumsV1: SyncRequestType.AlbumsV2,
+    SyncRequestType.AssetFacesV1: SyncRequestType.AssetFacesV2,
+}
 
 # Order for streaming delete events — reverse of FK dependency order.
 # Children are deleted before parents so the client can clean up FK references
@@ -91,10 +103,20 @@ _DELETE_TYPE_ORDER: list[SyncEntityType] = [
     SyncEntityType.AssetDeleteV1,
 ]
 
-# Request types that are accepted but have no Gumnut equivalent.
-# Prevents "unsupported" warnings while making the no-op explicit.
+# Request types that are accepted but have no Gumnut equivalent, so nothing is
+# emitted for them (the client tolerates absence). Listing them here prevents an
+# "unsupported" warning and logs them as intentional no-ops instead.
+#   - AssetEditsV1:    Gumnut has no asset edit history.
+#   - AssetOcrV1:      Gumnut has no OCR text data (new v3 entity type).
+#   - PartnerAssetsV2: Gumnut is single-user; there is no partner sharing.
+#   - AlbumAssetsV2:   album assets are the user's own, already streamed via
+#                      AssetsV2 + AlbumToAssetsV1 (this stream is for assets
+#                      shared into an album by other users, which Gumnut lacks).
 _NOOP_REQUEST_TYPES: dict[SyncRequestType, SyncEntityType] = {
     SyncRequestType.AssetEditsV1: SyncEntityType.AssetEditV1,
+    SyncRequestType.AssetOcrV1: SyncEntityType.AssetOcrV1,
+    SyncRequestType.PartnerAssetsV2: SyncEntityType.PartnerAssetV2,
+    SyncRequestType.AlbumAssetsV2: SyncEntityType.AlbumAssetCreateV2,
 }
 
 # Supported SyncRequestTypes (used to detect unsupported types requested by client)
@@ -525,12 +547,11 @@ async def generate_sync_stream(
             if request_type not in requested_types:
                 continue
 
-            # Skip V1 faces when V2 is also requested — both map to the same
-            # gumnut "face" entity type and would stream duplicate events.
-            if (
-                request_type == SyncRequestType.AssetFacesV1
-                and SyncRequestType.AssetFacesV2 in requested_types
-            ):
+            # Skip a V1 request type when its V2 counterpart is also requested —
+            # both map to the same gumnut entity type and would stream duplicate
+            # events. See _V1_SUPERSEDED_BY_V2.
+            superseding_v2 = _V1_SUPERSEDED_BY_V2.get(request_type)
+            if superseding_v2 is not None and superseding_v2 in requested_types:
                 continue
 
             # Get checkpoint for this entity type

--- a/routers/utils/asset_conversion.py
+++ b/routers/utils/asset_conversion.py
@@ -462,6 +462,8 @@ def build_asset_upload_ready_payload(
     sync_asset = SyncAssetV1(
         id=asset_uuid,
         ownerId=owner_id,
+        # "Uploaded to Immich at" — required on SyncAssetV1 in Immich v3.
+        createdAt=gumnut_asset.created_at,
         thumbhash=gumnut_asset.thumbhash,
         checksum=resolve_immich_checksum(gumnut_asset),
         deletedAt=gumnut_asset.trashed_at,

--- a/tests/unit/api/sync/test_sync_v2.py
+++ b/tests/unit/api/sync/test_sync_v2.py
@@ -1,0 +1,136 @@
+"""Immich v3 Sync-v2 conformance for the sync stream.
+
+At server version >= 3.0.0 the mobile client requests the V2 sync entity types
+(`assetsV2`, `albumsV2`, `assetFacesV2`) plus the new `assetOcrV1`, and swaps
+`partnerAssetsV2` / `albumAssetsV2` in for their V1 forms. These guard the thin
+V2 layer that extends the existing faces V1/V2 dual pattern:
+
+- `SyncAssetV2` is `SyncAssetV1` with int-ms `duration`.
+- `SyncAlbumV2` is `SyncAlbumV1` minus `ownerId` (the GA model dropped it; the
+  design doc's "byte-identical" predates that drop).
+- `SyncAssetV1.createdAt` is now required — both construction sites must set it.
+- OCR / partner-asset / album-asset V2 request types are accepted but emit
+  nothing (Gumnut has no such data); no V1/V2 double-emission.
+
+Assertions use `model_fields`, module-level constants, and `inspect.getsource`
+rather than constructing the DTOs: on the `migration/immichv3` branch the
+regenerated models carry `pattern`-constrained UUID/datetime fields that raise
+under the pinned pydantic, so instantiating a sync DTO is impossible here.
+Class/field/source inspection does not instantiate anything and runs cleanly.
+"""
+
+import inspect
+
+from routers.api.sync import converters, events, stream
+from routers.api.sync.stream import (
+    _NOOP_REQUEST_TYPES,
+    _SUPPORTED_REQUEST_TYPES,
+    _SYNC_TYPE_ORDER,
+    _V1_SUPERSEDED_BY_V2,
+)
+from routers.immich_models import (
+    SyncAlbumV1,
+    SyncAlbumV2,
+    SyncAssetV1,
+    SyncAssetV2,
+    SyncEntityType,
+    SyncRequestType,
+)
+from routers.utils import asset_conversion
+
+
+# --- Payload shape (model_fields only — no instantiation) --------------------
+
+
+def test_sync_asset_v2_is_v1_with_int_ms_duration():
+    """SyncAssetV2 has the same fields as V1, but duration is int-ms not string."""
+    assert set(SyncAssetV2.model_fields) == set(SyncAssetV1.model_fields)
+    assert SyncAssetV1.model_fields["duration"].annotation == (str | None)
+    assert SyncAssetV2.model_fields["duration"].annotation == (int | None)
+
+
+def test_sync_album_v2_is_v1_minus_owner_id():
+    """The GA SyncAlbumV2 drops ownerId; otherwise identical to V1."""
+    assert set(SyncAlbumV1.model_fields) - set(SyncAlbumV2.model_fields) == {"ownerId"}
+    assert set(SyncAlbumV2.model_fields) - set(SyncAlbumV1.model_fields) == set()
+
+
+def test_sync_asset_v1_created_at_now_required():
+    """v3 made SyncAssetV1.createdAt required (no default)."""
+    assert SyncAssetV1.model_fields["createdAt"].is_required()
+
+
+# --- Converters (source inspection — instantiation hits the pattern blocker) --
+
+
+def test_both_sync_asset_v1_sites_set_created_at():
+    """Both SyncAssetV1 construction sites populate the now-required createdAt."""
+    assert "createdAt=" in inspect.getsource(converters.gumnut_asset_to_sync_asset_v1)
+    assert "createdAt=" in inspect.getsource(
+        asset_conversion.build_asset_upload_ready_payload
+    )
+
+
+def test_asset_v2_converter_emits_int_ms_duration():
+    """The V2 asset converter swaps duration to int-ms via duration_ms."""
+    src = inspect.getsource(converters.gumnut_asset_to_sync_asset_v2)
+    assert "duration_ms" in src
+    assert 'fields["duration"]' in src
+
+
+def test_album_v2_converter_drops_owner_id():
+    """The V2 album converter drops ownerId (absent from SyncAlbumV2)."""
+    src = inspect.getsource(converters.gumnut_album_to_sync_album_v2)
+    assert 'fields.pop("ownerId"' in src
+
+
+# --- Stream wiring (module constants) ----------------------------------------
+
+
+def test_stream_order_maps_assets_v2_and_albums_v2():
+    """AssetsV2/AlbumsV2 stream through the asset/album entities as V2 events."""
+    assert (
+        SyncRequestType.AssetsV2,
+        "asset",
+        SyncEntityType.AssetV2,
+    ) in _SYNC_TYPE_ORDER
+    assert (
+        SyncRequestType.AlbumsV2,
+        "album",
+        SyncEntityType.AlbumV2,
+    ) in _SYNC_TYPE_ORDER
+
+
+def test_v1_superseded_by_v2_covers_assets_albums_faces():
+    """Requesting a V2 type skips its V1 counterpart — no double-emission."""
+    assert _V1_SUPERSEDED_BY_V2 == {
+        SyncRequestType.AssetsV1: SyncRequestType.AssetsV2,
+        SyncRequestType.AlbumsV1: SyncRequestType.AlbumsV2,
+        SyncRequestType.AssetFacesV1: SyncRequestType.AssetFacesV2,
+    }
+    # The stream loop must actually consult the table.
+    assert "_V1_SUPERSEDED_BY_V2" in inspect.getsource(stream.generate_sync_stream)
+
+
+def test_ocr_partner_album_asset_v2_are_accepted_noops():
+    """New v3 request types with no Gumnut data are accepted but emit nothing."""
+    noop_types = {
+        SyncRequestType.AssetOcrV1,
+        SyncRequestType.PartnerAssetsV2,
+        SyncRequestType.AlbumAssetsV2,
+    }
+    # Accepted (so they are not logged as "unsupported")...
+    assert noop_types <= set(_NOOP_REQUEST_TYPES)
+    assert noop_types <= _SUPPORTED_REQUEST_TYPES
+    # ...but never streamed (absent from the entity-producing order).
+    streamed_request_types = {rt for rt, _, _ in _SYNC_TYPE_ORDER}
+    assert noop_types.isdisjoint(streamed_request_types)
+
+
+def test_event_conversion_routes_v2_entities():
+    """convert_entity_to_sync_event dispatches AssetV2/AlbumV2 to the V2 converters."""
+    src = inspect.getsource(events.convert_entity_to_sync_event)
+    assert "SyncEntityType.AssetV2" in src
+    assert "gumnut_asset_to_sync_asset_v2" in src
+    assert "SyncEntityType.AlbumV2" in src
+    assert "gumnut_album_to_sync_album_v2" in src

--- a/tests/unit/api/sync/test_sync_v2.py
+++ b/tests/unit/api/sync/test_sync_v2.py
@@ -22,6 +22,7 @@ Class/field/source inspection does not instantiate anything and runs cleanly.
 import inspect
 
 from routers.api.sync import converters, events, stream
+from routers.api.sync.fk_integrity import _GUMNUT_TYPE_TO_SYNC_TYPES
 from routers.api.sync.stream import (
     _NOOP_REQUEST_TYPES,
     _SUPPORTED_REQUEST_TYPES,
@@ -108,8 +109,9 @@ def test_v1_superseded_by_v2_covers_assets_albums_faces():
         SyncRequestType.AlbumsV1: SyncRequestType.AlbumsV2,
         SyncRequestType.AssetFacesV1: SyncRequestType.AssetFacesV2,
     }
-    # The stream loop must actually consult the table.
-    assert "_V1_SUPERSEDED_BY_V2" in inspect.getsource(stream.generate_sync_stream)
+    # The stream loop must actually consult the table — match the call site,
+    # not the bare identifier (which also appears in a nearby comment).
+    assert "_V1_SUPERSEDED_BY_V2.get(" in inspect.getsource(stream.generate_sync_stream)
 
 
 def test_ocr_partner_album_asset_v2_are_accepted_noops():
@@ -134,3 +136,39 @@ def test_event_conversion_routes_v2_entities():
     assert "gumnut_asset_to_sync_asset_v2" in src
     assert "SyncEntityType.AlbumV2" in src
     assert "gumnut_album_to_sync_album_v2" in src
+
+
+# --- Invariants: keep the V2 rollout consistent across the sync package ------
+# Adding a V2 to _SYNC_TYPE_ORDER means it must also be routed in events, kept in
+# the FK-checkpoint map, and (for the album/face causal-consistency overrides)
+# covered by those overrides — these guard against the half-wired V2 rollout.
+
+
+def test_fk_checkpoint_map_covers_every_streamed_type():
+    """Every _SYNC_TYPE_ORDER entity type is in the FK checkpoint map for its
+    gumnut type, so a client that synced under V2 still matches on checkpoint
+    lookups (else FK reference checks emit spurious warnings)."""
+    for _req, gumnut_type, sync_type in _SYNC_TYPE_ORDER:
+        assert sync_type in _GUMNUT_TYPE_TO_SYNC_TYPES.get(gumnut_type, []), (
+            f"{sync_type} missing from _GUMNUT_TYPE_TO_SYNC_TYPES[{gumnut_type!r}]"
+        )
+
+
+def test_events_routing_references_every_streamed_v2_type():
+    """Every V2 entity type in _SYNC_TYPE_ORDER is dispatched in the event
+    converter — a V2 added to the order but not routed would silently stream
+    as V1 (the converter falls through to the V1 branch)."""
+    routing_src = inspect.getsource(events.convert_entity_to_sync_event)
+    v2_types = [st for _r, _g, st in _SYNC_TYPE_ORDER if st.value.endswith("V2")]
+    assert v2_types  # guard against the filter silently matching nothing
+    for sync_type in v2_types:
+        assert f"SyncEntityType.{sync_type.name}" in routing_src, (
+            f"{sync_type} not routed in convert_entity_to_sync_event"
+        )
+
+
+def test_album_cover_override_applies_to_album_v2():
+    """The album cover causal-consistency override must run on the AlbumV2 path
+    (the v3 client streams albums as AlbumV2), not just AlbumV1. The override
+    lives in _stream_entity_type, where AlbumV2 appears only in that gate."""
+    assert "SyncEntityType.AlbumV2" in inspect.getsource(stream._stream_entity_type)


### PR DESCRIPTION
## What
- Extend the sync stream's existing faces V1/V2 dual pattern to **assets** and **albums**: new `gumnut_asset_to_sync_asset_v2` (= V1 with `duration` as integer milliseconds — the only asset payload delta) and `gumnut_album_to_sync_album_v2` (= V1 minus `ownerId`, which the v3 GA model dropped). Wire `AssetsV2`/`AlbumsV2` into `_SYNC_TYPE_ORDER` and route them in `convert_entity_to_sync_event`.
- Accept `AssetOcrV1`, `PartnerAssetsV2`, and `AlbumAssetsV2` as **emit-nothing no-ops** (Gumnut has no OCR data, no partner sharing, and album assets are the user's own — already streamed via `AssetsV2` + the unconditional `AlbumToAssetsV1` join). The client tolerates their absence.
- Set the now-**required** `SyncAssetV1.createdAt` (from the asset's upload time) at both construction sites, including the WebSocket upload-ready payload.
- Generalize the hardcoded "skip V1 faces when V2 requested" into a `_V1_SUPERSEDED_BY_V2` table covering assets, albums, and faces — no entity double-emits.
- Self-review follow-through: extend the album-cover causal-consistency override and the FK checkpoint map (`_GUMNUT_TYPE_TO_SYNC_TYPES`) to the V2 types, since the v3 client streams assets/albums exclusively as V2; add invariant tests that fail a half-wired future V2 addition.

## Why
The adapter already reports server version 3.0.x, so the v3 mobile client requests the V2 sync entity types. Without these mappings, **no assets or albums sync** for a v3 client (they were silently logged as "unsupported"). This is step 3 of the Immich v3 retarget (design doc §5 / §7.3).

## Base branch
Merges to **`migration/immichv3`**, not `main` — it's one step of the multi-PR Immich v3 retarget; the integration branch merges to `main` once all steps land.

## Notes
- Scope boundary: the now-dangling `AssetDeltaSyncDto` import in `routes.py` (from the removed `/sync/delta-sync` + `/sync/full-sync` endpoints) is a separate removed-endpoints cleanup, out of scope here.
- The `migration/immichv3` branch is intentionally red: the regenerated models carry `pattern`-constrained UUID/datetime fields that raise at instantiation under the pinned pydantic + Python 3.14 (tracked separately). So tests assert on `model_fields`, stream module constants, and `inspect.getsource` rather than constructing the DTOs, and verification is by inspection + scoped checks.

## Test plan
- [x] `uv run pytest tests/unit/api/sync/test_sync_v2.py` — 13 passed (payload-shape, converters, stream wiring, no-op acceptance, event routing, and cross-site invariants)
- [x] `uv run ruff check` / `ruff format` — clean
- [x] `uv run pyright` — net +2 vs base, entirely the pre-existing `str→UUID` branch-blocker family unmasked by adding the required `createdAt` (the new V2 converters add zero); no new defect class
- [x] No regression in pre-existing sync/asset tests (identical failure counts with and without the change)

Generated by an AI coding agent.