### PR TITLE
docs: prune evergreen reference docs

### DIFF
--- a/docs/references/immich-sync-communication.md
+++ b/docs/references/immich-sync-communication.md
@@ -1,6 +1,6 @@
 ---
 title: "Immich Client<>Server Sync Communication"
-last-updated: 2026-06-05
+last-updated: 2026-07-12
 ---
 
 # Immich Client<>Server Sync Communication
@@ -58,7 +58,7 @@ The response is 275 lines and 140KB. Here is a subset:
 {"type":"AssetExifV1","data":{"assetId":"ec6cadf9-dc8a-40ce-b6e7-c3f6df2827cf","description":"","exifImageWidth":1600,"exifImageHeight":1066,"fileSizeInByte":251102,"orientation":null,"dateTimeOriginal":"2025-01-31T00:02:00.430Z","modifyDate":"2025-04-14T21:13:43.787Z","timeZone":"UTC-7","latitude":null,"longitude":null,"projectionType":null,"city":null,"state":null,"country":null,"make":"NIKON CORPORATION","model":"NIKON Z 8","lensModel":"NIKKOR Z 180-600mm f/5.6-6.3 VR","fNumber":6.3,"focalLength":600,"iso":125,"exposureTime":"1/500","profileDescription":"sRGB IEC61966-2.1","rating":null,"fps":null},"ack":"AssetExifV1|01994f97-f030-749f-8d14-7aa4d5bbb92b"}
 [...]
 {"type":"SyncAckV1","data":{},"ack":"AlbumAssetExifUpdateV1|019adb7b-eaef-7a5f-a073-a5e2331de138"}
-{"type":"AlbumAssetExifCreateV1","data":{"assetId":"ec6cadf9-dc8a-40ce-b6e7-c3f6df2827cf","description":"","exifImageWidth":1600,"exifImageHeight":1066,"fileSizeInByte":251102,"orientation":null,"dateTimeOriginal":"2025-01-31T00:02:00.430Z","modifyDate":"2025-04-14T21:13:43.787Z","timeZone":"UTC-7","latitude":null,"longitude":null,"projectionType":null,"city":null,"state":null,"country":null,"make":"NIKON CORPORATION","model":"NIKON Z 8","lensModel":"NIKKOR Z 180-600mm f/5.6-6.3 VR","fNumber":6.3,"focalLength":600,"iso":125,"exposureTime":"1/500","profileDescription":"sRGB IEC61966-2.1","rating":null,"fps":null},"ack":"AlbumAssetExifCreateV1|01994f98-b16c-703e-8b61-959cb9c3ee76"}
+{"type":"AlbumAssetExifCreateV1","data":{"assetId":"ec6cadf9-dc8a-40ce-b6e7-c3f6df2827cf",[...]},"ack":"AlbumAssetExifCreateV1|01994f98-b16c-703e-8b61-959cb9c3ee76"}
 [...]
 {"type":"MemoryDeleteV1","data":{"memoryId":"f0fecdc5-a3da-466a-9757-b5e106a69f40"},"ack":"MemoryDeleteV1|019ac453-886e-7f05-adba-44ca13ad94c5"}
 {"type":"MemoryV1","data":{"id":"3d3cd24d-4cd2-47e3-9843-325a990ed43c","createdAt":"2025-11-25T08:00:00.165Z","updatedAt":"2025-11-25T08:00:00.165Z","deletedAt":null,"ownerId":"5ccc983a-db97-4f49-b29b-a832f1d3d2b5","type":"on_this_day","data":{"year":2017},"isSaved":false,"memoryAt":"2017-11-28T00:00:00.000Z","seenAt":null,"showAt":"2025-11-28T00:00:00.000Z","hideAt":"2025-11-28T23:59:59.999Z"},"ack":"MemoryV1|019aba06-d0a7-7c88-989f-38bfe4bbc5c3"}
