### PR TITLE
Clear Immich v3 test residue: 147 failures to green

### DIFF
--- a/docs/references/development-tools.md
+++ b/docs/references/development-tools.md
@@ -53,6 +53,10 @@ The generator's `datamodel-code-generator` dependency is unpinned (`>=0.25.0`, r
 
 Before handing the spec to `datamodel-code-generator`, the generator drops constraints codegen would misapply to non-string types — currently `pattern` on schemas whose `format` maps to a non-string type (`uuid`, `date-time`, `date`, `time`), which otherwise yields `UUID` / `AwareDatetime` / `date` / `time` fields that raise `TypeError` at value validation under the pinned pydantic (and it collapses the now-redundant `RootModel[UUID]` id wrappers into plain `UUID`). Patterns on genuine string fields are kept. See `strip_non_string_patterns` in `tools/spec_preprocess.py`; if a future spec trips the same class of error for another non-string `format`, add it to `_NON_STRING_PATTERN_FORMATS` rather than hand-editing the generated file.
 
+### After Regenerating: Sweep Stub Literals via Pyright
+
+A regeneration that adds typing or pattern constraints (e.g. `str` → `UUID` ids, regex-patterned keys) silently turns hardcoded literals in stub endpoints into latent 500s — stubs have no test coverage, so the suite stays green while the endpoint fails response validation on every call. Don't hunt these by grep (partial sweeps have missed sites repeatedly); enumerate them from pyright's error list — `Literal['...'] cannot be assigned to parameter ... of type UUID` (or a pattern-constrained field) pinpoints every offending literal. Dynamic `str(...)`-of-UUID values coerce fine at runtime and are style cleanup, not defects; invalid *literals* are the class that 500s.
+
 ## API Compatibility Tool
 
 The `validate_api_compatibility.py` tool ensures that immich-adapter correctly implements the Immich API endpoints.

--- a/routers/api/activities.py
+++ b/routers/api/activities.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from typing import List
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, Query
 from routers.utils.current_user import get_current_user
