### PR TITLE
Drop Immich v3 removed endpoints (clean cut, no shims)

### DIFF
--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Immich Adapter Architecture"
-last-updated: 2026-07-03
+last-updated: 2026-07-07
 ---
 
 # Immich Adapter Architecture
@@ -374,14 +374,14 @@ The adapter implements a subset of Immich's API surface. Unimplemented endpoints
 
 | Area | Endpoints | Notes |
 |------|-----------|-------|
-| Assets | Upload, download (original + thumbnail), video playback, delete, bulk delete, existence check, statistics, single-asset and bulk metadata edit | Streaming downloads via `StreamingResponse`; video playback streams the `original` variant from CDN with Range/seek support; `DELETE /api/assets` soft-deletes by default and permanently deletes when `force=true`; `PUT /api/assets/{id}` forwards `description`, paired `latitude` + `longitude`, and `dateTimeOriginal` to the Gumnut API and emits `on_asset_update`; `PUT /api/assets` forwards the same in-scope fields via `client.assets.bulk_update_assets`, chunking over `BULK_CHUNK_SIZE`. Capture time uses one of three mutually exclusive datetime modes: absolute `dateTimeOriginal` (optionally localized by `timeZone`) replicated as one homogeneous `change`; per-asset `dateTimeRelative` minute-shift (matching Immich, which applies this field as minutes); or standalone `timeZone` reinterpret. The two per-asset modes read each chunk's current `original_datetime` (`assets.list(state="all", ids=...)`, including trashed assets so they aren't silently skipped, matching the homogeneous path) before writing a heterogeneous per-item change, skipping ids with no existing capture time; conflicting datetime modes are rejected with 422. `isFavorite`/`rating`/`visibility` are silently ignored on both paths; `livePhotoVideoId` on the single-asset path and `duplicateId` on the bulk path are silently ignored; the bulk path skips WebSocket emission |
+| Assets | Upload, download (original + thumbnail), video playback, delete, bulk delete, statistics, single-asset and bulk metadata edit | Streaming downloads via `StreamingResponse`; video playback streams the `original` variant from CDN with Range/seek support; `DELETE /api/assets` soft-deletes by default and permanently deletes when `force=true`; `PUT /api/assets/{id}` forwards `description`, paired `latitude` + `longitude`, and `dateTimeOriginal` to the Gumnut API and emits `on_asset_update`; `PUT /api/assets` forwards the same in-scope fields via `client.assets.bulk_update_assets`, chunking over `BULK_CHUNK_SIZE`. Capture time uses one of three mutually exclusive datetime modes: absolute `dateTimeOriginal` (optionally localized by `timeZone`) replicated as one homogeneous `change`; per-asset `dateTimeRelative` minute-shift (matching Immich, which applies this field as minutes); or standalone `timeZone` reinterpret. The two per-asset modes read each chunk's current `original_datetime` (`assets.list(state="all", ids=...)`, including trashed assets so they aren't silently skipped, matching the homogeneous path) before writing a heterogeneous per-item change, skipping ids with no existing capture time; conflicting datetime modes are rejected with 422. `isFavorite`/`rating`/`visibility` are silently ignored on both paths; `livePhotoVideoId` on the single-asset path and `duplicateId` on the bulk path are silently ignored; the bulk path skips WebSocket emission |
 | Trash | Restore-by-ids, restore-all, empty-trash | `trashDays` comes from `TRASH_RETENTION_DAYS`; web and mobile clients see real trash state |
 | Albums | CRUD, add/remove assets, statistics | User sharing not supported (returns 501) |
 | People | CRUD, list with pagination/sort/filter, thumbnails, statistics, merge | |
 | Faces | List, create, delete, reassign | Create draws a user-specified box on an asset and links it to a person (Immich's "create a face on-the-fly" flow) |
 | Timeline | Time buckets (monthly), bucket contents | Date-range filtering with timezone handling, including `isTrashed=true` |
 | Search | Smart search, metadata search, person search, statistics, random sampling, explore (cities + recents) | Places, cities, suggestions, and large-assets are stubs |
-| Sync | Full sync, delta sync, stream, ack | Two-phase ordering, checkpoint management |
+| Sync | Stream, ack | Two-phase ordering, checkpoint management |
 | Auth | OAuth login/callback, logout, session management | Clerk OAuth via the Gumnut API |
 | WebSockets | Real-time upload/trash/restore/delete notifications | Socket.IO with room-based messaging |
 | Memories (read) | Search, get-by-id, statistics for OnThisDay memories | Synthesized from per-day asset queries; mutations still stubbed |

--- a/docs/design-docs/immich-adapter-gap-analysis.md
+++ b/docs/design-docs/immich-adapter-gap-analysis.md
@@ -2,7 +2,7 @@
 title: "Immich Adapter Gap Analysis"
 status: active
 created: 2026-04-15
-last-updated: 2026-07-03
+last-updated: 2026-07-07
 ---
 
 # Immich Adapter Gap Analysis
@@ -285,9 +285,9 @@ Immich libraries represent import sources (e.g., local folders, external storage
 
 ### 14. Server Info (15 endpoints)
 
-Most server info endpoints return hardcoded fake data (storage, statistics, features, config, theme).
+Most server info endpoints return hardcoded fake data (storage, statistics, features, config).
 
-**Current behavior**: Version endpoints return dynamic data from settings. `GET /server/features` is static but accurate. `GET /server/config` is still mostly hardcoded, but `trashDays` now reflects `TRASH_RETENTION_DAYS` at request time. Storage still shows fake disk usage, statistics still return zeros, and the about/theme/license responses remain placeholders.
+**Current behavior**: Version endpoints return dynamic data from settings. `GET /server/features` is static but accurate. `GET /server/config` is still mostly hardcoded, but `trashDays` now reflects `TRASH_RETENTION_DAYS` at request time. Storage still shows fake disk usage, statistics still return zeros, and the about/license responses remain placeholders. (`GET /server/theme` was removed in Immich v3 and dropped from the adapter.)
 
 | Endpoint | Current behavior | Impact |
 |----------|-----------------|--------|
@@ -296,7 +296,7 @@ Most server info endpoints return hardcoded fake data (storage, statistics, feat
 | `GET /server/storage` | Fake disk usage | **Low** — Cosmetic in admin panel |
 | `GET /server/statistics` | All zeros | **Low** — Admin panel stats |
 | `GET /server/about` | Fake tool versions | **Low** — About page |
-| `GET /server/theme` | Empty CSS | **None** — No custom theme |
+| `GET /server/theme` | **Removed in v3** — dropped from the adapter | **None** — Gone from the v3 spec |
 | `GET /server/license` | Fake license | **None** — Gumnut isn't licensed this way |
 | Other (6) | Version info, ping | **None** — Already functional or cosmetic |
 

--- a/docs/design-docs/immich-v3-api-changes.md
+++ b/docs/design-docs/immich-v3-api-changes.md
@@ -116,17 +116,23 @@ mistake it for behavioral change.
 
 ## 3. Removed endpoints (−7)
 
+**Decision (clean cut to 3.0): all dropped from the adapter.** None of these paths
+exist in the v3 spec, so no supported v3 client calls them — the handlers were
+removed rather than kept as shims. (`/plugins/triggers` was never implemented in
+the adapter, so there was nothing to drop.)
+
 - `POST /sync/delta-sync` & `POST /sync/full-sync` — legacy mobile sync gone,
   replaced by Sync v2 over the existing `/sync/stream` (see §5). Schemas
-  `AssetDeltaSyncDto/ResponseDto`, `AssetFullSyncDto` deleted.
-  *(Adapter already marks both deprecated at `routers/api/sync/routes.py:305,373`.)*
-- `POST /assets/exist` — `CheckExistingAssetsDto/ResponseDto` deleted.
-  *(Adapter implements at `routers/api/assets.py:295`.)*
-- `GET /assets/random` — use `POST /search/random`.
-- `GET /assets/device/{deviceId}` — *(adapter `routers/api/assets.py:1062`, already deprecated.)*
-- `PUT /assets/{id}/original` — asset original-file replace removed (only method drop on a retained path).
-- `GET /server/theme` — `ServerThemeDto` deleted.
+  `AssetDeltaSyncDto/ResponseDto`, `AssetFullSyncDto` deleted. **Dropped.**
+- `POST /assets/exist` — `CheckExistingAssetsDto/ResponseDto` deleted. **Dropped.**
+- `GET /assets/random` — use `POST /search/random`. **Dropped.**
+- `GET /assets/device/{deviceId}` — was a deprecated stub. **Dropped.**
+- `PUT /assets/{id}/original` — asset original-file replace removed (only method
+  drop on a retained path; the `GET /assets/{id}/original` download stays). **Dropped.**
+- `GET /server/theme` — `ServerThemeDto` deleted. **Dropped** (also removed from
+  `auth_middleware.py`'s unauthenticated-path set).
 - `GET /plugins/triggers` — replaced by `/plugins/methods` + `/plugins/templates`.
+  **N/A** — never implemented in the adapter.
 
 ---
 
@@ -266,8 +272,8 @@ RC** (no methods were added) — likely pre-announcing a future PATCH migration:
 4. **Shared links** — token/key/slug access model rework.
 5. **`AssetResponseDto`** — drop device fields + `unassignedFaces`, switch
    `people` to `PersonResponseDto`.
-6. **Compat decisions** — whether to keep the 7 removed endpoints as shims
-   (several already deprecated in the adapter) and the deprecated PUTs.
+6. **Compat decisions** — resolved: the 7 removed endpoints are **dropped** (clean
+   cut, no shims; see §3). The deprecated-in-place PUTs (§6) stay as-is.
 7. **New feature areas** (HLS streaming, integrity, calendar heatmap,
    plugins/workflows) — likely stub/skip initially for the adapter.
 

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -1,6 +1,6 @@
 ---
 title: "Code Practices"
-last-updated: 2026-07-03
+last-updated: 2026-07-07
 ---
 
 # Code Practices
@@ -123,9 +123,10 @@ The SDK is auto-generated (Stainless), so a version bump can add **newly-require
 6. **Test endpoints**: Verify responses match Immich API expectations
 7. **Audit `/me/preferences` for a gating boolean**: Many client UI features (memories, tags, ratings, folders, people, shared links, email notifications, cast) are gated client-side on a flag in `UserPreferencesResponseDto`. The default in `routers/api/users.py::userPreferencesResponse` ships most of these as `enabled=False`, which silently hides the corresponding UI even after the backing endpoints are wired up. When implementing an endpoint that backs a client UI feature, grep `routers/api/users.py` for the matching preference field and flip its `enabled` to `True`. The Immich web client checks these via `$preferences?.<area>?.enabled`; missing the flip means the new endpoints become dead code on the client.
 8. **Audit `routers/api/server.py::server_features`**: Many client UI features are also gated by a server-feature flag advertised via `GET /server/features`. When promoting an area from stub to a real implementation, flip the matching key from `False` to `True` and update the explanatory comment so it scopes only to the remaining stubbed sub-features. Leaving the flag at `False` after implementing the endpoint silently hides the UI; flipping it to `True` while parts of the area are still stubbed surfaces non-functional UI.
-9. **Update the implementation-status docs**: Promoting an endpoint from stub to real changes two evergreen docs that the docs-as-system-of-record convention requires keeping current:
+9. **Update the implementation-status docs**: Promoting an endpoint from stub to real — **or dropping an endpoint removed upstream** — changes two evergreen docs that the docs-as-system-of-record convention requires keeping current:
    - `docs/architecture/adapter-architecture.md` — move the row from the "Stub implementations" table to "Fully implemented" (or split into a partial-implementation row, mirroring "Memories (read)" / "Memories (write)"); bump `last-updated` in the frontmatter.
    - `docs/design-docs/immich-adapter-gap-analysis.md` — flip the gap section to **Closed**, update the summary stub count, and strike the entry from the Tier-1/2/3 plan table; bump `last-updated`.
+   - **Removing an endpoint** is the inverse: strike it from the `adapter-architecture.md` "Fully implemented"/stub row (drop the whole row if nothing else remains) and update the gap-analysis row/count rather than moving anything. These curated tables live outside most code diffs, so diff-scoped self-review won't flag the drift — grep the docs for the removed path/handler. Also scrub endpoint-specific caller lists in *this* reference — e.g. the `ASSET_INCLUDE` row's `convert_gumnut_asset_to_immich` caller list — where the deleted handler was named.
 
    Skipping either leaves future readers (and gap-prioritization passes) reasoning from stale data — the gap-analysis doc explicitly carries `status: active`, so consistency with the implementation is part of its contract.
 
@@ -147,7 +148,7 @@ Use the constants in `routers/utils/asset_conversion.py`, chosen by what the con
 
 | Constant | Tokens | Use for |
 |----------|--------|---------|
-| `ASSET_INCLUDE` | `metadata, people, file_data` | Reads feeding `convert_gumnut_asset_to_immich` (it emits `people`): `get_asset_info`, search, albums, memories, full/delta sync, the upload-success retrieve. |
+| `ASSET_INCLUDE` | `metadata, people, file_data` | Reads feeding `convert_gumnut_asset_to_immich` (it emits `people`): `get_asset_info`, search, memories, the upload-success retrieve. |
 | `ASSET_INCLUDE_NO_PEOPLE` | `metadata, file_data` | The sync-stream `entity_fetch` reads, whose converters read the `file_data` scalars but never `people`. |
 | `ASSET_INCLUDE_METADATA_ONLY` | `metadata` | Reads that touch only `metadata`: map markers (GPS), the bulk per-asset datetime rewrite (`original_datetime`). |
 

--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -50,7 +50,6 @@ from routers.immich_models import (
     AssetBulkUploadCheckResponseDto,
     AssetCopyDto,
     AssetJobsDto,
-    AssetMediaReplaceDto,
     AssetMediaSize,
     AssetMediaResponseDto,
     AssetMediaStatus,
@@ -60,9 +59,7 @@ from routers.immich_models import (
     AssetResponseDto,
     AssetStatsResponseDto,
     AssetVisibility,
-    CheckExistingAssetsDto,
     UserResponseDto,
-    CheckExistingAssetsResponseDto,
     UpdateAssetDto,
 )
 from routers.utils.gumnut_id_conversion import (
@@ -295,24 +292,6 @@ async def bulk_upload_check(
             results.append({"id": asset.id, "action": "accept"})
 
     return AssetBulkUploadCheckResponseDto(results=results)
-
-
-@router.post("/exist")
-async def check_existing_assets(
-    request: CheckExistingAssetsDto,
-    client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
-) -> CheckExistingAssetsResponseDto:
-    """
-    Check if multiple assets exist on the server and return all existing.
-    """
-    existing_assets_response = await client.assets.check_existence(
-        device_id=request.deviceId, device_asset_ids=request.deviceAssetIds
-    )
-    existing_ids = [
-        str(safe_uuid_from_asset_id(asset.id))
-        for asset in existing_assets_response.assets
-    ]
-    return CheckExistingAssetsResponseDto(existingIds=existing_ids)
 
 
 def _parse_datetime(value: str | None, fallback: datetime) -> datetime:
@@ -1060,19 +1039,6 @@ async def _bulk_trash(
         )
 
 
-@router.get("/device/{deviceId}", deprecated=True)
-async def get_all_user_assets_by_device_id(
-    deviceId: str,
-    client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
-) -> List[str]:
-    """
-    Retrieve assets by device ID.
-    This is a stub implementation as Gumnut does not support querying by device ID directly.
-    Returns an empty list.
-    """
-    return []
-
-
 @router.get("/statistics")
 async def get_asset_statistics(
     isFavorite: bool = Query(default=None, alias="isFavorite"),
@@ -1106,20 +1072,6 @@ async def get_asset_statistics(
         videos=video_count,
         total=total_assets,
     )
-
-
-@router.get("/random", deprecated=True)
-async def get_random(
-    count: int = Query(default=None, ge=1, type="number"),
-    client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
-) -> List[AssetResponseDto]:
-    """
-    Get random assets.
-    This is a stub implementation that returns an empty list.
-    Deprecated in v1.116.0 - use search endpoint instead.
-    """
-    # Stub implementation: return empty list since this endpoint is deprecated
-    return []
 
 
 @router.post("/jobs", status_code=204)
@@ -1312,34 +1264,6 @@ async def download_asset(
         "original",
         forwarded_headers=DEFAULT_FORWARDED_HEADERS + ("content-disposition",),
     )
-
-
-@router.put(
-    "/{id}/original",
-    deprecated=True,
-    response_model=AssetMediaResponseDto,
-    openapi_extra={
-        "requestBody": {
-            "content": {
-                "multipart/form-data": {
-                    "schema": {"$ref": "#/components/schemas/AssetMediaReplaceDto"}
-                }
-            }
-        }
-    },
-)
-async def replace_asset(
-    id: UUID,
-    request: AssetMediaReplaceDto,
-    key: str = Query(default=None, alias="key"),
-    slug: str = Query(default=None, alias="slug"),
-    client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
-):
-    """
-    Replace the asset with new file, without changing its id.
-    Deprecated in immich and not supported by Gumnut.
-    """
-    return
 
 
 @router.get("/{id}/metadata")

--- a/routers/api/server.py
+++ b/routers/api/server.py
@@ -14,7 +14,6 @@ from routers.immich_models import (
     ServerPingResponse,
     ServerStatsResponseDto,
     ServerStorageResponseDto,
-    ServerThemeDto,
     ServerVersionHistoryResponseDto,
     ServerVersionResponseDto,
     ServerMediaTypesResponseDto,
@@ -326,12 +325,3 @@ async def set_server_license(request: LicenseKeyDto) -> LicenseResponseDto:
         activationKey=request.activationKey,
         activatedAt=datetime.now(timezone.utc),
     )
-
-
-@router.get("/theme")
-async def get_theme() -> ServerThemeDto:
-    """
-    Get server theme configuration.
-    This is a stub implementation returning empty custom CSS.
-    """
-    return ServerThemeDto(customCss="")

--- a/routers/api/sync/routes.py
+++ b/routers/api/sync/routes.py
@@ -1,8 +1,9 @@
 """
 Immich sync endpoints for mobile client synchronization.
 
-This module implements the Immich sync protocol, providing both streaming sync
-(for beta timeline mode) and full/delta sync (for legacy timeline mode).
+This module implements the Immich sync protocol via streaming sync. The legacy
+full/delta sync endpoints were removed in Immich v3 — Sync v2 supersedes them
+over the existing /sync/stream.
 
 The streaming sync uses the Gumnut API v2 events endpoint (/api/v2/events) to
 fetch lightweight event records, then batch-fetches full entities as needed.
@@ -25,19 +26,12 @@ from services.checkpoint_store import (
 from services.session_store import SessionStore, get_session_store
 
 from routers.immich_models import (
-    AssetDeltaSyncDto,
-    AssetDeltaSyncResponseDto,
-    AssetFullSyncDto,
-    AssetResponseDto,
     SyncAckDeleteDto,
     SyncAckDto,
     SyncAckSetDto,
     SyncEntityType,
     SyncStreamDto,
-    UserResponseDto,
 )
-from routers.utils.asset_conversion import ASSET_INCLUDE, convert_gumnut_asset_to_immich
-from routers.utils.current_user import get_current_user
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
 
 from routers.api.sync.events import to_ack_string
@@ -300,134 +294,6 @@ async def delete_sync_ack(
         )
     # else: empty list - do nothing (no-op)
     return
-
-
-@router.post("/delta-sync", deprecated=True)
-async def get_delta_sync(
-    request: AssetDeltaSyncDto,
-    gumnut_client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
-    current_user: UserResponseDto = Depends(get_current_user),
-) -> AssetDeltaSyncResponseDto:
-    """
-    Get delta sync data - returns assets modified after a specific timestamp.
-
-    Note: This implementation fetches all assets and filters in-memory,
-    which is inefficient for large libraries.
-    """
-    try:
-        logger.info(f"Delta sync requested for timestamp: {request.updatedAfter}")
-
-        upserted_assets = []
-        page_size = 100
-        starting_after_id = None
-
-        # Paginate through all assets using cursor-based pagination
-        while True:
-            # Fetch a page of assets
-            assets_page = await gumnut_client.assets.list(
-                limit=page_size,
-                starting_after_id=starting_after_id,
-                include=ASSET_INCLUDE,
-            )
-
-            page_assets = assets_page.data
-            if not page_assets:
-                break
-
-            # Filter and convert assets from this page
-            for asset in page_assets:
-                if asset.updated_at and asset.updated_at > request.updatedAfter:
-                    asset_dto = convert_gumnut_asset_to_immich(asset, current_user)
-                    upserted_assets.append(asset_dto)
-
-            # Check if there are more pages
-            if not assets_page.has_more:
-                break
-
-            # Update cursor for next page
-            starting_after_id = page_assets[-1].id
-
-        logger.info(
-            f"Delta sync found {len(upserted_assets)} updated assets",
-            extra={"asset_count": len(upserted_assets)},
-        )
-
-        # Note: Deletion tracking not supported by Gumnut
-        deleted_asset_ids = []
-
-        return AssetDeltaSyncResponseDto(
-            deleted=deleted_asset_ids,
-            needsFullSync=False,
-            upserted=upserted_assets,
-        )
-
-    except Exception as e:
-        logger.error(f"Error during delta sync: {str(e)}", exc_info=True)
-        return AssetDeltaSyncResponseDto(
-            deleted=[],
-            needsFullSync=True,
-            upserted=[],
-        )
-
-
-@router.post("/full-sync", deprecated=True)
-async def get_full_sync_for_user(
-    request: AssetFullSyncDto,
-    gumnut_client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
-    current_user: UserResponseDto = Depends(get_current_user),
-) -> List[AssetResponseDto]:
-    """
-    Get paginated list of assets for full sync (legacy timeline mode).
-
-    Supports cursor-based pagination using lastId parameter.
-    """
-    try:
-        logger.info(
-            "Full sync requested",
-            extra={
-                "limit": request.limit,
-                "lastId": request.lastId,
-                "updatedUntil": request.updatedUntil,
-                "userId": request.userId,
-            },
-        )
-
-        assets = []
-        skip_until_cursor = request.lastId is not None
-
-        async for asset in gumnut_client.assets.list(include=ASSET_INCLUDE):
-            # Skip until we find the cursor asset
-            if skip_until_cursor:
-                if asset.id == request.lastId:
-                    skip_until_cursor = False
-                    continue
-                continue
-
-            # Apply updatedUntil filter
-            if request.updatedUntil and asset.updated_at:
-                if asset.updated_at > request.updatedUntil:
-                    continue
-
-            asset_dto = convert_gumnut_asset_to_immich(asset, current_user)
-            assets.append(asset_dto)
-
-            if len(assets) >= request.limit:
-                break
-
-        logger.info(
-            "Full sync completed",
-            extra={
-                "asset_count": len(assets),
-                "limit": request.limit,
-                "has_more": len(assets) >= request.limit,
-            },
-        )
-
-        return assets
-
-    except Exception as e:
-        logger.error(f"Error during full sync: {str(e)}", exc_info=True)
-        return []
 
 
 @router.post("/stream")

--- a/routers/middleware/auth_middleware.py
+++ b/routers/middleware/auth_middleware.py
@@ -45,7 +45,6 @@ class AuthMiddleware(BaseHTTPMiddleware):
         "/api/server/features",
         "/api/server/media-types",
         "/api/server/ping",
-        "/api/server/theme",
         "/api/server/version",
         "/api/server/version-history",
     }

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -23,21 +23,17 @@ from routers.api.assets import (
     _immich_checksum_to_base64,
     _parse_datetime,
     bulk_upload_check,
-    check_existing_assets,
     copy_asset,
     upload_asset,
     update_assets,
     delete_assets,
-    get_all_user_assets_by_device_id,
     get_asset_statistics,
-    get_random,
     run_asset_jobs,
     update_asset,
     get_asset_info,
     get_asset_ocr,
     view_asset,
     download_asset,
-    replace_asset,
     get_asset_metadata,
     update_asset_metadata,
     delete_asset_metadata,
@@ -52,7 +48,6 @@ from routers.immich_models import (
     AssetCopyDto,
     AssetMediaResponseDto,
     AssetVisibility,
-    CheckExistingAssetsDto,
     AssetBulkUpdateDto,
     AssetBulkDeleteDto,
     AssetJobsDto,
@@ -275,61 +270,6 @@ class TestImmichChecksumToBase64:
         # Should convert successfully
         decoded = base64.b64decode(result)
         assert decoded == bytes.fromhex("aabbccdd")
-
-
-class TestCheckExistingAssets:
-    """Test the check_existing_assets endpoint."""
-
-    @pytest.mark.anyio
-    async def test_check_existing_assets_returns_empty(self):
-        """Test that check_existing_assets returns empty list when no assets exist."""
-        # Setup
-        request = CheckExistingAssetsDto(
-            deviceAssetIds=["asset1", "asset2"], deviceId="device-123"
-        )
-
-        # Mock the Gumnut client - no existing assets
-        mock_client = Mock()
-        mock_response = Mock()
-        mock_response.assets = []
-        mock_client.assets.check_existence = AsyncMock(return_value=mock_response)
-
-        # Execute
-        result = await check_existing_assets(request, client=mock_client)
-
-        # Assert
-        assert result.existingIds == []
-        mock_client.assets.check_existence.assert_called_once_with(
-            device_id="device-123", device_asset_ids=["asset1", "asset2"]
-        )
-
-    @pytest.mark.anyio
-    async def test_check_existing_assets_returns_existing(self, sample_uuid):
-        """Test that check_existing_assets returns IDs of existing assets."""
-        # Setup
-        request = CheckExistingAssetsDto(
-            deviceAssetIds=["asset1", "asset2", "asset3"], deviceId="device-123"
-        )
-
-        # Mock the Gumnut client - some assets exist
-        mock_client = Mock()
-        mock_asset1 = Mock()
-        mock_asset1.id = uuid_to_gumnut_asset_id(sample_uuid)
-        second_uuid = uuid4()
-        mock_asset2 = Mock()
-        mock_asset2.id = uuid_to_gumnut_asset_id(second_uuid)
-
-        mock_response = Mock()
-        mock_response.assets = [mock_asset1, mock_asset2]
-        mock_client.assets.check_existence = AsyncMock(return_value=mock_response)
-
-        # Execute
-        result = await check_existing_assets(request, client=mock_client)
-
-        # Assert
-        assert len(result.existingIds) == 2
-        assert str(sample_uuid) in result.existingIds
-        assert str(second_uuid) in result.existingIds
 
 
 def _make_mock_request(
@@ -2630,19 +2570,6 @@ class TestDeleteAssets:
                 )
 
 
-class TestGetAllUserAssetsByDeviceId:
-    """Test the get_all_user_assets_by_device_id endpoint."""
-
-    @pytest.mark.anyio
-    async def test_get_all_user_assets_by_device_id_returns_empty(self):
-        """Test that get_all_user_assets_by_device_id returns empty list."""
-        # Execute
-        result = await get_all_user_assets_by_device_id("device-123")
-
-        # Assert
-        assert result == []
-
-
 class TestGetAssetStatistics:
     """Test the get_asset_statistics endpoint."""
 
@@ -2732,19 +2659,6 @@ class TestGetAssetStatistics:
         await get_asset_statistics(isTrashed=False, client=mock_client)
 
         mock_client.assets.list.assert_called_once_with()
-
-
-class TestGetRandom:
-    """Test the get_random endpoint."""
-
-    @pytest.mark.anyio
-    async def test_get_random_returns_empty(self):
-        """Test that get_random returns empty list (deprecated endpoint)."""
-        # Execute
-        result = await get_random(count=5)
-
-        # Assert
-        assert result == []
 
 
 class TestRunAssetJobs:
@@ -3358,22 +3272,6 @@ class TestDownloadAsset:
                 "content-disposition",
             ),
         )
-
-
-class TestReplaceAsset:
-    """Test the replace_asset endpoint."""
-
-    @pytest.mark.anyio
-    async def test_replace_asset_returns_none(self, sample_uuid):
-        """Test replace asset (deprecated, returns None)."""
-        # Setup
-        request = Mock()  # AssetMediaReplaceDto mock
-
-        # Execute
-        result = await replace_asset(sample_uuid, request)
-
-        # Assert
-        assert result is None
 
 
 class TestGetAssetMetadata:


### PR DESCRIPTION
## What
Immich v3 removed 7 endpoints. This drops their handlers from the adapter (clean cut, no shims):

- `POST /sync/delta-sync`, `POST /sync/full-sync` — Sync v2 supersedes them over the existing `/sync/stream`
- `POST /assets/exist`
- `GET /assets/random` — use `POST /search/random`
- `GET /assets/device/{deviceId}`
- `PUT /assets/{id}/original` — **method drop only**; the `GET /assets/{id}/original` download on the same path stays
- `GET /server/theme` — also removed from the auth-middleware unauthenticated-path set

`GET /plugins/triggers` was never implemented in the adapter, so there was nothing to drop.

Also removes the now-orphaned imports of DTOs deleted from the v3 models (`AssetDeltaSync*`, `AssetFullSyncDto`, `CheckExistingAssets*`, `AssetMediaReplaceDto`, `ServerThemeDto`), drops the four dead handler test classes, and records the drop decision in the v3 API-change and gap-analysis design docs.

## Why
The adapter retarget to Immich 3.0 is a clean cut with no dual-support window (product is in alpha), so removed endpoints need not stay as shims — none of these paths exist in the v3 spec, so no supported v3 client (Immich mobile/web v3) calls them. Keeping dead handlers that import deleted model symbols also left latent breakage.

**This PR merges to `migration/immichv3`, not `main`** — it is one step of the multi-PR Immich v3 retarget; the integration branch merges to `main` once all steps land.

## Test plan
- [x] `uv run ruff check` / `ruff format` clean
- [x] `uv run pyright`: 162 errors, down 8 from the branch baseline of 170 — **zero new** errors
- [x] Node-ID diff of pytest failures vs the base commit: **0 previously-passing tests regressed**
- [x] Removing the dead deleted-DTO imports unblocks test collection (15 → 11 collection errors); the 24 sync ack/session tests that directly exercise the edited router all pass
- Note: `migration/immichv3` is intentionally red due to a separate `Error1` import blocker (a different issue). The 5 newly-visible `test_sync_stream.py` failures are pre-existing `SyncAssetV1.createdAt` Mock-fixture issues from the merged Sync-v2 work — un-masked by this PR unblocking collection, not caused by it.

Generated by an AI coding agent.