@@ -72,34 +72,7 @@ The response is 275 lines and 140KB. Here is a subset:
 
 The entities are roughly ordered by `SyncRequestType`, though each `SyncRequestType` has its own handler which determines the actual order of the entities it emits. Entities are not globally ordered by the UUID v7 time-ordered `updateId`.
 
-The detail for the first AssetV1 entity:
-
-```json
-{
-    "type": "AssetV1",
-    "data": {
-        "id": "bb90997e-7dc0-4398-a401-d40f791e4ef2",
-        "ownerId": "5ccc983a-db97-4f49-b29b-a832f1d3d2b5",
-        "originalFileName": "DSC_0982.jpg",
-        "fileCreatedAt": "2025-01-30T00:13:07.230Z",
-        "fileModifiedAt": "2025-01-30T04:18:36.290Z",
-        "localDateTime": "2025-01-29T16:13:07.230Z",
-        "type": "IMAGE",
-        "deletedAt": null,
-        "isFavorite": false,
-        "visibility": "timeline",
-        "duration": null,
-        "livePhotoVideoId": null,
-        "stackId": null,
-        "libraryId": null,
-        "checksum": "vCbD4DZ3BqQibzmnh3qO1uEpLBA=",
-        "thumbhash": "lbYFDQLUmHaHWIeIeJ90qAh4ioCn"
-    },
-    "ack": "AssetV1|01994f97-f1fd-7d4f-ab66-c5624fe665d7"
-}
-```
-
-It contains just the details of the asset. EXIF comes later in a `AssetExifV1` record. Note that there is no binary image - the client retrieves the thumbnail a bit later as we'll see below.
+The `AssetV1` record shown compact above contains just the details of the asset. EXIF comes later in a `AssetExifV1` record. Note that there is no binary image - the client retrieves the thumbnail a bit later as we'll see below.
 
 ## The Full Initial Conversation
 
@@ -114,16 +87,7 @@ This is the complete set of requests starting with the call to `/sync/stream`:
 | /api/sync/ack | POST | AlbumAssetUpdateV1 |
 | /api/assets/0c56b89c-e87a-4f95-bead-4424b8413207/thumbnail | GET | WEBP image thumbnail |
 | /api/assets/3df1f6a0-8a01-4ff8-9f02-d7c3d3de8618/thumbnail | GET | WEBP image thumbnail |
-| /api/assets/7b5d073c-1304-4082-9ed3-030a1b2bbbae/thumbnail | GET | WEBP image thumbnail |
-| /api/assets/d687118b-eed6-4a49-a0c5-1b42d3df872e/thumbnail | GET | WEBP image thumbnail |
-| /api/assets/028e983d-3353-47df-82ff-4f83de672dc7/thumbnail | GET | WEBP image thumbnail |
-| /api/assets/e526140d-48bc-4772-9107-5b7cc17f24f0/thumbnail | GET | WEBP image thumbnail |
-| /api/assets/1fe1616c-4803-490f-851c-bd7875195625/thumbnail | GET | WEBP image thumbnail |
-| /api/assets/ec6cadf9-dc8a-40ce-b6e7-c3f6df2827cf/thumbnail | GET | WEBP image thumbnail |
-| /api/assets/37cf2ca5-13cf-4aa6-91dc-e8e911b0fd56/thumbnail | GET | WEBP image thumbnail |
-| /api/assets/bb90997e-7dc0-4398-a401-d40f791e4ef2/thumbnail | GET | WEBP image thumbnail |
-| /api/assets/02b7e3e3-5d89-4564-9908-902908ea998a/thumbnail | GET | WEBP image thumbnail |
-| /api/assets/f8e63cec-6673-4e87-85fe-0ae96d9eca10/thumbnail | GET | WEBP image thumbnail |
+| … (further thumbnail GETs, one per displayed asset) | GET | WEBP image thumbnail |
 | /api/sync/ack | POST | AlbumAssetCreateV1 |
 | /api/sync/ack | POST | AlbumV1 |
 | /api/sync/ack | POST | AlbumToAssetV1 |
