### PR TITLE
Retarget test_assets.py removed Action enum to v3 AssetUploadAction

### DIFF
--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -42,7 +42,6 @@ from routers.api.assets import (
 )
 from routers.utils.gumnut_id_conversion import uuid_to_gumnut_asset_id
 from routers.immich_models import (
-    Action,
     AssetBulkUploadCheckDto,
     AssetBulkUploadCheckItem,
     AssetCopyDto,
@@ -57,6 +56,7 @@ from routers.immich_models import (
     AssetMetadataUpsertItemDto,
     AssetMediaSize,
     AssetMediaStatus,
+    AssetUploadAction,
 )
 
 
@@ -88,7 +88,7 @@ class TestBulkUploadCheck:
 
         # Assert
         assert len(result.results) == 2
-        assert all(item.action == Action.accept for item in result.results)
+        assert all(item.action == AssetUploadAction.accept for item in result.results)
         assert result.results[0].id == "asset1"
         assert result.results[1].id == "asset2"
         mock_client.assets.check_existence.assert_called_once()
@@ -127,11 +127,11 @@ class TestBulkUploadCheck:
         assert len(result.results) == 2
         # First asset should be rejected as duplicate
         assert result.results[0].id == "asset1"
-        assert result.results[0].action == Action.reject
+        assert result.results[0].action == AssetUploadAction.reject
         assert result.results[0].assetId == str(sample_uuid)
         # Second asset should be accepted
         assert result.results[1].id == "asset2"
-        assert result.results[1].action == Action.accept
+        assert result.results[1].action == AssetUploadAction.accept
 
     @pytest.mark.anyio
     async def test_bulk_upload_check_with_base64_checksum(self, sample_uuid):
@@ -165,7 +165,7 @@ class TestBulkUploadCheck:
         # Assert - should detect as duplicate
         assert len(result.results) == 1
         assert result.results[0].id == "mobile-asset-1"
-        assert result.results[0].action == Action.reject
+        assert result.results[0].action == AssetUploadAction.reject
         assert result.results[0].assetId == str(sample_uuid)
 
         # Verify the base64 checksum was passed to Gumnut as-is
@@ -203,7 +203,7 @@ class TestBulkUploadCheck:
 
         # Assert - both assets should be accepted (invalid one has false negative)
         assert len(result.results) == 2
-        assert all(item.action == Action.accept for item in result.results)
+        assert all(item.action == AssetUploadAction.accept for item in result.results)
 
 
 class TestImmichChecksumToBase64:


### PR DESCRIPTION
## What
- Repoint `tests/unit/api/test_assets.py` from the removed anonymous `Action` enum to the Immich v3 `AssetUploadAction` (same `accept`/`reject` values): one import line plus the five `Action.accept`/`Action.reject` assertion sites.
- Test-only — no production code references the old name.

## Why
- The Immich v3 GA model regeneration renamed the anonymous bulk-upload-check enum, so the stale import made `test_assets.py` fail collection with an `ImportError` — the suite's last remaining collection error on the integration branch. With this change the module collects again (147 tests) and the retargeted enum assertions pass.
- `AssetUploadAction` types the `action` field on the bulk-upload-check result DTO, so the enum-member comparisons carry over unchanged.
- This PR merges to `migration/immichv3`, not `main` — it is one step of the Immich v3 retarget; the integration branch merges to `main` when the whole migration lands.
- Out of scope, per the tracked plan: the 9 pre-existing v3-migration failures the module now reveals (id `str`→`UUID` assertion residue on untouched lines) are part of a separate mechanical sweep.

## Test plan
- [x] `uv run pytest tests/unit/api/test_assets.py --collect-only` — collects 147 tests, no `ImportError`
- [x] `grep -n '\bAction\b' tests/unit/api/test_assets.py` — no bare `Action` reference remains
- [x] `uv run pytest tests/unit/api/test_assets.py` — 138 passed / 9 failed, all 9 confirmed pre-existing str→UUID residue on lines this diff does not touch
- [x] `uv run ruff check` / `uv run ruff format` — clean
- [x] `uv run pyright tests/unit/api/test_assets.py` — zero new errors vs. base (stash-diff baseline); fixes one baseline error (the unknown `Action` import)

Generated by an AI coding agent.