@@ -51,7 +51,7 @@ async def create_activity(
         assetId="d6773835-4b91-4c7d-8667-26bd5daa1a45",  # still a dummy asset id
         comment="Test activity comment",
         createdAt=now,
-        id="activity-id-123",
+        id=uuid4(),
         type=ReactionType.comment,
         user=UserResponseDto(
             avatarColor=UserAvatarColor.primary,

--- a/routers/api/admin.py
+++ b/routers/api/admin.py
@@ -127,7 +127,7 @@ async def create_user_admin(request: UserAdminCreateDto) -> UserAdminResponseDto
         license=UserLicense(
             activatedAt=datetime.now(tz=timezone.utc),
             activationKey="activation-key",
-            licenseKey="license-key",
+            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
         ),
         profileChangedAt=datetime.now(tz=timezone.utc),
         deletedAt=datetime.now(tz=timezone.utc),
@@ -158,7 +158,7 @@ async def get_user_admin(id: UUID) -> UserAdminResponseDto:
         license=UserLicense(
             activatedAt=datetime.now(tz=timezone.utc),
             activationKey="activation-key",
-            licenseKey="license-key",
+            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
         ),
         profileChangedAt=datetime.now(tz=timezone.utc),
         deletedAt=datetime.now(tz=timezone.utc),
@@ -191,7 +191,7 @@ async def update_user_admin(
         license=UserLicense(
             activatedAt=datetime.now(tz=timezone.utc),
             activationKey="activation-key",
-            licenseKey="license-key",
+            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
         ),
         profileChangedAt=datetime.now(tz=timezone.utc),
         deletedAt=datetime.now(tz=timezone.utc),
@@ -224,7 +224,7 @@ async def delete_user_admin(
         license=UserLicense(
             activatedAt=datetime.now(tz=timezone.utc),
             activationKey="activation-key",
-            licenseKey="license-key",
+            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
         ),
         profileChangedAt=datetime.now(tz=timezone.utc),
         deletedAt=datetime.now(tz=timezone.utc),
@@ -303,7 +303,7 @@ async def restore_user_admin(id: UUID) -> UserAdminResponseDto:
         license=UserLicense(
             activatedAt=datetime.now(tz=timezone.utc),
             activationKey="activation-key",
-            licenseKey="license-key",
+            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
         ),
         profileChangedAt=datetime.now(tz=timezone.utc),
         deletedAt=datetime.now(tz=timezone.utc),

--- a/routers/api/admin.py
+++ b/routers/api/admin.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter, Query
-from uuid import UUID
+from uuid import UUID, uuid4
 from datetime import datetime, timezone
 from typing import List
 
+from routers.api.constants import STUB_LICENSE_KEY
 from routers.immich_models import (
     AlbumsResponse,
     AssetOrder,
@@ -61,7 +62,8 @@ async def create_notification(request: NotificationCreateDto) -> NotificationDto
     This is a stub implementation that returns a fake notification response.
     """
     return NotificationDto(
-        id="notification-id",
+        # v3 types the id UUID; a non-UUID stub fails response validation.
+        id=uuid4(),
         title=request.title,
         level=request.level or NotificationLevel.info,
         type=request.type or NotificationType.Custom,
@@ -114,7 +116,8 @@ async def create_user_admin(request: UserAdminCreateDto) -> UserAdminResponseDto
     This is a stub implementation that returns a fake user response.
     """
     return UserAdminResponseDto(
-        id="user-id",
+        # v3 types the id UUID; a non-UUID stub fails response validation.
+        id=uuid4(),
         email=request.email,
         name=request.name,
         isAdmin=request.isAdmin or False,
@@ -127,7 +130,7 @@ async def create_user_admin(request: UserAdminCreateDto) -> UserAdminResponseDto
         license=UserLicense(
             activatedAt=datetime.now(tz=timezone.utc),
             activationKey="activation-key",
-            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
+            licenseKey=STUB_LICENSE_KEY,
         ),
         profileChangedAt=datetime.now(tz=timezone.utc),
         deletedAt=datetime.now(tz=timezone.utc),
@@ -158,7 +161,7 @@ async def get_user_admin(id: UUID) -> UserAdminResponseDto:
         license=UserLicense(
             activatedAt=datetime.now(tz=timezone.utc),
             activationKey="activation-key",
-            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
+            licenseKey=STUB_LICENSE_KEY,
         ),
         profileChangedAt=datetime.now(tz=timezone.utc),
         deletedAt=datetime.now(tz=timezone.utc),
@@ -191,7 +194,7 @@ async def update_user_admin(
         license=UserLicense(
             activatedAt=datetime.now(tz=timezone.utc),
             activationKey="activation-key",
-            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
+            licenseKey=STUB_LICENSE_KEY,
         ),
         profileChangedAt=datetime.now(tz=timezone.utc),
         deletedAt=datetime.now(tz=timezone.utc),
@@ -224,7 +227,7 @@ async def delete_user_admin(
         license=UserLicense(
             activatedAt=datetime.now(tz=timezone.utc),
             activationKey="activation-key",
-            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
+            licenseKey=STUB_LICENSE_KEY,
         ),
         profileChangedAt=datetime.now(tz=timezone.utc),
         deletedAt=datetime.now(tz=timezone.utc),
@@ -303,7 +306,7 @@ async def restore_user_admin(id: UUID) -> UserAdminResponseDto:
         license=UserLicense(
             activatedAt=datetime.now(tz=timezone.utc),
             activationKey="activation-key",
-            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
+            licenseKey=STUB_LICENSE_KEY,
         ),
         profileChangedAt=datetime.now(tz=timezone.utc),
         deletedAt=datetime.now(tz=timezone.utc),

--- a/routers/api/api_keys.py
+++ b/routers/api/api_keys.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from uuid import UUID
+from uuid import UUID, uuid4
 from datetime import datetime, timezone
 from typing import List
 
@@ -35,7 +35,7 @@ async def create_api_key(request: ApiKeyCreateDto) -> ApiKeyCreateResponseDto:
     This is a stub implementation that returns a fake API key response.
     """
     api_key = ApiKeyResponseDto(
-        id="api-key-id",
+        id=uuid4(),
         name=request.name or "API Key",
         permissions=request.permissions,
         createdAt=datetime.now(tz=timezone.utc),
@@ -51,7 +51,7 @@ async def get_my_api_key() -> ApiKeyResponseDto:
     This is a stub implementation that returns a fake API key response.
     """
     return ApiKeyResponseDto(
-        id="current-api-key-id",
+        id=uuid4(),
         name="Current API Key",
         permissions=[Permission.asset_read],
         createdAt=datetime.now(tz=timezone.utc),

--- a/routers/api/constants.py
+++ b/routers/api/constants.py
@@ -11,3 +11,9 @@ GUMNUT_API_MAX_PAGE_SIZE = 200
 # the backend deduplicates by checksum, not by device identifier, so true
 # re-uploads are still caught (see docs/design-docs/checksum-support.md).
 GUMNUT_UPLOAD_DEVICE_ID = "gumnut-device"
+
+# Placeholder license key for the stubbed license surfaces (the adapter has no
+# licensing). Immich v3's UserLicense DTO enforces the key pattern
+# ^IM(SV|CL)(-[\dA-Za-z]{4}){8}$ on responses, so any stub value must match it
+# or the returning endpoint 500s on response validation.
+STUB_LICENSE_KEY = "IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA"

--- a/routers/api/libraries.py
+++ b/routers/api/libraries.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends
-from uuid import UUID
+from uuid import UUID, uuid4
 from datetime import datetime, timezone
 from typing import List
 
@@ -39,7 +39,7 @@ async def create_library(
     This is a stub implementation that returns a fake library response.
     """
     return LibraryResponseDto(
-        id="library-id",
+        id=uuid4(),
         name=request.name or "New Library",
         ownerId=str(current_user_id),
         assetCount=0,

--- a/routers/api/memories.py
+++ b/routers/api/memories.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from datetime import date, datetime, timedelta, timezone
 from typing import Annotated, List
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from gumnut import AsyncGumnut
@@ -261,7 +261,7 @@ async def create_memory(
     This is a stub implementation that returns a fake memory response.
     """
     return MemoryResponseDto(
-        id="memory-id",
+        id=uuid4(),
         assets=[],
         createdAt=datetime.now(tz=timezone.utc),
         data=OnThisDayDto(year=2024),

--- a/routers/api/oauth.py
+++ b/routers/api/oauth.py
@@ -213,7 +213,7 @@ async def finish_oauth(
         # Return login response with session token
         return LoginResponseDto(
             accessToken=session_token,
-            userId=result.user.id,
+            userId=user_uuid,
             userEmail=result.user.email or "",
             name=name,
             isAdmin=False,  # TODO: determine admin status
@@ -270,7 +270,7 @@ async def link_oauth_account(
         license=UserLicense(
             activatedAt=now,
             activationKey="dummy-activation-key",
-            licenseKey="dummy-license-key",
+            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
         ),
         name=current_user.name,
         oauthId="oauth-123456",
@@ -328,7 +328,7 @@ async def unlink_oauth_account(
         license=UserLicense(
             activatedAt=now,
             activationKey="dummy-activation-key",
-            licenseKey="dummy-license-key",
+            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
         ),
         name=current_user.name,
         oauthId="",

--- a/routers/api/oauth.py
+++ b/routers/api/oauth.py
@@ -4,6 +4,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from gumnut import AsyncGumnut, BadRequestError, omit
 
+from routers.api.constants import STUB_LICENSE_KEY
 from routers.immich_models import (
     LoginResponseDto,
     OAuthAuthorizeResponseDto,
@@ -270,7 +271,7 @@ async def link_oauth_account(
         license=UserLicense(
             activatedAt=now,
             activationKey="dummy-activation-key",
-            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
+            licenseKey=STUB_LICENSE_KEY,
         ),
         name=current_user.name,
         oauthId="oauth-123456",
@@ -328,7 +329,7 @@ async def unlink_oauth_account(
         license=UserLicense(
             activatedAt=now,
             activationKey="dummy-activation-key",
-            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
+            licenseKey=STUB_LICENSE_KEY,
         ),
         name=current_user.name,
         oauthId="",

--- a/routers/api/people.py
+++ b/routers/api/people.py
@@ -134,9 +134,10 @@ async def _update_one_person(
     `GumnutError`, raised from either `_resolve_thumbnail_face_id`'s inner
     `client.faces.list` or the final `client.people.update`) is delegated to
     `classify_bulk_item_call`, mirroring the per-chunk policy used by
-    `chunked_per_item_bulk` for chunked bulk endpoints. The pre-call
-    exception specific to this endpoint (`HTTPException` from
-    `_resolve_thumbnail_face_id`'s "missing face" branch) stays here.
+    `chunked_per_item_bulk` for chunked bulk endpoints. The exception
+    specific to this endpoint (`HTTPException` from
+    `_resolve_thumbnail_face_id`'s "missing face" branch) stays here — it
+    is not an SDK error, so `classify_bulk_item_call` lets it propagate.
     """
     log_extra = {"person_id": person_item.id}
 

--- a/routers/api/people.py
+++ b/routers/api/people.py
@@ -135,24 +135,14 @@ async def _update_one_person(
     `client.faces.list` or the final `client.people.update`) is delegated to
     `classify_bulk_item_call`, mirroring the per-chunk policy used by
     `chunked_per_item_bulk` for chunked bulk endpoints. The pre-call
-    exceptions specific to this endpoint (`ValueError` from UUID parsing,
-    `HTTPException` from `_resolve_thumbnail_face_id`'s "missing face"
-    branch) stay here.
+    exception specific to this endpoint (`HTTPException` from
+    `_resolve_thumbnail_face_id`'s "missing face" branch) stays here.
     """
     log_extra = {"person_id": person_item.id}
 
-    try:
-        # immich openapi specs switch between str and UUID for people id, so
-        # UUID(...) can raise on malformed input.
-        gumnut_person_id = uuid_to_gumnut_person_id(UUID(person_item.id))
-    except ValueError as ve:
-        logger.warning(
-            "Invalid person id in bulk update",
-            extra={**log_extra, "error": str(ve)},
-        )
-        return BulkIdResponseDto(
-            id=person_item.id, success=False, error=BulkIdErrorReason.unknown
-        )
+    # v3 types `PeopleUpdateItem.id` as UUID, so malformed ids are rejected
+    # with a 422 at the request boundary before reaching this handler.
+    gumnut_person_id = uuid_to_gumnut_person_id(person_item.id)
 
     try:
         sdk_error = await classify_bulk_item_call(
@@ -396,7 +386,7 @@ async def merge_person(
     )
 
     return [
-        BulkIdResponseDto(id=str(source_uuid), success=True, error=None)
+        BulkIdResponseDto(id=source_uuid, success=True, error=None)
         for source_uuid in request.ids
     ]
 

--- a/routers/api/server.py
+++ b/routers/api/server.py
@@ -53,6 +53,8 @@ server_features = {
     "configFile": False,
     "email": False,
     "ocr": False,
+    # No server-side transcoding; assets are served as stored.
+    "realtimeTranscoding": False,
 }
 
 
@@ -77,6 +79,9 @@ def get_fake_config() -> dict:
         "publicUsers": True,
         "mapDarkStyleUrl": "https://tiles.immich.cloud/v1/style/dark.json",
         "mapLightStyleUrl": "https://tiles.immich.cloud/v1/style/light.json",
+        # Immich's people-recognition server default; face detection runs in
+        # the Gumnut API, so this only feeds the client's settings display.
+        "minFaces": 3,
     }
 
 
@@ -276,6 +281,8 @@ async def get_server_version() -> ServerVersionResponseDto:
         major=version.major,
         minor=version.minor,
         patch=version.patch,
+        # Tracked container tags are GA releases, never pre-releases.
+        prerelease=None,
     )
 
 
@@ -299,7 +306,8 @@ async def get_server_license() -> LicenseResponseDto:
     This is a stub implementation returning basic license info.
     """
     return LicenseResponseDto(
-        licenseKey="/IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA/",
+        # Must match the v3 UserLicense key pattern or the endpoint 500s.
+        licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
         activationKey=str(uuid()),
         activatedAt=datetime(1900, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
     )

--- a/routers/api/server.py
+++ b/routers/api/server.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter
 from shortuuid import uuid
 
 from config.settings import get_settings
+from routers.api.constants import STUB_LICENSE_KEY
 from routers.immich_models import (
     LicenseKeyDto,
     LicenseResponseDto,
@@ -306,8 +307,7 @@ async def get_server_license() -> LicenseResponseDto:
     This is a stub implementation returning basic license info.
     """
     return LicenseResponseDto(
-        # Must match the v3 UserLicense key pattern or the endpoint 500s.
-        licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
+        licenseKey=STUB_LICENSE_KEY,
         activationKey=str(uuid()),
         activatedAt=datetime(1900, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
     )

--- a/routers/api/stacks.py
+++ b/routers/api/stacks.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Query
-from uuid import UUID
+from uuid import UUID, uuid4
 from typing import List
 
 from routers.immich_models import (
@@ -43,7 +43,7 @@ async def create_stack(request: StackCreateDto) -> StackResponseDto:
     This is a stub implementation that returns a fake stack response.
     """
     return StackResponseDto(
-        id="stack-id", primaryAssetId=str(request.assetIds[0]), assets=[]
+        id=uuid4(), primaryAssetId=str(request.assetIds[0]), assets=[]
     )
 
 
@@ -53,7 +53,7 @@ async def get_stack(id: UUID) -> StackResponseDto:
     Get stack by ID.
     This is a stub implementation that returns a fake stack response.
     """
-    return StackResponseDto(id=str(id), primaryAssetId="primary-asset-id", assets=[])
+    return StackResponseDto(id=id, primaryAssetId=uuid4(), assets=[])
 
 
 @router.put("/{id}")
@@ -63,10 +63,8 @@ async def update_stack(id: UUID, request: StackUpdateDto) -> StackResponseDto:
     This is a stub implementation that returns a fake stack response.
     """
     return StackResponseDto(
-        id=str(id),
-        primaryAssetId=str(request.primaryAssetId)
-        if request.primaryAssetId
-        else "primary-asset-id",
+        id=id,
+        primaryAssetId=request.primaryAssetId if request.primaryAssetId else uuid4(),
         assets=[],
     )
 

--- a/routers/api/tags.py
+++ b/routers/api/tags.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from uuid import UUID
+from uuid import UUID, uuid4
 from typing import List
 from datetime import datetime, timezone
 
@@ -37,7 +37,7 @@ async def create_tag(request: TagCreateDto) -> TagResponseDto:
     This is a stub implementation that returns a fake tag response.
     """
     return TagResponseDto(
-        id="tag-id",
+        id=uuid4(),
         name=request.name,
         value=request.name.lower().replace(" ", "-"),
         color=request.color,

--- a/routers/api/users.py
+++ b/routers/api/users.py
@@ -5,6 +5,7 @@ from uuid import UUID, uuid4
 from typing import List
 import logging
 
+from routers.api.constants import STUB_LICENSE_KEY
 from routers.immich_models import (
     AlbumsResponse,
     AssetOrder,
@@ -112,7 +113,7 @@ async def update_my_user(
         license=UserLicense(
             activatedAt=datetime.now(tz=timezone.utc),
             activationKey=str(uuid4()),
-            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
+            licenseKey=STUB_LICENSE_KEY,
         ),
     )
 
@@ -124,7 +125,7 @@ async def get_user_license() -> LicenseResponseDto:
     This is a stub implementation that returns fake license data.
     """
     return LicenseResponseDto(
-        licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
+        licenseKey=STUB_LICENSE_KEY,
         activationKey=str(uuid4()),
         activatedAt=datetime(1900, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
     )

--- a/routers/api/users.py
+++ b/routers/api/users.py
@@ -112,7 +112,7 @@ async def update_my_user(
         license=UserLicense(
             activatedAt=datetime.now(tz=timezone.utc),
             activationKey=str(uuid4()),
-            licenseKey="/IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA/",
+            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
         ),
     )
 
@@ -124,7 +124,7 @@ async def get_user_license() -> LicenseResponseDto:
     This is a stub implementation that returns fake license data.
     """
     return LicenseResponseDto(
-        licenseKey="/IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA/",
+        licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
         activationKey=str(uuid4()),
         activatedAt=datetime(1900, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
     )

--- a/routers/utils/album_conversion.py
+++ b/routers/utils/album_conversion.py
@@ -48,11 +48,10 @@ def convert_gumnut_album_to_immich(
         id=str(safe_uuid_from_album_id(album_id)),
         albumName=album_name,
         description=album_description,  # type: ignore
-        albumThumbnailAssetId=str(
-            safe_uuid_from_asset_id(gumnut_album.album_cover_asset_id)
-        )
+        # v3 types this UUID | None; None (not "") is the no-cover value.
+        albumThumbnailAssetId=safe_uuid_from_asset_id(gumnut_album.album_cover_asset_id)
         if gumnut_album.album_cover_asset_id
-        else "",
+        else None,
         createdAt=created_at,
         updatedAt=updated_at,
         # An album's start/end date is the min/max of its assets' local capture

--- a/routers/utils/album_conversion.py
+++ b/routers/utils/album_conversion.py
@@ -45,7 +45,7 @@ def convert_gumnut_album_to_immich(
     final_asset_count = asset_count if asset_count is not None else 0
 
     return AlbumResponseDto(
-        id=str(safe_uuid_from_album_id(album_id)),
+        id=safe_uuid_from_album_id(album_id),
         albumName=album_name,
         description=album_description,  # type: ignore
         # v3 types this UUID | None; None (not "") is the no-cover value.

--- a/routers/utils/current_user.py
+++ b/routers/utils/current_user.py
@@ -115,7 +115,7 @@ async def get_current_user_admin(
         license=UserLicense(
             activatedAt=datetime.now(tz=timezone.utc),
             activationKey=str(uuid4()),
-            licenseKey="/IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA/",
+            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
         ),
     )
 
@@ -159,4 +159,4 @@ async def get_current_user_id(
     Returns:
         UUID of the current user
     """
-    return UUID(user_admin.id)
+    return user_admin.id

--- a/routers/utils/current_user.py
+++ b/routers/utils/current_user.py
@@ -14,6 +14,7 @@ from fastapi import Depends, Request
 from gumnut import AsyncGumnut
 from gumnut.types.user_response import UserResponse
 
+from routers.api.constants import STUB_LICENSE_KEY
 from routers.immich_models import (
     UserAdminResponseDto,
     UserAvatarColor,
@@ -95,7 +96,7 @@ async def get_current_user_admin(
     quota = map_user_quota(user)
 
     user_admin_dto = UserAdminResponseDto(
-        id=str(user_uuid),
+        id=user_uuid,
         email=user.email or "",
         name=full_name,
         isAdmin=False,  # Always False - no need to show Immich admin controls
@@ -115,7 +116,7 @@ async def get_current_user_admin(
         license=UserLicense(
             activatedAt=datetime.now(tz=timezone.utc),
             activationKey=str(uuid4()),
-            licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
+            licenseKey=STUB_LICENSE_KEY,
         ),
     )
 

--- a/tests/integration/test_oauth_integration.py
+++ b/tests/integration/test_oauth_integration.py
@@ -159,7 +159,7 @@ class TestFinishOAuthIntegration:
         result = response.json()
         expected_session_token = str(TEST_SESSION_UUID)
         assert result["accessToken"] == expected_session_token
-        assert result["userId"] == TEST_GUMNUT_USER_ID
+        assert result["userId"] == str(TEST_USER_UUID)
         assert result["userEmail"] == "test@example.com"
         assert result["name"] == "Test User"
         assert result["isAdmin"] is False

--- a/tests/integration/test_server_config.py
+++ b/tests/integration/test_server_config.py
@@ -45,3 +45,13 @@ class TestServerConfigTrashDays:
         response = client.get("/api/server/config")
         assert response.status_code == 200
         assert response.json()["trashDays"] == 45
+
+
+class TestServerConfigMinFaces:
+    def test_min_faces_matches_immich_default(self, client):
+        """minFaces (required by the v3 ServerConfigDto) pins Immich's
+        people-recognition server default; face detection itself runs in the
+        Gumnut API, so this only feeds the client's settings display."""
+        response = client.get("/api/server/config")
+        assert response.status_code == 200
+        assert response.json()["minFaces"] == 3

--- a/tests/integration/test_server_features.py
+++ b/tests/integration/test_server_features.py
@@ -21,6 +21,7 @@ class TestServerFeaturesEndpoint:
         data = response.json()
         for flag in (
             "duplicateDetection",
+            "realtimeTranscoding",
             "reverseGeocoding",
             "sidecar",
         ):

--- a/tests/integration/test_server_version.py
+++ b/tests/integration/test_server_version.py
@@ -44,12 +44,13 @@ class TestServerVersionEndpoint:
         data = response.json()
 
         # Verify all required fields are present
-        assert set(data.keys()) == {"major", "minor", "patch"}
+        assert set(data.keys()) == {"major", "minor", "patch", "prerelease"}
 
         # Verify all values are integers
         assert isinstance(data["major"], int)
         assert isinstance(data["minor"], int)
         assert isinstance(data["patch"], int)
+        assert data["prerelease"] is None
 
 
 class TestVersionCheckEndpoint:

--- a/tests/unit/api/sync/conftest.py
+++ b/tests/unit/api/sync/conftest.py
@@ -150,6 +150,9 @@ def create_mock_asset_data(updated_at: datetime) -> Mock:
     asset.mime_type = "image/jpeg"
     asset.original_file_name = "test.jpg"
     asset.local_datetime = updated_at
+    # SyncAssetV1.createdAt is required in Immich v3 and validated as an
+    # aware datetime — a bare Mock attribute would fail validation.
+    asset.created_at = updated_at
     asset.updated_at = updated_at
     asset.thumbhash = None
     asset.width = 1920

--- a/tests/unit/api/sync/test_datetime_conversion.py
+++ b/tests/unit/api/sync/test_datetime_conversion.py
@@ -268,6 +268,7 @@ class TestGumnutAssetToSyncAssetV1DateHandling:
         local_datetime: datetime,
         file_created_at: datetime,
         file_modified_at: datetime,
+        created_at: datetime | None = None,
     ) -> Mock:
         """Create a mock asset with the given dates."""
         asset = Mock()
@@ -277,7 +278,7 @@ class TestGumnutAssetToSyncAssetV1DateHandling:
         asset.local_datetime = local_datetime
         # SyncAssetV1.createdAt is required in Immich v3 and validated as an
         # aware datetime — a bare Mock attribute would fail validation.
-        asset.created_at = file_created_at
+        asset.created_at = created_at if created_at is not None else file_created_at
         # File/provenance scalars live on the nested ``file_data`` group
         # (requested via ``include=file_data``); the adapter reads them from there.
         asset.file_data = Mock()
@@ -319,6 +320,25 @@ class TestGumnutAssetToSyncAssetV1DateHandling:
         assert result.fileCreatedAt.year == 2020
         assert result.fileCreatedAt.month == 5
         assert result.fileCreatedAt.day == 15
+
+    def test_created_at_maps_from_asset_created_at(self):
+        """createdAt must come from the asset's own created_at.
+
+        Every other datetime in the fixture is distinct, so an accidental
+        mapping from file_created_at / file_modified_at / local_datetime
+        would fail this assertion rather than aliasing to the same value.
+        """
+        local_datetime = datetime(2020, 5, 15, 10, 30, 0, tzinfo=timezone.utc)
+        file_created_at = datetime(2024, 12, 1, 14, 0, 0, tzinfo=timezone.utc)
+        file_modified_at = datetime(2024, 12, 2, 9, 0, 0, tzinfo=timezone.utc)
+        created_at = datetime(2023, 3, 7, 8, 15, 0, tzinfo=timezone.utc)
+
+        asset = self._create_mock_asset(
+            local_datetime, file_created_at, file_modified_at, created_at=created_at
+        )
+        result = gumnut_asset_to_sync_asset_v1(asset, OWNER_UUID)
+
+        assert result.createdAt == created_at
 
     def test_local_datetime_uses_keep_local_time_format(self):
         """localDateTime should use Immich's "keepLocalTime" format.

--- a/tests/unit/api/sync/test_datetime_conversion.py
+++ b/tests/unit/api/sync/test_datetime_conversion.py
@@ -12,6 +12,8 @@ from routers.utils.datetime_utils import (
 from routers.utils.gumnut_id_conversion import uuid_to_gumnut_asset_id
 from tests.unit.api.sync.conftest import TEST_UUID
 
+OWNER_UUID = "22222222-2222-2222-2222-222222222222"
+
 
 class TestToImmichLocalDatetime:
     """Tests for to_immich_local_datetime helper function.
@@ -273,6 +275,9 @@ class TestGumnutAssetToSyncAssetV1DateHandling:
         asset.mime_type = "image/jpeg"
         asset.original_file_name = "test.jpg"
         asset.local_datetime = local_datetime
+        # SyncAssetV1.createdAt is required in Immich v3 and validated as an
+        # aware datetime — a bare Mock attribute would fail validation.
+        asset.created_at = file_created_at
         # File/provenance scalars live on the nested ``file_data`` group
         # (requested via ``include=file_data``); the adapter reads them from there.
         asset.file_data = Mock()
@@ -307,7 +312,7 @@ class TestGumnutAssetToSyncAssetV1DateHandling:
         asset = self._create_mock_asset(
             local_datetime, file_created_at, file_modified_at
         )
-        result = gumnut_asset_to_sync_asset_v1(asset, "owner-uuid")
+        result = gumnut_asset_to_sync_asset_v1(asset, OWNER_UUID)
 
         # fileCreatedAt should be 2020-05-15 (EXIF date), not 2024-12-01 (file date)
         assert result.fileCreatedAt is not None
@@ -330,7 +335,7 @@ class TestGumnutAssetToSyncAssetV1DateHandling:
         asset = self._create_mock_asset(
             local_datetime, file_created_at, file_modified_at
         )
-        result = gumnut_asset_to_sync_asset_v1(asset, "owner-uuid")
+        result = gumnut_asset_to_sync_asset_v1(asset, OWNER_UUID)
 
         # localDateTime should be 10:30:00 UTC (keepLocalTime - preserves 10:30)
         assert result.localDateTime is not None
@@ -356,7 +361,7 @@ class TestGumnutAssetToSyncAssetV1DateHandling:
         asset = self._create_mock_asset(
             local_datetime, file_created_at, file_modified_at
         )
-        result = gumnut_asset_to_sync_asset_v1(asset, "owner-uuid")
+        result = gumnut_asset_to_sync_asset_v1(asset, OWNER_UUID)
 
         # fileCreatedAt should be 18:30:00 UTC (actual UTC conversion)
         assert result.fileCreatedAt is not None
@@ -380,7 +385,7 @@ class TestGumnutAssetToSyncAssetV1DateHandling:
         asset = self._create_mock_asset(
             local_datetime, file_created_at, file_modified_at
         )
-        result = gumnut_asset_to_sync_asset_v1(asset, "owner-uuid")
+        result = gumnut_asset_to_sync_asset_v1(asset, OWNER_UUID)
 
         # localDateTime: 15:00 UTC (keepLocalTime - preserves the 3 PM)
         assert result.localDateTime is not None
@@ -403,7 +408,7 @@ class TestGumnutAssetToSyncAssetV1DateHandling:
         asset = self._create_mock_asset(
             local_datetime, file_created_at, file_modified_at
         )
-        result = gumnut_asset_to_sync_asset_v1(asset, "owner-uuid")
+        result = gumnut_asset_to_sync_asset_v1(asset, OWNER_UUID)
 
         # fileModifiedAt should be the same as input
         assert result.fileModifiedAt == file_modified_at

--- a/tests/unit/api/test_albums.py
+++ b/tests/unit/api/test_albums.py
@@ -263,12 +263,12 @@ class TestGetAllAlbums:
         # Assert - verify albumThumbnailAssetId is set correctly
         assert len(result) == 3
         # First album should have the converted asset ID
-        expected_uuid0 = str(safe_uuid_from_asset_id(cover_asset_id0))
+        expected_uuid0 = safe_uuid_from_asset_id(cover_asset_id0)
         assert result[0].albumThumbnailAssetId == expected_uuid0
-        # Second album should have empty string (no cover)
-        assert result[1].albumThumbnailAssetId == ""
+        # Second album should have None (no cover)
+        assert result[1].albumThumbnailAssetId is None
         # Third album should have its converted asset ID
-        expected_uuid2 = str(safe_uuid_from_asset_id(cover_asset_id2))
+        expected_uuid2 = safe_uuid_from_asset_id(cover_asset_id2)
         assert result[2].albumThumbnailAssetId == expected_uuid2
 
     @pytest.mark.anyio
@@ -432,7 +432,7 @@ class TestGetAlbumInfo:
         )
 
         # Assert - verify albumThumbnailAssetId is set correctly
-        expected_uuid = str(safe_uuid_from_asset_id(cover_asset_id))
+        expected_uuid = safe_uuid_from_asset_id(cover_asset_id)
         assert result.albumThumbnailAssetId == expected_uuid
 
     @pytest.mark.anyio
@@ -543,7 +543,7 @@ class TestAddAssetsToAlbum:
         request = BulkIdsDto(ids=[asset_id1, asset_id2])
         result = await add_assets_to_album(sample_uuid, request, client=mock_client)
 
-        assert [item.id for item in result] == [str(asset_id1), str(asset_id2)]
+        assert [item.id for item in result] == [asset_id1, asset_id2]
         assert all(item.success is True for item in result)
         mock_client.albums.assets_associations.add.assert_called_once_with(
             uuid_to_gumnut_album_id(sample_uuid),
@@ -567,9 +567,9 @@ class TestAddAssetsToAlbum:
         result = await add_assets_to_album(sample_uuid, request, client=mock_client)
 
         assert len(result) == 2
-        assert result[0].id == str(new_asset)
+        assert result[0].id == new_asset
         assert result[0].success is True
-        assert result[1].id == str(dup_asset)
+        assert result[1].id == dup_asset
         assert result[1].success is False
         assert result[1].error == BulkIdErrorReason.duplicate
 
@@ -595,9 +595,9 @@ class TestAddAssetsToAlbum:
         result = await add_assets_to_album(sample_uuid, request, client=mock_client)
 
         assert len(result) == 2
-        assert result[0].id == str(new_asset)
+        assert result[0].id == new_asset
         assert result[0].success is True
-        assert result[1].id == str(missing_asset)
+        assert result[1].id == missing_asset
         assert result[1].success is False
         assert result[1].error == BulkIdErrorReason.not_found
 
@@ -619,7 +619,7 @@ class TestAddAssetsToAlbum:
 
         result = await add_assets_to_album(sample_uuid, request, client=mock_client)
 
-        assert [item.id for item in result] == [str(asset_id1), str(asset_id2)]
+        assert [item.id for item in result] == [asset_id1, asset_id2]
         assert all(item.success is False for item in result)
         assert all(item.error == BulkIdErrorReason.not_found for item in result)
         assert mock_client.albums.assets_associations.add.call_count == 1
@@ -638,7 +638,7 @@ class TestAddAssetsToAlbum:
 
         result = await add_assets_to_album(sample_uuid, request, client=mock_client)
 
-        assert [item.id for item in result] == [str(asset_id1), str(asset_id2)]
+        assert [item.id for item in result] == [asset_id1, asset_id2]
         assert all(item.success is False for item in result)
         assert all(item.error == BulkIdErrorReason.unknown for item in result)
         assert mock_client.albums.assets_associations.add.call_count == 1
@@ -657,7 +657,7 @@ class TestAddAssetsToAlbum:
 
         result = await add_assets_to_album(sample_uuid, request, client=mock_client)
 
-        assert [item.id for item in result] == [str(asset_id1), str(asset_id2)]
+        assert [item.id for item in result] == [asset_id1, asset_id2]
         assert all(item.success is False for item in result)
         assert all(item.error == BulkIdErrorReason.unknown for item in result)
         assert mock_client.albums.assets_associations.add.call_count == 1
@@ -695,7 +695,7 @@ class TestAddAssetsToAlbum:
         request = BulkIdsDto(ids=asset_uuids)
         result = await add_assets_to_album(sample_uuid, request, client=mock_client)
 
-        assert [item.id for item in result] == [str(u) for u in asset_uuids]
+        assert [item.id for item in result] == asset_uuids
         assert all(item.success is True for item in result)
 
         assert (
@@ -860,9 +860,9 @@ class TestAddAssetsToAlbum:
         with caplog.at_level(logging.WARNING):
             result = await add_assets_to_album(sample_uuid, request, client=mock_client)
 
-        assert result[0].id == str(present)
+        assert result[0].id == present
         assert result[0].success is True
-        assert result[1].id == str(missing)
+        assert result[1].id == missing
         assert result[1].success is False
         assert result[1].error == BulkIdErrorReason.unknown
         assert any(
@@ -921,9 +921,7 @@ class TestUpdateAlbum:
             name="Updated Album",
             album_cover_asset_id=cover_gumnut_id,
         )
-        assert result.albumThumbnailAssetId == str(
-            safe_uuid_from_asset_id(cover_gumnut_id)
-        )
+        assert result.albumThumbnailAssetId == safe_uuid_from_asset_id(cover_gumnut_id)
 
     @pytest.mark.anyio
     async def test_update_album_not_found_propagates(
@@ -961,7 +959,7 @@ class TestRemoveAssetFromAlbum:
         request = BulkIdsDto(ids=[asset_id1, asset_id2])
         result = await remove_asset_from_album(sample_uuid, request, client=mock_client)
 
-        assert [item.id for item in result] == [str(asset_id1), str(asset_id2)]
+        assert [item.id for item in result] == [asset_id1, asset_id2]
         assert all(item.success is True for item in result)
         mock_client.albums.assets_associations.remove.assert_called_once_with(
             uuid_to_gumnut_album_id(sample_uuid),
@@ -982,7 +980,7 @@ class TestRemoveAssetFromAlbum:
 
         result = await remove_asset_from_album(sample_uuid, request, client=mock_client)
 
-        assert [item.id for item in result] == [str(asset_id1), str(asset_id2)]
+        assert [item.id for item in result] == [asset_id1, asset_id2]
         assert all(item.success is False for item in result)
         assert all(item.error == BulkIdErrorReason.not_found for item in result)
 
@@ -1046,7 +1044,7 @@ class TestRemoveAssetFromAlbum:
         request = BulkIdsDto(ids=asset_uuids)
         result = await remove_asset_from_album(sample_uuid, request, client=mock_client)
 
-        assert [item.id for item in result] == [str(u) for u in asset_uuids]
+        assert [item.id for item in result] == asset_uuids
         assert all(item.success is True for item in result)
 
         assert (

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -128,7 +128,7 @@ class TestBulkUploadCheck:
         # First asset should be rejected as duplicate
         assert result.results[0].id == "asset1"
         assert result.results[0].action == AssetUploadAction.reject
-        assert result.results[0].assetId == str(sample_uuid)
+        assert result.results[0].assetId == sample_uuid
         # Second asset should be accepted
         assert result.results[1].id == "asset2"
         assert result.results[1].action == AssetUploadAction.accept
@@ -166,7 +166,7 @@ class TestBulkUploadCheck:
         assert len(result.results) == 1
         assert result.results[0].id == "mobile-asset-1"
         assert result.results[0].action == AssetUploadAction.reject
-        assert result.results[0].assetId == str(sample_uuid)
+        assert result.results[0].assetId == sample_uuid
 
         # Verify the base64 checksum was passed to Gumnut as-is
         mock_client.assets.check_existence.assert_called_once()
@@ -376,7 +376,7 @@ class TestUploadAsset:
             )
 
         assert isinstance(result, AssetMediaResponseDto)
-        assert result.id == str(sample_uuid)
+        assert result.id == sample_uuid
         assert result.status == AssetMediaStatus.created
         mock_client.assets.with_raw_response.create.assert_called_once()
         call_kwargs = mock_client.assets.with_raw_response.create.call_args
@@ -556,7 +556,7 @@ class TestUploadAsset:
             )
 
         assert isinstance(result, AssetMediaResponseDto)
-        assert UUID(result.id)
+        assert isinstance(result.id, UUID)
         assert result.status == AssetMediaStatus.created
         mock_client.assets.with_raw_response.create.assert_not_called()
 
@@ -585,7 +585,7 @@ class TestUploadAsset:
             )
 
         assert isinstance(result, AssetMediaResponseDto)
-        assert UUID(result.id)
+        assert isinstance(result.id, UUID)
         assert result.status == AssetMediaStatus.created
         mock_client.assets.with_raw_response.create.assert_not_called()
 
@@ -642,7 +642,7 @@ class TestUploadAsset:
             )
 
             assert isinstance(result, AssetMediaResponseDto)
-            assert result.id == str(sample_uuid)
+            assert result.id == sample_uuid
             assert result.status == AssetMediaStatus.created
             mock_client.assets.with_raw_response.create.assert_called_once()
 
@@ -775,7 +775,7 @@ class TestUploadAsset:
             )
 
             assert isinstance(result, AssetMediaResponseDto)
-            assert result.id == str(sample_uuid)
+            assert result.id == sample_uuid
             assert result.status == AssetMediaStatus.created
 
     @pytest.mark.anyio
@@ -1907,7 +1907,7 @@ class TestUpdateAsset:
         mock_client.assets.update_asset.assert_awaited_once_with(
             uuid_to_gumnut_asset_id(sample_uuid), description="hello"
         )
-        assert result.id == str(sample_uuid)
+        assert result.id == sample_uuid
 
     @pytest.mark.anyio
     async def test_update_asset_description_null_clears(
@@ -2220,7 +2220,7 @@ class TestUpdateAsset:
             include=["metadata", "people", "file_data"],
         )
         mock_emit.assert_not_awaited()
-        assert result.id == str(sample_uuid)
+        assert result.id == sample_uuid
 
     @pytest.mark.anyio
     async def test_update_asset_out_of_scope_fields_no_sdk_call(

--- a/tests/unit/api/test_faces.py
+++ b/tests/unit/api/test_faces.py
@@ -166,7 +166,7 @@ class TestGetFaces:
         assert len(result) == 1
         assert result[0].person is not None
         assert result[0].person.name == "Calvin"
-        assert result[0].person.id == str(safe_uuid_from_person_id(person_id))
+        assert result[0].person.id == safe_uuid_from_person_id(person_id)
 
     @pytest.mark.anyio
     async def test_multiple_faces_same_person_fetches_once(self, mock_sync_cursor_page):
@@ -334,7 +334,7 @@ class TestReassignFace:
         )
         mock_client.people.retrieve.assert_called_once_with(gumnut_person_id)
         assert result.name == "Calvin"
-        assert result.id == str(safe_uuid_from_person_id(gumnut_person_id))
+        assert result.id == safe_uuid_from_person_id(gumnut_person_id)
 
     @pytest.mark.anyio
     async def test_sdk_error_propagates(self):
@@ -428,7 +428,7 @@ class TestCreateFace:
         assert result.imageHeight == 2160
         assert result.person is not None
         assert result.person.name == "Calvin"
-        assert result.person.id == str(safe_uuid_from_person_id(gumnut_person_id))
+        assert result.person.id == safe_uuid_from_person_id(gumnut_person_id)
 
     @pytest.mark.anyio
     async def test_box_passes_through_when_preview_matches_asset(self):

--- a/tests/unit/api/test_map.py
+++ b/tests/unit/api/test_map.py
@@ -113,9 +113,7 @@ class TestGetMapMarkers:
 
         assert len(result) == 1
         marker = result[0]
-        assert marker.id == str(
-            safe_uuid_from_asset_id(uuid_to_gumnut_asset_id(asset_uuid))
-        )
+        assert marker.id == safe_uuid_from_asset_id(uuid_to_gumnut_asset_id(asset_uuid))
         assert marker.lat == 37.7749
         assert marker.lon == -122.4194
         assert marker.city == "San Francisco"

--- a/tests/unit/api/test_memories.py
+++ b/tests/unit/api/test_memories.py
@@ -136,7 +136,7 @@ class TestSearchMemories:
         for_param = datetime(2026, 5, 4, 23, 0, tzinfo=timezone.utc)
         result = await _call_search(
             client=client,
-            current_user_id=UUID(mock_current_user.id),
+            current_user_id=mock_current_user.id,
             current_user=mock_current_user,
             for_param=for_param,
         )
@@ -154,7 +154,7 @@ class TestSearchMemories:
         assert result[0].data.year == 2024
         assert len(result[0].assets) == 1
         # ID is decodable back to the same year/month/day.
-        decoded = decode_memory_id(UUID(result[0].id), UUID(mock_current_user.id))
+        decoded = decode_memory_id(result[0].id, mock_current_user.id)
         assert decoded == (2024, 5, 4)
 
     @pytest.mark.anyio
@@ -172,7 +172,7 @@ class TestSearchMemories:
 
         result = await _call_search(
             client=client,
-            current_user_id=UUID(mock_current_user.id),
+            current_user_id=mock_current_user.id,
             current_user=mock_current_user,
             for_param=datetime(2026, 5, 4, tzinfo=timezone.utc),
         )
@@ -188,7 +188,7 @@ class TestSearchMemories:
 
         result = await _call_search(
             client=client,
-            current_user_id=UUID(mock_current_user.id),
+            current_user_id=mock_current_user.id,
             current_user=mock_current_user,
             isSaved=True,
         )
@@ -203,7 +203,7 @@ class TestSearchMemories:
 
         result = await _call_search(
             client=client,
-            current_user_id=UUID(mock_current_user.id),
+            current_user_id=mock_current_user.id,
             current_user=mock_current_user,
             isTrashed=True,
         )
@@ -224,7 +224,7 @@ class TestSearchMemories:
 
         result = await _call_search(
             client=client,
-            current_user_id=UUID(mock_current_user.id),
+            current_user_id=mock_current_user.id,
             current_user=mock_current_user,
             type=MemoryType.on_this_day,
             for_param=datetime(2026, 5, 4, tzinfo=timezone.utc),
@@ -252,7 +252,7 @@ class TestSearchMemories:
             mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
             result = await _call_search(
                 client=client,
-                current_user_id=UUID(mock_current_user.id),
+                current_user_id=mock_current_user.id,
                 current_user=mock_current_user,
                 for_param=for_param,
             )
@@ -285,7 +285,7 @@ class TestSearchMemories:
 
         result = await _call_search(
             client=client,
-            current_user_id=UUID(mock_current_user.id),
+            current_user_id=mock_current_user.id,
             current_user=mock_current_user,
             for_param=datetime(2026, 5, 4, tzinfo=timezone.utc),
             isSaved=isSaved,
@@ -305,7 +305,7 @@ class TestSearchMemories:
 
         result = await _call_search(
             client=client,
-            current_user_id=UUID(mock_current_user.id),
+            current_user_id=mock_current_user.id,
             current_user=mock_current_user,
             for_param=datetime(2026, 5, 4, tzinfo=timezone.utc),
             isTrashed=isTrashed,
@@ -333,7 +333,7 @@ class TestSearchMemories:
 
         result = await _call_search(
             client=client,
-            current_user_id=UUID(mock_current_user.id),
+            current_user_id=mock_current_user.id,
             current_user=mock_current_user,
             for_param=datetime(2024, 2, 29, tzinfo=timezone.utc),
         )
@@ -364,7 +364,7 @@ class TestSearchMemories:
 
         result = await _call_search(
             client=client,
-            current_user_id=UUID(mock_current_user.id),
+            current_user_id=mock_current_user.id,
             current_user=mock_current_user,
             for_param=datetime(2026, 5, 4, tzinfo=timezone.utc),
         )
@@ -387,7 +387,7 @@ class TestSearchMemories:
             mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
             await _call_search(
                 client=client,
-                current_user_id=UUID(mock_current_user.id),
+                current_user_id=mock_current_user.id,
                 current_user=mock_current_user,
             )
 
@@ -470,7 +470,7 @@ class TestFetchAssetsForDay:
 class TestGetMemory:
     @pytest.mark.anyio
     async def test_returns_memory_for_valid_id(self, mock_current_user):
-        user_uuid = UUID(mock_current_user.id)
+        user_uuid = mock_current_user.id
         memory_id = encode_memory_id(user_uuid, 2024, 5, 4)
         captured = datetime(2024, 5, 4, 12, 0, tzinfo=timezone.utc)
         client = Mock()
@@ -485,7 +485,7 @@ class TestGetMemory:
             current_user=mock_current_user,
         )
 
-        assert result.id == str(memory_id)
+        assert result.id == memory_id
         assert result.data.year == 2024
         assert len(result.assets) == 1
 
@@ -498,7 +498,7 @@ class TestGetMemory:
             await get_memory(
                 id=uuid4(),
                 client=client,
-                current_user_id=UUID(mock_current_user.id),
+                current_user_id=mock_current_user.id,
                 current_user=mock_current_user,
             )
         assert exc.value.status_code == 404
@@ -518,7 +518,7 @@ class TestGetMemory:
             await get_memory(
                 id=memory_id,
                 client=client,
-                current_user_id=UUID(mock_current_user.id),
+                current_user_id=mock_current_user.id,
                 current_user=mock_current_user,
             )
         assert exc.value.status_code == 404
@@ -527,7 +527,7 @@ class TestGetMemory:
 
     @pytest.mark.anyio
     async def test_404_when_year_has_no_assets(self, mock_current_user):
-        user_uuid = UUID(mock_current_user.id)
+        user_uuid = mock_current_user.id
         memory_id = encode_memory_id(user_uuid, 2024, 5, 4)
         client = Mock()
         client.assets.list = Mock(return_value=MockSyncCursorPage([]))

--- a/tests/unit/api/test_people.py
+++ b/tests/unit/api/test_people.py
@@ -128,8 +128,8 @@ class TestUpdatePeople:
         mock_client = Mock()
         mock_client.people.update = AsyncMock(return_value=None)
 
-        person_id1 = str(uuid4())
-        person_id2 = str(uuid4())
+        person_id1 = uuid4()
+        person_id2 = uuid4()
 
         person_updates = [
             PeopleUpdateItem(id=person_id1, name="Updated Name 1"),
@@ -164,8 +164,8 @@ class TestUpdatePeople:
             ]
         )
 
-        person_id1 = str(uuid4())
-        person_id2 = str(uuid4())
+        person_id1 = uuid4()
+        person_id2 = uuid4()
 
         person_updates = [
             PeopleUpdateItem(id=person_id1, name="Updated Name 1"),
@@ -192,8 +192,8 @@ class TestUpdatePeople:
         mock_client = Mock()
         mock_client.people.update = AsyncMock(return_value=None)
 
-        person_id1 = str(uuid4())
-        person_id2 = str(uuid4())
+        person_id1 = uuid4()
+        person_id2 = uuid4()
 
         # Only updating some fields
         person_updates = [
@@ -223,8 +223,8 @@ class TestUpdatePeople:
             side_effect=[None, make_sdk_connection_error("PUT")]
         )
 
-        person_id1 = str(uuid4())
-        person_id2 = str(uuid4())
+        person_id1 = uuid4()
+        person_id2 = uuid4()
         request = PeopleUpdateDto(
             people=[
                 PeopleUpdateItem(id=person_id1, name="Good"),
@@ -241,33 +241,17 @@ class TestUpdatePeople:
         assert result[1].id == person_id2
         assert result[1].error == BulkIdErrorReason.unknown
 
-    @pytest.mark.anyio
-    async def test_update_people_malformed_uuid_does_not_abort_batch(self):
-        """A malformed UUID in one item must not abort the bulk operation.
+    def test_update_people_malformed_uuid_rejected_at_dto_boundary(self):
+        """A malformed UUID is rejected at the request boundary.
 
-        Immich's `PeopleUpdateItem.id` is typed as `str` (the OpenAPI spec
-        switches between str and UUID for people ids), so `UUID(...)` can
-        raise `ValueError` here even when other items in the batch are
-        well-formed.
+        Immich v3 types `PeopleUpdateItem.id` as `UUID`, so a malformed id
+        fails DTO validation (FastAPI returns 422) before the handler runs —
+        it can never reach the per-item error mapping.
         """
-        mock_client = Mock()
-        mock_client.people.update = AsyncMock(return_value=None)
+        from pydantic import ValidationError
 
-        valid_id = str(uuid4())
-        person_updates = [
-            PeopleUpdateItem(id="not-a-uuid", name="Bad"),
-            PeopleUpdateItem(id=valid_id, name="Good"),
-        ]
-        request = PeopleUpdateDto(people=person_updates)
-
-        result = await update_people(request, client=mock_client)
-
-        assert len(result) == 2
-        assert result[0].success is False
-        assert result[0].id == "not-a-uuid"
-        assert result[0].error == BulkIdErrorReason.unknown
-        assert result[1].success is True
-        assert result[1].id == valid_id
+        with pytest.raises(ValidationError):
+            PeopleUpdateItem(id="not-a-uuid", name="Bad")  # type: ignore[arg-type]
 
     @pytest.mark.anyio
     async def test_update_people_uses_bounded_concurrency(self):
@@ -289,7 +273,7 @@ class TestUpdatePeople:
         mock_client.people.update = AsyncMock(side_effect=update_side_effect)
 
         person_updates = [
-            PeopleUpdateItem(id=str(uuid4()), name=f"Person {i}")
+            PeopleUpdateItem(id=uuid4(), name=f"Person {i}")
             for i in range(BULK_FANOUT_CONCURRENCY_LIMIT + 5)
         ]
         request = PeopleUpdateDto(people=person_updates)
@@ -409,7 +393,7 @@ class TestUpdatePeopleFeatureFace:
         mock_client.faces.list = AsyncMock(return_value=mock_faces_page)
 
         person_updates = [
-            PeopleUpdateItem(id=str(person_uuid), featureFaceAssetId=asset_uuid),
+            PeopleUpdateItem(id=person_uuid, featureFaceAssetId=asset_uuid),
         ]
         request = PeopleUpdateDto(people=person_updates)
 
@@ -439,9 +423,7 @@ class TestUpdatePeopleFeatureFace:
         person_uuid = uuid4()
         asset_uuid = uuid4()
         request = PeopleUpdateDto(
-            people=[
-                PeopleUpdateItem(id=str(person_uuid), featureFaceAssetId=asset_uuid)
-            ]
+            people=[PeopleUpdateItem(id=person_uuid, featureFaceAssetId=asset_uuid)]
         )
 
         result = await update_people(request, client=mock_client)
@@ -482,8 +464,8 @@ class TestUpdatePeopleFeatureFace:
         asset_uuid = uuid4()
         request = PeopleUpdateDto(
             people=[
-                PeopleUpdateItem(id=str(person_a), featureFaceAssetId=asset_uuid),
-                PeopleUpdateItem(id=str(person_b), name="b"),
+                PeopleUpdateItem(id=person_a, featureFaceAssetId=asset_uuid),
+                PeopleUpdateItem(id=person_b, name="b"),
             ]
         )
 
@@ -714,8 +696,8 @@ class TestGetAllPeopleSorting:
         result = await call_get_all_people(client=mock_client)
 
         # Older should come first — identify by person ID
-        older_id = str(safe_uuid_from_person_id(older.id))
-        newer_id = str(safe_uuid_from_person_id(newer.id))
+        older_id = safe_uuid_from_person_id(older.id)
+        newer_id = safe_uuid_from_person_id(newer.id)
         assert result.people[0].id == older_id
         assert result.people[1].id == newer_id
 
@@ -1167,7 +1149,7 @@ class TestMergePerson:
         result = await merge_person(target_uuid, request, client=mock_client)
 
         assert len(result) == 1
-        assert result[0].id == str(source_uuid)
+        assert result[0].id == source_uuid
         assert result[0].success is True
         assert result[0].error is None
 
@@ -1194,7 +1176,7 @@ class TestMergePerson:
 
         assert len(result) == 2
         assert all(r.success for r in result)
-        assert [r.id for r in result] == [str(source_1), str(source_2)]
+        assert [r.id for r in result] == [source_1, source_2]
 
         mock_client.people.merge.assert_called_once_with(
             uuid_to_gumnut_person_id(target_uuid),

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -81,7 +81,7 @@ class TestSearchPerson:
 
         assert len(result) == 1
         assert result[0].name == "Calvin"
-        assert result[0].id == str(safe_uuid_from_person_id(person_id))
+        assert result[0].id == safe_uuid_from_person_id(person_id)
         mock_client.people.list.assert_called_once_with(name="Calvin")
 
     @pytest.mark.anyio
@@ -384,7 +384,7 @@ class TestSearchMetadata:
 
         assert result.assets.count == 1
         assert len(result.assets.items) == 1
-        assert result.assets.items[0].id == str(asset_uuid)
+        assert result.assets.items[0].id == asset_uuid
         assert result.assets.items[0].originalFileName == "sunset.jpg"
 
     @pytest.mark.anyio
@@ -557,9 +557,7 @@ class TestSearchExplore:
         assert len(city_group.items) == 1
         assert city_group.items[0].value == "Sydney"
         # The representative is the newest (first-scanned) image for the city.
-        assert city_group.items[0].data.id == str(
-            safe_uuid_from_asset_id(city_assets[0].id)
-        )
+        assert city_group.items[0].data.id == safe_uuid_from_asset_id(city_assets[0].id)
         assert len(recents_group.items) == 6
         # The scan is metadata-only; the batched re-fetch carries the full
         # include set the conversion needs.
@@ -714,7 +712,7 @@ class TestSearchExplore:
         recents_group = result[1]
         # Only the first two scanned assets made it into recents.
         assert [item.data.id for item in recents_group.items] == [
-            str(safe_uuid_from_asset_id(a.id)) for a in full_assets[:2]
+            safe_uuid_from_asset_id(a.id) for a in full_assets[:2]
         ]
 
     @pytest.mark.anyio
@@ -742,7 +740,7 @@ class TestSearchExplore:
 
         recents_group = result[1]
         assert [item.data.id for item in recents_group.items] == [
-            str(safe_uuid_from_asset_id(a.id)) for a in full_assets[:2]
+            safe_uuid_from_asset_id(a.id) for a in full_assets[:2]
         ]
 
     @pytest.mark.anyio
@@ -832,7 +830,7 @@ class TestSearchRandom:
         for request in (
             RandomSearchDto(takenAfter=datetime(2024, 1, 1, tzinfo=timezone.utc)),
             RandomSearchDto(city="Sydney"),
-            RandomSearchDto(rating=0),
+            RandomSearchDto(rating=1),
             RandomSearchDto(isMotion=True),
             RandomSearchDto(tagIds=[uuid4()]),
         ):
@@ -860,9 +858,7 @@ class TestSearchRandom:
             current_user=mock_current_user,
         )
 
-        assert [asset.id for asset in result] == [
-            str(safe_uuid_from_asset_id(image.id))
-        ]
+        assert [asset.id for asset in result] == [safe_uuid_from_asset_id(image.id)]
 
     @pytest.mark.anyio
     async def test_type_filter_with_no_matches_returns_empty(
@@ -996,7 +992,7 @@ class TestSearchRandom:
         )
 
         expected_uuids = {
-            str(safe_uuid_from_asset_id(a.id)) for a in feb_assets + jan_assets
+            safe_uuid_from_asset_id(a.id) for a in feb_assets + jan_assets
         }
         assert {asset.id for asset in result} == expected_uuids
 
@@ -1045,7 +1041,7 @@ class TestSearchRandom:
         )
 
         assert len(result) == 2
-        all_uuids = {str(safe_uuid_from_asset_id(a.id)) for a in jan_assets}
+        all_uuids = {safe_uuid_from_asset_id(a.id) for a in jan_assets}
         assert {asset.id for asset in result} <= all_uuids
         assert len({asset.id for asset in result}) == 2
 
@@ -1144,7 +1140,7 @@ class TestSearchRandom:
             current_user=mock_current_user,
         )
 
-        expected_uuids = {str(safe_uuid_from_asset_id(a.id)) for a in jan_assets}
+        expected_uuids = {safe_uuid_from_asset_id(a.id) for a in jan_assets}
         assert {asset.id for asset in result} == expected_uuids
 
     @pytest.mark.anyio
@@ -1183,8 +1179,8 @@ class TestSearchRandom:
         )
 
         expected_uuids = {
-            str(safe_uuid_from_asset_id(feb_assets[1].id)),
-            str(safe_uuid_from_asset_id(jan_assets[0].id)),
+            safe_uuid_from_asset_id(feb_assets[1].id),
+            safe_uuid_from_asset_id(jan_assets[0].id),
         }
         assert {asset.id for asset in result} == expected_uuids
 

--- a/tests/unit/api/test_sessions.py
+++ b/tests/unit/api/test_sessions.py
@@ -56,7 +56,7 @@ class TestHelperFunctions:
         assert result.deviceOS == "iOS 17"
         assert result.appVersion == "1.94.0"
         assert result.isPendingSyncReset is False
-        assert result.id == str(TEST_SESSION_ID)
+        assert result.id == TEST_SESSION_ID
 
     def test_session_to_response_dto_current_false(self):
         """Test converting session to DTO when it's not the current session."""
@@ -78,7 +78,7 @@ class TestHelperFunctions:
 
         assert result.current is False
         assert result.isPendingSyncReset is True
-        assert result.id == str(TEST_SESSION_ID)
+        assert result.id == TEST_SESSION_ID
 
     def test_session_to_response_dto_empty_app_version(self):
         """Test that empty app_version is converted to None."""
@@ -191,8 +191,8 @@ class TestGetSessions:
 
         # Verify session IDs are used as response IDs
         response_ids = {s.id for s in result}
-        assert str(TEST_SESSION_ID) in response_ids
-        assert str(TEST_SESSION_ID_2) in response_ids
+        assert TEST_SESSION_ID in response_ids
+        assert TEST_SESSION_ID_2 in response_ids
 
     @pytest.mark.anyio
     async def test_get_sessions_empty(self, mock_request, mock_session_store):
@@ -434,7 +434,7 @@ class TestUpdateSession:
         )
 
         assert result.isPendingSyncReset is True
-        assert result.id == str(TEST_SESSION_ID)
+        assert result.id == TEST_SESSION_ID
         mock_session_store.get_by_id.assert_called_with(str(TEST_SESSION_ID))
         mock_session_store.set_pending_sync_reset.assert_called_once_with(
             str(TEST_SESSION_ID), True
@@ -522,7 +522,7 @@ class TestUpdateSession:
             session_store=mock_session_store,
         )
 
-        assert result.id == str(TEST_SESSION_ID)
+        assert result.id == TEST_SESSION_ID
         # set_pending_sync_reset should not be called
         mock_session_store.set_pending_sync_reset.assert_not_called()
 

--- a/tests/unit/api/test_users.py
+++ b/tests/unit/api/test_users.py
@@ -6,6 +6,7 @@ from uuid import UUID, uuid4
 import pytest
 import shortuuid
 
+from routers.api.constants import STUB_LICENSE_KEY
 from routers.api.users import get_my_user, update_my_user
 from routers.immich_models import (
     UserAdminResponseDto,
@@ -46,7 +47,7 @@ class TestGetMyUser:
             license=UserLicense(
                 activatedAt=datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
                 activationKey="test-key",
-                licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
+                licenseKey=STUB_LICENSE_KEY,
             ),
         )
 
@@ -100,7 +101,7 @@ class TestGetMyUser:
             license=UserLicense(
                 activatedAt=datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
                 activationKey="test-key",
-                licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
+                licenseKey=STUB_LICENSE_KEY,
             ),
         )
 
@@ -137,7 +138,7 @@ class TestGetMyUser:
             license=UserLicense(
                 activatedAt=datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
                 activationKey="test-key",
-                licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
+                licenseKey=STUB_LICENSE_KEY,
             ),
         )
 

--- a/tests/unit/api/test_users.py
+++ b/tests/unit/api/test_users.py
@@ -46,7 +46,7 @@ class TestGetMyUser:
             license=UserLicense(
                 activatedAt=datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
                 activationKey="test-key",
-                licenseKey="test-license",
+                licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
             ),
         )
 
@@ -56,8 +56,8 @@ class TestGetMyUser:
         # Assert response matches expected format (should just return what was passed in)
         assert isinstance(result, UserAdminResponseDto)
         assert result == mock_user_admin
-        # ID should be the UUID string
-        assert result.id == str(test_uuid)
+        # ID should be the UUID
+        assert result.id == test_uuid
         assert result.email == "test@example.com"
         assert result.name == "John Doe"
         assert result.isAdmin is True
@@ -100,7 +100,7 @@ class TestGetMyUser:
             license=UserLicense(
                 activatedAt=datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
                 activationKey="test-key",
-                licenseKey="test-license",
+                licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
             ),
         )
 
@@ -137,7 +137,7 @@ class TestGetMyUser:
             license=UserLicense(
                 activatedAt=datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
                 activationKey="test-key",
-                licenseKey="test-license",
+                licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
             ),
         )
 

--- a/tests/unit/utils/test_asset_conversion.py
+++ b/tests/unit/utils/test_asset_conversion.py
@@ -385,7 +385,7 @@ class TestDimensionEmission:
             sample_gumnut_asset, orientation=6, raw_width=4032, raw_height=2268
         )
 
-        result = extract_sync_exif(sample_gumnut_asset, asset_uuid="x")
+        result = extract_sync_exif(sample_gumnut_asset, asset_uuid=str(uuid4()))
 
         assert result.exifImageWidth == 4032
         assert result.exifImageHeight == 2268
@@ -398,7 +398,7 @@ class TestDimensionEmission:
             sample_gumnut_asset, orientation=6, raw_width=None, raw_height=None
         )
 
-        result = extract_sync_exif(sample_gumnut_asset, asset_uuid="x")
+        result = extract_sync_exif(sample_gumnut_asset, asset_uuid=str(uuid4()))
 
         assert result.exifImageWidth == 2268
         assert result.exifImageHeight == 4032
@@ -417,7 +417,7 @@ class TestDimensionEmission:
         sample_gumnut_asset.height = 1080
         sample_gumnut_asset.metadata = None
 
-        result = extract_sync_exif(sample_gumnut_asset, asset_uuid="x")
+        result = extract_sync_exif(sample_gumnut_asset, asset_uuid=str(uuid4()))
 
         assert result.exifImageWidth == 1920
         assert result.exifImageHeight == 1080
@@ -454,7 +454,7 @@ class TestDimensionEmission:
         sample_gumnut_asset.height = 1080
         _attach_metadata(sample_gumnut_asset, orientation=6, raw_width=0, raw_height=0)
 
-        sync_result = extract_sync_exif(sample_gumnut_asset, asset_uuid="x")
+        sync_result = extract_sync_exif(sample_gumnut_asset, asset_uuid=str(uuid4()))
         assert sync_result.exifImageWidth == 1920
         assert sync_result.exifImageHeight == 1080
         assert sync_result.orientation is None
@@ -475,7 +475,7 @@ class TestDimensionEmission:
             sample_gumnut_asset, orientation=None, raw_width=0, raw_height=0
         )
 
-        sync_result = extract_sync_exif(sample_gumnut_asset, asset_uuid="x")
+        sync_result = extract_sync_exif(sample_gumnut_asset, asset_uuid=str(uuid4()))
         assert sync_result.exifImageWidth is None
         assert sync_result.exifImageHeight is None
         assert sync_result.orientation is None

--- a/tests/unit/utils/test_current_user.py
+++ b/tests/unit/utils/test_current_user.py
@@ -7,6 +7,7 @@ from uuid import UUID, uuid4
 from datetime import datetime, timezone
 
 
+from routers.api.constants import STUB_LICENSE_KEY
 from routers.utils.current_user import (
     get_current_user_admin,
     get_current_user,
@@ -276,7 +277,7 @@ class TestGetCurrentUser:
             license=UserLicense(
                 activatedAt=now,
                 activationKey="key123",
-                licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
+                licenseKey=STUB_LICENSE_KEY,
             ),
         )
 
@@ -322,7 +323,7 @@ class TestGetCurrentUserId:
             license=UserLicense(
                 activatedAt=now,
                 activationKey="key123",
-                licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
+                licenseKey=STUB_LICENSE_KEY,
             ),
         )
 

--- a/tests/unit/utils/test_current_user.py
+++ b/tests/unit/utils/test_current_user.py
@@ -53,7 +53,7 @@ class TestGetCurrentUserAdmin:
 
         # Assert
         assert isinstance(result, UserAdminResponseDto)
-        assert result.id == str(test_uuid)
+        assert result.id == test_uuid
         assert result.email == "test@example.com"
         assert result.name == "Test User"
         assert result.isAdmin is False
@@ -276,7 +276,7 @@ class TestGetCurrentUser:
             license=UserLicense(
                 activatedAt=now,
                 activationKey="key123",
-                licenseKey="license123",
+                licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
             ),
         )
 
@@ -322,7 +322,7 @@ class TestGetCurrentUserId:
             license=UserLicense(
                 activatedAt=now,
                 activationKey="key123",
-                licenseKey="license123",
+                licenseKey="IMSV-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA-AAAA",
             ),
         )
 


### PR DESCRIPTION
## What
- Adapts tests to the regenerated v3 models — ids typed `UUID`, stricter `AwareDatetime` and pattern validation: UUID-vs-str assertion updates, license fixtures using the shared stub constant, real `created_at` datetimes in sync mocks (`SyncAssetV1` gained a required `createdAt`), valid UUIDs replacing sentinel id strings, and a `RandomSearchDto` rating fixture bumped to the new `ge=1` floor (16 test files). New pinned tests: `minFaces == 3`, `SyncAssetV1.createdAt` mapping (distinct sentinel), `realtimeTranscoding` in the unimplemented-flags tuple.
- Fixes the real production defects the newly-collecting suite exposed:
  - `album_conversion.py` — `albumThumbnailAssetId` used `""` as the no-cover sentinel; v3 types it `UUID | None`, so every coverless album failed response validation. Emit `None`.
  - `server.py` — supply newly required fields: `ServerVersionResponseDto.prerelease`, `ServerConfigDto.minFaces`, `ServerFeaturesDto.realtimeTranscoding`.
  - `oauth.py` — `LoginResponseDto.userId` received the raw Gumnut user id; route it through the existing `safe_uuid_from_user_id` conversion.
  - `people.py` — bulk people update double-wrapped an already-`UUID` id (`UUID(UUID(...))` → `AttributeError`), crashing every `PUT /api/people`; malformed ids are now rejected with 422 at the DTO boundary, and the unreachable `ValueError` branch is removed.
  - **License stubs** — keys failing v3's `UserLicense` pattern 500ed their endpoints; now a shared `STUB_LICENSE_KEY` in `routers/api/constants.py` (carrying the pattern rationale) used at all 11 production sites.
  - **Stub id literals** — non-UUID string ids in stub endpoints (`admin`, `tags`, `activities`, `libraries`, `memories`, `api_keys`, `stacks` incl. `primaryAssetId`) were latent 500s under v3 response validation; replaced with `uuid4()` (11 sites, enumerated via pyright's literal-assignment errors).
  - `current_user.py` — `get_current_user_id` double-wrapped the now-`UUID` `UserAdminResponseDto.id`; dead `str()` wraps dropped at two UUID construction sites.
- Documents the post-regeneration pyright sweep in `docs/references/development-tools.md`.

## Why
- These failures were pre-existing v3 residue, masked until the app could import and the suite could collect (unblocked by the previous integration-branch PRs). Several were real user-facing crashes under v3 — coverless albums, bulk people updates, and every stub endpoint returning a literal that the regenerated models now reject.
- The generated v3 models are kept strict throughout: no `UUID`/`AwareDatetime` typing or pattern was weakened; tests were adapted to the contract and production call sites fixed to honor it.
- This PR merges to `migration/immichv3`, not `main` — it is part of the Immich v3 retarget; the integration branch merges to `main` when the whole migration lands.

## Known verification item (deliberately unchanged)
- Three sites fall back to `""` for a missing user email and now feed `EmailStr`-typed fields (`oauth.py` login, `current_user.py`, `users.py`). Accounts are Clerk-backed, so a null email is assumed impossible; if that assumption ever breaks, these 500 loudly. Decision: leave as-is this PR, verify the upstream guarantee separately.

## Follow-up candidates (pre-existing, untouched)
- `jobs.py` / `system_config.py` have the missing-required-field family of latent 500s (visible in the pyright backlog) — same residue-burndown series, separate change.

## Test plan
- [x] `uv run pytest` — **1125 passed / 0 failed** (was 147 failed / 976 passed)
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `uv run pyright` — 116 errors vs. 155 on base: 39 fixed, zero new (list-diffed against base)
- [x] Untested stub endpoints smoke-tested via TestClient (`GET /api/server/license`, `GET /api/stacks/{id}` → 200; both previously 500)
- [x] Two independent review passes (pre-PR + two self-review iterations this round); all findings fixed or explicitly adjudicated

Generated by an AI coding agent.