@@ -160,7 +124,7 @@ A new image was added via the Immich web client, and then the mobile client was 
 {"type":"AuthUserV1","data":{"id":"5ccc983a-db97-4f49-b29b-a832f1d3d2b5","name":"Example User","email":"user@example.com","avatarColor":null,"deletedAt":null,"profileChangedAt":"2025-09-15T22:55:19.045Z","isAdmin":true,"pinCode":null,"oauthId":"","storageLabel":"admin","quotaSizeInBytes":null,"quotaUsageInBytes":83212978,"hasProfileImage":false},"ack":"AuthUserV1|019adc6a-abb8-7191-af07-f65f5e5bd628"}
 {"type":"UserV1","data":{"id":"5ccc983a-db97-4f49-b29b-a832f1d3d2b5","name":"Example User","email":"user@example.com","avatarColor":null,"deletedAt":null,"profileChangedAt":"2025-09-15T22:55:19.045Z","hasProfileImage":false},"ack":"UserV1|019adc6a-abb8-7191-af07-f65f5e5bd628"}
 {"type":"AssetV1","data":{"id":"1ee6d743-54fd-43de-9164-b99fb18caf36","ownerId":"5ccc983a-db97-4f49-b29b-a832f1d3d2b5","originalFileName":"DSC_8766.jpg","fileCreatedAt":"2010-10-08T22:16:30.900Z","fileModifiedAt":"2025-09-17T02:41:46.000Z","localDateTime":"2010-10-08T15:16:30.900Z","type":"IMAGE","deletedAt":null,"isFavorite":false,"visibility":"timeline","duration":null,"livePhotoVideoId":null,"stackId":null,"libraryId":null,"checksum":"1HHXeKxJMUSpQsIvJJVdZuBOm+0=","thumbhash":"XoUJHoT4t0mGl0iMdnR2uFiYCHaDgDc="},"ack":"AssetV1|019adc6a-af34-73d3-ad9d-6e7622d7f211"}
-{"type":"AssetExifV1","data":{"assetId":"1ee6d743-54fd-43de-9164-b99fb18caf36","description":"","exifImageWidth":2400,"exifImageHeight":1920,"fileSizeInByte":1058587,"orientation":null,"dateTimeOriginal":"2010-10-08T22:16:30.900Z","modifyDate":"2025-09-17T02:41:46.000Z","timeZone":"UTC-7","latitude":null,"longitude":null,"projectionType":null,"city":null,"state":null,"country":null,"make":"NIKON CORPORATION","model":"NIKON D60","lensModel":"AF-S Nikkor 300mm f/4D IF-ED","fNumber":4,"focalLength":300,"iso":110,"exposureTime":"1/1000","profileDescription":"sRGB IEC61966-2.1","rating":5,"fps":null},"ack":"AssetExifV1|019adc6a-ad2b-7813-bc0a-6e2f059fcd60"}
+{"type":"AssetExifV1","data":{"assetId":"1ee6d743-54fd-43de-9164-b99fb18caf36",[...]},"ack":"AssetExifV1|019adc6a-ad2b-7813-bc0a-6e2f059fcd60"}
 {"type":"SyncCompleteV1","data":{},"ack":"SyncCompleteV1|019adc6c-3ba4-7f57-a7e0-9b67da6b27d3"}
 ```
 
@@ -185,7 +149,7 @@ When an asset is added to an existing album, the `/api/sync/stream` response car
 {"type":"AlbumV1","data":{"id":"0142f336-3ae4-4b33-bafd-31442ae5e835","ownerId":"5ccc983a-db97-4f49-b29b-a832f1d3d2b5","name":"Fleet Week","description":"","createdAt":"2025-12-01T23:15:52.074Z","updatedAt":"2025-12-02T00:27:12.552Z","thumbnailAssetId":"4eb5665e-1cd3-4da0-82b4-e989061d2692","isActivityEnabled":true,"order":"desc"},"ack":"AlbumV1|019adc74-c928-779f-8c84-8ae4aa40943a"}
 {"type":"AlbumToAssetV1","data":{"assetId":"1ee6d743-54fd-43de-9164-b99fb18caf36","albumId":"0142f336-3ae4-4b33-bafd-31442ae5e835"},"ack":"AlbumToAssetV1|019adc74-c908-70c5-908c-e71c68e4a396"}
 {"type":"SyncAckV1","data":{},"ack":"AlbumAssetExifUpdateV1|019adc74-ea58-751b-9139-1054075c249a"}
-{"type":"AlbumAssetExifCreateV1","data":{"assetId":"1ee6d743-54fd-43de-9164-b99fb18caf36","description":"","exifImageWidth":2400,"exifImageHeight":1920,"fileSizeInByte":1058587,"orientation":null,"dateTimeOriginal":"2010-10-08T22:16:30.900Z","modifyDate":"2025-09-17T02:41:46.000Z","timeZone":"UTC-7","latitude":null,"longitude":null,"projectionType":null,"city":null,"state":null,"country":null,"make":"NIKON CORPORATION","model":"NIKON D60","lensModel":"AF-S Nikkor 300mm f/4D IF-ED","fNumber":4,"focalLength":300,"iso":110,"exposureTime":"1/1000","profileDescription":"sRGB IEC61966-2.1","rating":5,"fps":null},"ack":"AlbumAssetExifCreateV1|019adc74-c908-70c5-908c-e71c68e4a396"}
+{"type":"AlbumAssetExifCreateV1","data":{"assetId":"1ee6d743-54fd-43de-9164-b99fb18caf36",[...]},"ack":"AlbumAssetExifCreateV1|019adc74-c908-70c5-908c-e71c68e4a396"}
 {"type":"SyncCompleteV1","data":{},"ack":"SyncCompleteV1|019adc74-ea58-751b-9139-1054075c249a"}
 ```
 

