### PR TITLE
Add v3 createdAt array to timeline bucket response

### DIFF
--- a/routers/api/timeline.py
+++ b/routers/api/timeline.py
@@ -17,6 +17,7 @@ from routers.utils.asset_conversion import (
     duration_ms,
     mime_type_to_asset_type,
     resolve_capture_datetime,
+    resolve_created_at,
 )
 from routers.utils.current_user import get_current_user_id
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
@@ -207,6 +208,11 @@ async def get_time_bucket(
     asset_count = len(filtered_assets)
 
     asset_ids = []
+    created_at_list = []  # Upload timestamps (actual UTC)
+    # Capture timestamps, currently emitted as wall-clock local time. Immich v3
+    # expects actual UTC here (clients derive local time by adding
+    # localOffsetHours), so known-timezone captures display shifted — a known
+    # gap, fixed separately from the createdAt addition.
     file_created_at_list = []
     is_image_list = []
     ratio_list = []
@@ -218,12 +224,12 @@ async def get_time_bucket(
 
     for asset in filtered_assets:
         asset_id = asset.id
-        created_at = resolve_capture_datetime(asset)
+        captured_at = resolve_capture_datetime(asset)
         aspect_ratio = (
             asset.width / asset.height if asset.width and asset.height else 1.0
         )
-        utc_offset = created_at.utcoffset()
-        if created_at.tzinfo and utc_offset is not None:
+        utc_offset = captured_at.utcoffset()
+        if captured_at.tzinfo and utc_offset is not None:
             local_datetime_offset = int(utc_offset.total_seconds() / 3600)
         else:
             local_datetime_offset = 0
@@ -232,7 +238,10 @@ async def get_time_bucket(
 
         # Immich's TimeBucketAssetResponseDto needs ISO 8601 without timezone
         # and exactly 3 digits of milliseconds (e.g., "2023-10-05T09:41:00.123").
-        file_created_at_list.append(created_at.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3])
+        created_at_list.append(
+            resolve_created_at(asset).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
+        )
+        file_created_at_list.append(captured_at.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3])
 
         is_image_list.append(
             mime_type_to_asset_type(asset.mime_type) == AssetTypeEnum.IMAGE
@@ -261,20 +270,21 @@ async def get_time_bucket(
     return {
         "city": [None] * asset_count,
         "country": [None] * asset_count,
+        "createdAt": created_at_list,
         "duration": duration_list,
-        "livePhotoVideoId": [None] * asset_count,
-        "projectionType": [None] * asset_count,
-        "id": asset_ids,
         "fileCreatedAt": file_created_at_list,
-        "isImage": is_image_list,
-        "ratio": ratio_list,
-        "visibility": visibility_list,
-        "localOffsetHours": local_offset_hours_list,
+        "id": asset_ids,
         "isFavorite": [False] * asset_count,
+        "isImage": is_image_list,
         "isTrashed": is_trashed_list,
-        "ownerId": [str(current_user_id)] * asset_count,
-        "thumbhash": thumbhash_list,
         "latitude": [None] * asset_count,
+        "livePhotoVideoId": [None] * asset_count,
+        "localOffsetHours": local_offset_hours_list,
         "longitude": [None] * asset_count,
+        "ownerId": [str(current_user_id)] * asset_count,
+        "projectionType": [None] * asset_count,
+        "ratio": ratio_list,
         "stack": [None] * asset_count,
+        "thumbhash": thumbhash_list,
+        "visibility": visibility_list,
     }

--- a/routers/utils/asset_conversion.py
+++ b/routers/utils/asset_conversion.py
@@ -158,6 +158,11 @@ def resolve_file_created_at(gumnut_asset: AssetResponse) -> datetime:
     return to_actual_utc(resolve_capture_datetime(gumnut_asset))
 
 
+def resolve_created_at(gumnut_asset: AssetResponse) -> datetime:
+    """Return the Gumnut upload time (``created_at``) formatted for Immich ``createdAt`` fields."""
+    return to_actual_utc(gumnut_asset.created_at)
+
+
 def resolve_local_date_time(gumnut_asset: AssetResponse) -> datetime:
     """Return capture time formatted for Immich ``localDateTime`` fields."""
     return to_immich_local_datetime(resolve_capture_datetime(gumnut_asset))

--- a/tests/unit/api/test_timeline.py
+++ b/tests/unit/api/test_timeline.py
@@ -498,6 +498,11 @@ class TestGetTimeBucket:
             assert result["fileCreatedAt"][0] == "2024-01-15T10:00:00.000"
             assert result["fileCreatedAt"][1] == "2024-01-25T16:00:00.000"
 
+            # createdAt is the upload time converted to actual UTC, unlike
+            # fileCreatedAt which keeps the capture wall-clock time.
+            assert result["createdAt"][0] == "2024-01-15T15:00:00.000"
+            assert result["createdAt"][1] == "2024-01-25T14:00:00.000"
+
             assert all(fav is False for fav in result["isFavorite"])
             assert all(trash is False for trash in result["isTrashed"])
             assert all(vis == AssetVisibility.timeline for vis in result["visibility"])
@@ -733,7 +738,7 @@ class TestGetTimeBucket:
         mock_asset = Mock()
         mock_asset.id = uuid_to_gumnut_asset_id(uuid4())
         mock_asset.local_datetime = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
-        mock_asset.created_at = None
+        mock_asset.created_at = mock_asset.local_datetime
         mock_asset.mime_type = ""
         mock_asset.width = None
         mock_asset.height = None


### PR DESCRIPTION
## Summary

Immich v3's `TimeBucketAssetResponseDto` requires a `createdAt` array — "Array of UTC timestamps when each asset was originally uploaded" — which the adapter previously omitted from `GET /api/timeline/bucket`. This PR populates it.

## Changes

- **`routers/utils/asset_conversion.py`**: new `resolve_created_at` helper alongside the existing capture-time resolvers. It maps the Gumnut asset's `created_at` (upload time) through `to_actual_utc`, matching the semantics of the upstream Immich server, which emits this field as the actual-UTC upload instant.
- **`routers/api/timeline.py`**: `get_time_bucket` builds and returns the `createdAt` array, formatted like the other bucket timestamp arrays (ISO 8601, no timezone suffix, exactly 3 digits of milliseconds). The loop's `created_at` variable is renamed to `captured_at` now that two different timestamps flow through it.
- **`tests/unit/api/test_timeline.py`**: `test_get_time_bucket_success` pins the new field, including the UTC conversion (`createdAt` is the actual-UTC instant, distinct from `fileCreatedAt`'s wall-clock convention — a `-05:00` capture asserts `15:00` upload vs `10:00` capture). The missing-attributes test mock now carries a real `created_at`, since the Gumnut SDK declares the field non-nullable.

## Out of scope, documented

While verifying the new field against upstream, we found that the bucket's pre-existing `fileCreatedAt` emits capture wall-clock time where Immich v3 expects actual UTC (v3 clients reconstruct display time as `fileCreatedAt + localOffsetHours`, so known-timezone captures display shifted). That bug and the related fractional-offset truncation in `localOffsetHours` predate this change and are tracked separately; this PR adds a code comment marking the gap so the correct UTC handling on the adjacent `createdAt` lines doesn't read as an inconsistency.

## Testing

- `uv run pytest` — 1125 passed
- `uv run ruff check` / `uv run ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)