### PR TITLE
Add album map-markers endpoint (Immich v3)

### DIFF
--- a/docs/design-docs/immich-adapter-gap-analysis.md
+++ b/docs/design-docs/immich-adapter-gap-analysis.md
@@ -2,7 +2,7 @@
 title: "Immich Adapter Gap Analysis"
 status: active
 created: 2026-04-15
-last-updated: 2026-07-07
+last-updated: 2026-07-13
 ---
 
 # Immich Adapter Gap Analysis

--- a/docs/design-docs/immich-adapter-gap-analysis.md
+++ b/docs/design-docs/immich-adapter-gap-analysis.md
@@ -708,17 +708,19 @@ echoing the requested window so the client's date parse stays valid; an empty
 
 **Albums — map markers** — `GET /albums/{id}/map-markers`. New in v3; the global
 `GET /map/markers` dropped its `albumIds` filter, so the v3 web album page calls
-this album-scoped endpoint on every album open. The current 404 produces a
-console error and a user-visible "Something went wrong" toast on a high-traffic
-screen (the album still renders). The existing `/api/map/markers` implementation
-(gap #3a) is directly reusable — the Gumnut client accepts `album_id` and a world
-`bbox` together — so a faithful implementation costs only a few lines more than a
-`[]` stub and is strictly better (real pins vs. a permanently empty map).
-**Implement** (adapter-only, effort S); tracked as separate implementation work.
+this album-scoped endpoint on every album open. Its 404 produced a console error
+and a user-visible "Something went wrong" toast on a high-traffic screen (the
+album still rendered). The existing `/api/map/markers` implementation (gap #3a)
+is directly reusable — the Gumnut client accepts `album_id` and a world `bbox`
+together — so a faithful implementation costs only a few lines more than a `[]`
+stub and is strictly better (real pins vs. a permanently empty map).
+**Implement** (adapter-only, effort S).
 
 **Status:** the calendar-heatmap user-endpoint stub is implemented in
-`routers/api/users.py`. Album map markers are planned as a separate change. All
-other areas are intentional gaps with no adapter code.
+`routers/api/users.py`. Album map markers are implemented in
+`routers/api/albums.py`, with the shared marker retrieval in
+`routers/utils/map_markers.py`. All other areas are intentional gaps with no
+adapter code.
 
 ---
 

--- a/routers/api/albums.py
+++ b/routers/api/albums.py
@@ -21,6 +21,7 @@ from routers.immich_models import (
     AlbumsAddAssetsDto,
     AlbumsAddAssetsResponseDto,
     AlbumStatisticsResponseDto,
+    MapMarkerResponseDto,
     UpdateAlbumDto,
     UpdateAlbumUserDto,
     AddUsersDto,
@@ -32,6 +33,7 @@ from routers.utils.gumnut_id_conversion import (
     uuid_to_gumnut_asset_id,
 )
 from routers.utils.album_conversion import convert_gumnut_album_to_immich
+from routers.utils.map_markers import collect_geotagged_markers
 from pydantic.json_schema import SkipJsonSchema
 
 logger = logging.getLogger(__name__)
@@ -123,6 +125,36 @@ async def get_album_info(
         current_user,
         asset_count=gumnut_album.asset_count,
     )
+
+
+@router.get("/{id}/map-markers")
+async def get_album_map_markers(
+    id: UUID,
+    key: Annotated[str | SkipJsonSchema[None], Query(alias="key")] = None,
+    slug: Annotated[str | SkipJsonSchema[None], Query(alias="slug")] = None,
+    client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
+) -> List[MapMarkerResponseDto]:
+    """Return map markers for the GPS-tagged assets in a single album.
+
+    New in Immich v3 (the global `/map/markers` dropped its `albumIds` filter),
+    the v3 web album view calls this on every album open. Markers are the
+    album's geotagged assets, collected by the shared `collect_geotagged_markers`
+    helper with the album filter AND-combined with the world bbox.
+
+    `key` / `slug` are accepted for client compatibility (shared-link tokens)
+    but dropped — this adapter doesn't support shared links. A missing album
+    404s: `albums.retrieve` raises `NotFoundError`, mapped to 404 by the global
+    handler (matching Immich, and consistent with `get_album_info`).
+    """
+    _ = key, slug  # accepted for client compat, dropped
+
+    gumnut_album_id = uuid_to_gumnut_album_id(id)
+
+    # Strict 404 for a missing album — retrieve first so a nonexistent album
+    # returns 404 rather than an empty marker list.
+    await client.albums.retrieve(gumnut_album_id)
+
+    return await collect_geotagged_markers(client, album_id=gumnut_album_id)
 
 
 @router.post("", status_code=201)

--- a/routers/api/albums.py
+++ b/routers/api/albums.py
@@ -150,8 +150,7 @@ async def get_album_map_markers(
 
     gumnut_album_id = uuid_to_gumnut_album_id(id)
 
-    # Strict 404 for a missing album — retrieve first so a nonexistent album
-    # returns 404 rather than an empty marker list.
+    # Retrieve first so a missing album 404s instead of returning an empty list.
     await client.albums.retrieve(gumnut_album_id)
 
     return await collect_geotagged_markers(client, album_id=gumnut_album_id)

--- a/routers/api/map.py
+++ b/routers/api/map.py
@@ -1,16 +1,14 @@
 import logging
 from datetime import datetime
-from typing import Annotated, Any, List
+from typing import Annotated, List
 
 from fastapi import APIRouter, Depends, Query
 from gumnut import AsyncGumnut
 from pydantic.json_schema import SkipJsonSchema
 
-from routers.api.constants import GUMNUT_API_MAX_PAGE_SIZE
 from routers.immich_models import MapMarkerResponseDto, MapReverseGeocodeResponseDto
-from routers.utils.asset_conversion import ASSET_INCLUDE_METADATA_ONLY
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
-from routers.utils.gumnut_id_conversion import safe_uuid_from_asset_id
+from routers.utils.map_markers import collect_geotagged_markers
 
 logger = logging.getLogger(__name__)
 
@@ -20,38 +18,6 @@ router = APIRouter(
     tags=["map"],
     responses={404: {"description": "Not found"}},
 )
-
-
-# A bounding box covering the whole globe. Passing it to the Gumnut API's
-# coordinate filter returns *only* geotagged assets — not because it narrows the
-# area (it spans the planet) but because the filter is a coordinate *range*
-# check: an asset with no coordinate has a NULL latitude/longitude, and
-# `NULL BETWEEN min AND max` is never true, so every non-geotagged asset is
-# excluded even by a world-wide box. That lets the adapter page through markers
-# instead of scanning the whole library and discarding coordinate-less assets
-# client-side (verified: on a mixed library the newest page drops from 7
-# coordinate-less assets to 0 with this box applied). The backend serves it
-# index-only from its geo covering index. Order is
-# `min_longitude,min_latitude,max_longitude,max_latitude`.
-GEOTAGGED_WORLD_BBOX = "-180,-90,180,90"
-
-# Hard cap on returned markers. Each list page requests only `metadata` via
-# `include` — not faces/people/file_data/asset_urls — since the marker build
-# reads just three GPS fields off `metadata`. Because the coordinate filter
-# makes every returned asset a marker, paging cost now scales with the marker
-# count, not the library's GPS density: 2000 markers ≈ 2000 / page_size pages
-# regardless of how sparsely the library is geotagged. The SDK orders by
-# capture time descending, so when the cap fires the oldest GPS-tagged assets
-# are dropped.
-MAP_MARKERS_CAP = 2000
-
-# Safety net bounding total assets walked. In the normal path the coordinate
-# filter returns only geotagged assets, so the marker cap fires first and this
-# never triggers. It guards the degraded case where the `bbox` filter is *not*
-# applied — an older Gumnut API that ignores the unknown param (e.g. the adapter
-# deploying ahead of the API), or a filter regression — which would otherwise
-# turn a low-GPS-density library's marker request into a full-library scan.
-MAX_ASSETS_SCANNED = 30 * GUMNUT_API_MAX_PAGE_SIZE
 
 
 @router.get("/markers")
@@ -74,6 +40,9 @@ async def get_map_markers(
     timeline endpoints handle `isFavorite` the same way; they don't accept
     an `isArchived` filter at all (archived state is folded into `visibility`
     there), so `isArchived` short-circuiting here is map-specific.
+
+    The paging loop, marker/scan caps, and logging live in
+    `collect_geotagged_markers` (shared with the album-scoped map endpoint).
     """
     _ = withPartners, withSharedAlbums  # accepted, dropped
 
@@ -83,65 +52,15 @@ async def get_map_markers(
     if isFavorite is True or isArchived is True:
         return []
 
-    list_kwargs: dict[str, Any] = {
-        "limit": GUMNUT_API_MAX_PAGE_SIZE,
-        "include": ASSET_INCLUDE_METADATA_ONLY,
-        # Filter to geotagged assets server-side (see GEOTAGGED_WORLD_BBOX) so we
-        # page through markers, not the whole library.
-        "bbox": GEOTAGGED_WORLD_BBOX,
-    }
-    if fileCreatedAfter is not None:
-        list_kwargs["local_datetime_after"] = fileCreatedAfter.isoformat()
-    if fileCreatedBefore is not None:
-        list_kwargs["local_datetime_before"] = fileCreatedBefore.isoformat()
-
-    markers: list[MapMarkerResponseDto] = []
-    assets_scanned = 0
-    marker_cap_hit = False
-    async for asset in client.assets.list(**list_kwargs):
-        assets_scanned += 1
-        metadata = asset.metadata
-        # The bbox filter guarantees a coordinate, but guard defensively so an
-        # unexpected null can't crash marker construction (lat/lon are required).
-        if (
-            metadata is not None
-            and metadata.latitude is not None
-            and metadata.longitude is not None
-        ):
-            markers.append(
-                MapMarkerResponseDto(
-                    id=safe_uuid_from_asset_id(asset.id),
-                    lat=metadata.latitude,
-                    lon=metadata.longitude,
-                    city=metadata.city,
-                    state=metadata.state,
-                    country=metadata.country,
-                )
-            )
-            if len(markers) >= MAP_MARKERS_CAP:
-                marker_cap_hit = True
-                break
-        # Safety net if the coordinate filter wasn't applied (see
-        # MAX_ASSETS_SCANNED) — bounds work so a low-GPS library can't degrade
-        # into a full-library scan.
-        if assets_scanned >= MAX_ASSETS_SCANNED:
-            break
-
-    scan_cap_hit = assets_scanned >= MAX_ASSETS_SCANNED and not marker_cap_hit
-    logger.info(
-        "map markers: scanned %d assets, returned %d markers (marker_cap_hit=%s, scan_cap_hit=%s)",
-        assets_scanned,
-        len(markers),
-        marker_cap_hit,
-        scan_cap_hit,
-        extra={
-            "assets_scanned": assets_scanned,
-            "markers_returned": len(markers),
-            "marker_cap_hit": marker_cap_hit,
-            "scan_cap_hit": scan_cap_hit,
-        },
+    return await collect_geotagged_markers(
+        client,
+        local_datetime_after=(
+            fileCreatedAfter.isoformat() if fileCreatedAfter is not None else None
+        ),
+        local_datetime_before=(
+            fileCreatedBefore.isoformat() if fileCreatedBefore is not None else None
+        ),
     )
-    return markers
 
 
 @router.get("/reverse-geocode")

--- a/routers/api/map.py
+++ b/routers/api/map.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime
 from typing import Annotated, List
 
@@ -9,8 +8,6 @@ from pydantic.json_schema import SkipJsonSchema
 from routers.immich_models import MapMarkerResponseDto, MapReverseGeocodeResponseDto
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
 from routers.utils.map_markers import collect_geotagged_markers
-
-logger = logging.getLogger(__name__)
 
 
 router = APIRouter(
@@ -30,7 +27,7 @@ async def get_map_markers(
     withSharedAlbums: Annotated[bool | SkipJsonSchema[None], Query()] = None,
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
 ) -> List[MapMarkerResponseDto]:
-    """Return up to `MAP_MARKERS_CAP` markers for the caller's GPS-tagged assets.
+    """Return a bounded list of markers for the caller's GPS-tagged assets.
 
     `withPartners` / `withSharedAlbums` are accepted for client-compatibility
     (Immich clients send them) but have no Gumnut analog, so they're dropped

--- a/routers/utils/map_markers.py
+++ b/routers/utils/map_markers.py
@@ -71,8 +71,7 @@ async def collect_geotagged_markers(
     list_kwargs: dict[str, Any] = {
         "limit": GUMNUT_API_MAX_PAGE_SIZE,
         "include": ASSET_INCLUDE_METADATA_ONLY,
-        # Filter to geotagged assets server-side (see GEOTAGGED_WORLD_BBOX) so we
-        # page through markers, not the whole library.
+        # World bbox → geotagged assets only; see GEOTAGGED_WORLD_BBOX.
         "bbox": GEOTAGGED_WORLD_BBOX,
     }
     if album_id is not None:

--- a/routers/utils/map_markers.py
+++ b/routers/utils/map_markers.py
@@ -1,0 +1,134 @@
+"""Shared marker retrieval for the map endpoints.
+
+Both the global map endpoint (`GET /api/map/markers`) and the album-scoped
+endpoint (`GET /api/albums/{id}/map-markers`) return the same
+`MapMarkerResponseDto` shape over the caller's GPS-tagged assets. The paging
+loop, marker/scan caps, and structured logging live here so the two routes
+share one implementation and can't drift.
+"""
+
+import logging
+from typing import Any
+
+from gumnut import AsyncGumnut
+
+from routers.api.constants import GUMNUT_API_MAX_PAGE_SIZE
+from routers.immich_models import MapMarkerResponseDto
+from routers.utils.asset_conversion import ASSET_INCLUDE_METADATA_ONLY
+from routers.utils.gumnut_id_conversion import safe_uuid_from_asset_id
+
+logger = logging.getLogger(__name__)
+
+
+# A bounding box covering the whole globe. Passing it to the Gumnut API's
+# coordinate filter returns *only* geotagged assets — not because it narrows the
+# area (it spans the planet) but because the filter is a coordinate *range*
+# check: an asset with no coordinate has a NULL latitude/longitude, and
+# `NULL BETWEEN min AND max` is never true, so every non-geotagged asset is
+# excluded even by a world-wide box. That lets the adapter page through markers
+# instead of scanning the whole library and discarding coordinate-less assets
+# client-side (verified: on a mixed library the newest page drops from 7
+# coordinate-less assets to 0 with this box applied). The backend serves it
+# index-only from its geo covering index. Order is
+# `min_longitude,min_latitude,max_longitude,max_latitude`.
+GEOTAGGED_WORLD_BBOX = "-180,-90,180,90"
+
+# Hard cap on returned markers. Each list page requests only `metadata` via
+# `include` — not faces/people/file_data/asset_urls — since the marker build
+# reads just three GPS fields off `metadata`. Because the coordinate filter
+# makes every returned asset a marker, paging cost now scales with the marker
+# count, not the library's GPS density: 2000 markers ≈ 2000 / page_size pages
+# regardless of how sparsely the library is geotagged. The SDK orders by
+# capture time descending, so when the cap fires the oldest GPS-tagged assets
+# are dropped.
+MAP_MARKERS_CAP = 2000
+
+# Safety net bounding total assets walked. In the normal path the coordinate
+# filter returns only geotagged assets, so the marker cap fires first and this
+# never triggers. It guards the degraded case where the `bbox` filter is *not*
+# applied — an older Gumnut API that ignores the unknown param (e.g. the adapter
+# deploying ahead of the API), or a filter regression — which would otherwise
+# turn a low-GPS-density library's marker request into a full-library scan.
+MAX_ASSETS_SCANNED = 30 * GUMNUT_API_MAX_PAGE_SIZE
+
+
+async def collect_geotagged_markers(
+    client: AsyncGumnut,
+    *,
+    album_id: str | None = None,
+    local_datetime_after: str | None = None,
+    local_datetime_before: str | None = None,
+) -> list[MapMarkerResponseDto]:
+    """Page the caller's GPS-tagged assets into up to `MAP_MARKERS_CAP` markers.
+
+    The world `bbox` filters to geotagged assets server-side (see
+    `GEOTAGGED_WORLD_BBOX`) so we page through markers rather than the whole
+    library. When `album_id` is given it further restricts to one album's assets
+    (AND-combined with the bbox — the two are independent filters). Optional
+    `local_datetime_after` / `local_datetime_before` are ISO-8601 strings that
+    narrow by capture time.
+    """
+    list_kwargs: dict[str, Any] = {
+        "limit": GUMNUT_API_MAX_PAGE_SIZE,
+        "include": ASSET_INCLUDE_METADATA_ONLY,
+        # Filter to geotagged assets server-side (see GEOTAGGED_WORLD_BBOX) so we
+        # page through markers, not the whole library.
+        "bbox": GEOTAGGED_WORLD_BBOX,
+    }
+    if album_id is not None:
+        list_kwargs["album_id"] = album_id
+    if local_datetime_after is not None:
+        list_kwargs["local_datetime_after"] = local_datetime_after
+    if local_datetime_before is not None:
+        list_kwargs["local_datetime_before"] = local_datetime_before
+
+    markers: list[MapMarkerResponseDto] = []
+    assets_scanned = 0
+    marker_cap_hit = False
+    async for asset in client.assets.list(**list_kwargs):
+        assets_scanned += 1
+        metadata = asset.metadata
+        # The bbox filter guarantees a coordinate, but guard defensively so an
+        # unexpected null can't crash marker construction (lat/lon are required).
+        if (
+            metadata is not None
+            and metadata.latitude is not None
+            and metadata.longitude is not None
+        ):
+            markers.append(
+                MapMarkerResponseDto(
+                    id=safe_uuid_from_asset_id(asset.id),
+                    lat=metadata.latitude,
+                    lon=metadata.longitude,
+                    city=metadata.city,
+                    state=metadata.state,
+                    country=metadata.country,
+                )
+            )
+            if len(markers) >= MAP_MARKERS_CAP:
+                marker_cap_hit = True
+                break
+        # Safety net if the coordinate filter wasn't applied (see
+        # MAX_ASSETS_SCANNED) — bounds work so a low-GPS library can't degrade
+        # into a full-library scan.
+        if assets_scanned >= MAX_ASSETS_SCANNED:
+            break
+
+    scan_cap_hit = assets_scanned >= MAX_ASSETS_SCANNED and not marker_cap_hit
+    logger.info(
+        "map markers: scanned %d assets, returned %d markers "
+        "(album_id=%s, marker_cap_hit=%s, scan_cap_hit=%s)",
+        assets_scanned,
+        len(markers),
+        album_id,
+        marker_cap_hit,
+        scan_cap_hit,
+        extra={
+            "assets_scanned": assets_scanned,
+            "markers_returned": len(markers),
+            "album_id": album_id,
+            "marker_cap_hit": marker_cap_hit,
+            "scan_cap_hit": scan_cap_hit,
+        },
+    )
+    return markers

--- a/tests/unit/api/test_albums.py
+++ b/tests/unit/api/test_albums.py
@@ -15,13 +15,16 @@ from routers.api.albums import (
     get_all_albums,
     get_album_statistics,
     get_album_info,
+    get_album_map_markers,
     create_album,
     add_assets_to_album,
     update_album,
     remove_asset_from_album,
     delete_album,
     add_assets_to_albums,
+    router as albums_router,
 )
+from routers.utils.map_markers import GEOTAGGED_WORLD_BBOX
 from routers.immich_models import (
     AlbumUserRole,
     CreateAlbumDto,
@@ -1268,3 +1271,107 @@ class TestAddAssetsToAlbums:
         assert result.success is True
         assert peak > 1, "expected concurrent execution"
         assert peak <= BULK_FANOUT_CONCURRENCY_LIMIT
+
+
+def _make_geo_asset(
+    *,
+    lat: float | None = None,
+    lon: float | None = None,
+    city: str | None = None,
+    state: str | None = None,
+    country: str | None = None,
+    metadata_missing: bool = False,
+) -> Mock:
+    """Mock Gumnut asset with the GPS-relevant subset of metadata fields."""
+    asset = Mock()
+    asset.id = uuid_to_gumnut_asset_id(uuid4())
+    if metadata_missing:
+        asset.metadata = None
+    else:
+        metadata = Mock()
+        metadata.latitude = lat
+        metadata.longitude = lon
+        metadata.city = city
+        metadata.state = state
+        metadata.country = country
+        asset.metadata = metadata
+    return asset
+
+
+class TestGetAlbumMapMarkers:
+    """Test the get_album_map_markers endpoint (GET /albums/{id}/map-markers)."""
+
+    @pytest.mark.anyio
+    async def test_returns_markers_for_geotagged_album_assets(
+        self, sample_uuid, sample_gumnut_album, mock_sync_cursor_page
+    ):
+        """Geotagged assets become markers; coordinate-less assets are skipped."""
+        asset_with_gps = _make_geo_asset(
+            lat=40.5, lon=-74.1, city="Trenton", state="NJ", country="USA"
+        )
+        asset_no_metadata = _make_geo_asset(metadata_missing=True)
+        asset_no_coords = _make_geo_asset(lat=None, lon=None, city="Nowhere")
+
+        mock_client = Mock()
+        mock_client.albums.retrieve = AsyncMock(return_value=sample_gumnut_album)
+        mock_client.assets.list.return_value = mock_sync_cursor_page(
+            [asset_with_gps, asset_no_metadata, asset_no_coords]
+        )
+
+        result = await get_album_map_markers(sample_uuid, client=mock_client)
+
+        assert len(result) == 1
+        marker = result[0]
+        assert marker.id == safe_uuid_from_asset_id(asset_with_gps.id)
+        assert marker.lat == 40.5
+        assert marker.lon == -74.1
+        assert marker.city == "Trenton"
+        assert marker.state == "NJ"
+        assert marker.country == "USA"
+
+    @pytest.mark.anyio
+    async def test_forwards_album_id_and_world_bbox(
+        self, sample_uuid, sample_gumnut_album, mock_sync_cursor_page
+    ):
+        """The album filter is AND-combined with the geotagged world bbox."""
+        mock_client = Mock()
+        mock_client.albums.retrieve = AsyncMock(return_value=sample_gumnut_album)
+        mock_client.assets.list.return_value = mock_sync_cursor_page([])
+
+        await get_album_map_markers(sample_uuid, client=mock_client)
+
+        kwargs = mock_client.assets.list.call_args.kwargs
+        assert kwargs["album_id"] == uuid_to_gumnut_album_id(sample_uuid)
+        assert kwargs["bbox"] == GEOTAGGED_WORLD_BBOX
+
+    @pytest.mark.anyio
+    async def test_empty_album_returns_empty_list(
+        self, sample_uuid, sample_gumnut_album, mock_sync_cursor_page
+    ):
+        """An album with no geotagged assets returns an empty marker list."""
+        mock_client = Mock()
+        mock_client.albums.retrieve = AsyncMock(return_value=sample_gumnut_album)
+        mock_client.assets.list.return_value = mock_sync_cursor_page([])
+
+        result = await get_album_map_markers(sample_uuid, client=mock_client)
+
+        assert result == []
+
+    @pytest.mark.anyio
+    async def test_missing_album_raises_not_found_before_listing(self, sample_uuid):
+        """A missing album 404s via retrieve; markers are never listed."""
+        mock_client = Mock()
+        mock_client.albums.retrieve = AsyncMock(
+            side_effect=make_sdk_status_error(404, "Not found", cls=NotFoundError)
+        )
+        mock_client.assets.list = Mock()
+
+        with pytest.raises(NotFoundError):
+            await get_album_map_markers(sample_uuid, client=mock_client)
+
+        mock_client.assets.list.assert_not_called()
+
+    def test_route_registered(self):
+        """The album map-markers route is registered on the albums router."""
+        paths = [getattr(route, "path", None) for route in albums_router.routes]
+        assert "/api/albums/{id}/map-markers" in paths

--- a/tests/unit/api/test_albums.py
+++ b/tests/unit/api/test_albums.py
@@ -1345,6 +1345,44 @@ class TestGetAlbumMapMarkers:
         assert kwargs["bbox"] == GEOTAGGED_WORLD_BBOX
 
     @pytest.mark.anyio
+    async def test_key_and_slug_are_dropped_not_forwarded(
+        self, sample_uuid, sample_gumnut_album, mock_sync_cursor_page
+    ):
+        """`key` / `slug` are accepted for client compat then dropped.
+
+        They're shared-link tokens this adapter doesn't honor (`_ = key, slug`).
+        This mirrors the global endpoint's `test_partner_and_shared_album_filters_are_dropped`
+        and guards against a future edit wiring them into `retrieve`/`list` — the
+        `retrieve` path especially, since threading a token there would be a
+        silent shared-link authorization change.
+        """
+        mock_client = Mock()
+        mock_client.albums.retrieve = AsyncMock(return_value=sample_gumnut_album)
+        mock_client.assets.list.return_value = mock_sync_cursor_page([])
+
+        await get_album_map_markers(
+            sample_uuid,
+            key="shared-link-key",
+            slug="shared-slug",
+            client=mock_client,
+        )
+
+        # The album retrieve gets only the album id — no key/slug threaded in.
+        retrieve_call = mock_client.albums.retrieve.call_args
+        assert "key" not in retrieve_call.kwargs
+        assert "slug" not in retrieve_call.kwargs
+        assert "shared-link-key" not in retrieve_call.args
+        assert "shared-slug" not in retrieve_call.args
+
+        # The asset list forwards only album_id + limit + include + bbox.
+        assert set(mock_client.assets.list.call_args.kwargs.keys()) == {
+            "album_id",
+            "limit",
+            "include",
+            "bbox",
+        }
+
+    @pytest.mark.anyio
     async def test_empty_album_returns_empty_list(
         self, sample_uuid, sample_gumnut_album, mock_sync_cursor_page
     ):

--- a/tests/unit/api/test_map.py
+++ b/tests/unit/api/test_map.py
@@ -6,11 +6,11 @@ from uuid import uuid4
 
 import pytest
 
-from routers.api.map import (
+from routers.api.map import get_map_markers
+from routers.utils.map_markers import (
     GEOTAGGED_WORLD_BBOX,
     MAP_MARKERS_CAP,
     MAX_ASSETS_SCANNED,
-    get_map_markers,
 )
 from routers.utils.gumnut_id_conversion import (
     safe_uuid_from_asset_id,


### PR DESCRIPTION
## What
- Add `GET /api/albums/{id}/map-markers` — map markers for a single album's GPS-tagged assets (new in Immich v3).
- Extract the shared geotagged-marker paging/caps/logging from the global map endpoint into `routers/utils/map_markers.collect_geotagged_markers`, parameterized by an optional `album_id` (AND-combined with the world bbox); `get_map_markers` becomes a thin wrapper.
- A missing album returns 404 (pre-`retrieve`, matching Immich); `key`/`slug` shared-link params are accepted and dropped.

## Why
Immich v3 introduced this album-scoped endpoint and dropped the `albumIds` filter from the global `/map/markers`, so the v3 web album view calls it on every album open. The adapter returned 404, surfacing a console error and a user-visible "Something went wrong" toast on a high-traffic screen (the album still rendered). The album's markers reuse the existing geotagged-bbox retrieval over the Gumnut API, so a faithful implementation (real pins) costs only marginally more than an empty stub.

## Base
Targets `migration/immichv3`, not `main` — this is part of the Immich v3 retarget; the integration branch merges to `main` when the retarget lands.

## Test plan
- [x] `uv run pytest` — full suite green; adds album-scoped tests (markers built, coordinate-less skipped, `album_id` forwarded, empty album, missing album → 404 before listing, route registered)
- [x] Existing `/map/markers` tests pass unchanged — the refactor is behavior-preserving
- [x] `uv run ruff check` / `ruff format --check` / `uv run pyright` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)