--- a/docs/references/session-checkpoint-reference.md
+++ b/docs/references/session-checkpoint-reference.md
@@ -1,13 +1,9 @@
 ---
 title: "Session & Checkpoint Object Reference"
-last-updated: 2026-06-05
+last-updated: 2026-07-12
 ---
 
 # Session & Checkpoint Object Reference
-
-This document describes the Redis data model for Session and Checkpoint objects in immich-adapter.
-
----
 
 ## Redis Data Model
 
@@ -106,19 +102,7 @@ Contains all session UUIDs belonging to a user. Enables efficient lookup of all 
 **Key:** `session:{uuid}:checkpoints`
 **Type:** Hash
 
-Each field is an entity type, and the value is a pipe-delimited string:
-
-```text
-{last_synced_at}|{updated_at}
-```
-
-**Example:**
-
-```text
-AssetV1: "2025-01-20T10:30:45.123456+00:00|2025-01-20T10:30:45+00:00"
-```
-
-Both timestamps are fixed ISO 8601 format, so the value is split on the single `|` rather than carrying a JSON wrapper.
+Each field is an entity type, and the value is a pipe-delimited `{last_synced_at}|{updated_at}` string (see the [Key Schema](#key-schema) for an example). Both timestamps are fixed ISO 8601 format, so the value is split on the single `|` rather than carrying a JSON wrapper.
 
 **Why checkpoints are tied to sessions:**
 
@@ -126,8 +110,6 @@ Both timestamps are fixed ISO 8601 format, so the value is split on the single `
 - When a session is deleted, its checkpoints are also deleted
 - Client must re-sync from scratch if session is revoked
 - Because the session UUID is stable across JWT refresh (see [Session Token Architecture](#session-token-architecture)), checkpoints survive token refreshes
-
-### Checkpoint Fields
 
 ### `last_synced_at` (First Component)
 
@@ -157,11 +139,6 @@ last_synced_at, updated_at = checkpoint_value.split("|")
 - **Monitoring** - Alert if a session stops syncing
 
 **How it's used:** `cleanup_stale_sessions` (in `services/session_store.py`) range-queries `sessions:by_updated_at` (a sorted set scored by `updated_at`) for sessions whose score is older than its `days` threshold, then deletes each stale session and its associated data.
-
-**Difference from `last_synced_at`:**
-
-- `last_synced_at`: "Client processed data up to this time"
-- `updated_at`: "We received this checkpoint at this time"
 
 ---
 

--- a/docs/references/websocket-events-reference.md
+++ b/docs/references/websocket-events-reference.md
@@ -1,11 +1,9 @@
 ---
 title: "Immich WebSocket Events Reference"
-last-updated: 2026-06-05
+last-updated: 2026-07-12
 ---
 
 # Immich WebSocket Events Reference
-
-This document describes the WebSocket events emitted by the Immich server and how clients handle them.
 
 ## Summary Table
 
@@ -37,7 +35,7 @@ This document describes the WebSocket events emitted by the Immich server and ho
 
 **Adapter trigger**:
 - **Images**: emitted synchronously from the upload handler. Image variants (`thumbnail`, `preview`, `fullsize`) are CDN-resized URLs to the same uploaded file, so they're available the moment the upload write completes.
-- **Videos**: emission is **deferred** by `_VIDEO_EMIT_DELAY_SECONDS` (3.0s, defined in `routers/api/assets.py`) via a detached `asyncio.create_task`. Video still-image variants (`thumbnail_image`, `preview_image`, `fullsize_image`) live at a separate `derived_path` that only exists after the Gumnut API's ffmpeg extraction finishes — without the delay, the Immich web client receives `on_upload_success`, inserts the asset into the timeline grid, then renders "Error loading image" because the thumbnail URL still 404s. The HTTP `POST /api/assets` 201 response is **not** delayed; only the WebSocket emission waits.
+- **Videos**: emission is **deferred** by `_VIDEO_EMIT_DELAY_SECONDS` (defined in `routers/api/assets.py`) via a detached `asyncio.create_task`. Video still-image variants (`thumbnail_image`, `preview_image`, `fullsize_image`) live at a separate `derived_path` that only exists after the Gumnut API's ffmpeg extraction finishes — without the delay, the Immich web client receives `on_upload_success`, inserts the asset into the timeline grid, then renders "Error loading image" because the thumbnail URL still 404s. The HTTP `POST /api/assets` 201 response is **not** delayed; only the WebSocket emission waits.
 
 **Sent to**: Asset owner (by userId)
 **Payload**: Full `AssetResponseDto` (see `routers/immich_models.py`)
@@ -70,37 +68,25 @@ This document describes the WebSocket events emitted by the Immich server and ho
 
 ### `on_asset_delete`
 
-**Trigger**: Emitted when asset is permanently deleted (`notification.service.ts`).
 **Sent to**: Asset owner (by userId)
-**Payload**: `assetId: string`
 
-**Client handling**:
-- **Web**: Global listener
-- **Mobile**: Listener, triggers sync
+Otherwise as in the Summary Table; emitted from `notification.service.ts`, and the mobile listener triggers a sync.
 
 ---
 
 ### `on_asset_trash`
 
-**Trigger**: Emitted when asset(s) moved to trash (`notification.service.ts`).
 **Sent to**: Asset owner (by userId)
-**Payload**: `assetIds: string[]`
 
-**Client handling**:
-- **Web**: Global listener
-- **Mobile**: Listener, triggers sync
+Otherwise as in the Summary Table; emitted from `notification.service.ts`, and the mobile listener triggers a sync.
 
 ---
 
 ### `on_asset_restore`
 
-**Trigger**: Emitted when asset(s) restored from trash (`notification.service.ts`).
 **Sent to**: Asset owner (by userId)
-**Payload**: `assetIds: string[]`
 
-**Client handling**:
-- **Web**: Global listener
-- **Mobile**: Listener, triggers sync
+Otherwise as in the Summary Table; emitted from `notification.service.ts`, and the mobile listener triggers a sync.
 
 ---
 
@@ -123,13 +109,9 @@ This document describes the WebSocket events emitted by the Immich server and ho
 
 ### `on_asset_stack_update`
 
-**Trigger**: Emitted when stack is created, updated, or deleted (`notification.service.ts`).
 **Sent to**: Stack owner (by userId)
-**Payload**: None (empty)
 
-**Client handling**:
-- **Web**: Global listener
-- **Mobile**: Listener, triggers sync
+Otherwise as in the Summary Table; emitted from `notification.service.ts`, and the mobile listener triggers a sync.
 
 ---
 
@@ -206,13 +188,9 @@ When received, the client updates `person.updatedAt` to force the browser to fet
 
 ### `on_config_update`
 
-**Trigger**: Emitted when admin updates system configuration (`notification.service.ts`).
 **Sent to**: All connected clients (broadcast)
-**Payload**: None (empty)
 
-**Client handling**:
-- **Web**: Global listener
-- **Mobile**: Listener
+Otherwise as in the Summary Table; emitted from `notification.service.ts`.
 
 ---
 
@@ -230,29 +208,23 @@ When received, the client updates `person.updatedAt` to force the browser to fet
 
 ### `on_server_version`
 
-**Trigger**: Sent on WebSocket connection establishment.
 **Sent to**: Connecting client
-**Payload**: `ServerVersionResponseDto`
 
-**Client handling**:
-- **Web**: Global listener. Updates `websocketStore.serverVersion`.
+Otherwise as in the Summary Table; sent on WebSocket connection establishment, and the web listener updates `websocketStore.serverVersion`.
 
 ---
 
 ### `on_user_delete`
 
-**Trigger**: Emitted when user account is deleted (`notification.service.ts`).
 **Sent to**: All connected clients (broadcast)
-**Payload**: `userId: string`
 
-**Client handling**:
-- **Web**: Global listener
+Otherwise as in the Summary Table; emitted from `notification.service.ts`.
 
 ---
 
 ## Client Event Registration
 
-Per-event subscriptions are listed in each event's "Client handling" subsection and in the Summary Table's Web/Mobile columns. The grouping below covers only the registration distinctions not visible there.
+Per-event subscriptions are listed in the Summary Table's Web/Mobile columns and, for events with a detailed section, that event's "Client handling" subsection. The grouping below covers only the registration distinctions not visible there.
 
 ### Web Client (`websocket.ts`)
 


### PR DESCRIPTION
## Summary

Prunes low-signal content from **three evergreen reference docs** using the `prune-reference-docs` skill — keeping codebase-specific protocol shapes, gotchas, and grounded rationale. Net **−87 lines**; editorial only, and **PII redaction in captured payloads preserved**.

Part of a whole-dev-root reference-docs prune (the companion PR prunes 9 docs in the photos repo).

## Per-file cuts

| File | Cut |
|---|---|
| `session-checkpoint-reference.md` | Consolidate the Redis schema restated across the Key Schema block, field table, and value format; drop scaffolding opener + double heading |
| `immich-sync-communication.md` | Remove a duplicated pretty-printed `AssetV1` payload; truncate repeated `AssetExifV1` blobs to `[...]`; trim 12 near-identical thumbnail-GET rows to a couple + ellipsis |
| `websocket-events-reference.md` | Thin per-event Detail sections that only restated the Summary Table; drop the `3.0s` literal (keep the `routers/api/assets.py` pointer) |

## Verification

- `_VIDEO_EMIT_DELAY_SECONDS` value verified in `routers/api/assets.py` before dropping the `3.0s` literal.
- PII redaction (`Example User` / `user@example.com`) preserved in all captured wire payloads.
- `last-updated` bumped on all 3; no dangling anchors; Documentation Map "Consult when…" descriptions still accurate.

Companion PR (photos reference docs): https://github.com/gumnut-ai/photos/pull/1274

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXYQ4RLPYmqTLdFDNrD5yF
