### PR TITLE
Refine adapter handling of v3 mobile sync request types

### DIFF
--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -23,6 +23,19 @@ Event types are classified into `_DELETE_EVENT_TYPES` (construct delete sync eve
 
 `face_created` events have person_id nulled out (face detection never assigns a person). `face_updated` events use the causally-consistent person_id from the event payload instead of current entity state. For every face batch, payload person_ids are collected (see `extract_payload_fk_refs`) and verified against production via `people.list` — IDs that return 404 are recorded in `stats.not_found_ids["person"]` and nulled out on the outgoing event, regardless of whether a `PersonV1` checkpoint exists. This prevents stale payload references (from clustering runs that predate a person's deletion) from leaking across sync cycles and causing FK violations on the client.
 
+## User Preferences (minimumFaces)
+
+Gumnut has no per-user preferences, but the v3 client reads `people.minimumFaces`
+from the `UserMetadataV1` stream to decide which people appear in the People tab,
+defaulting to **3** when absent — which would hide Gumnut clusters of 1–2 faces.
+The adapter synthesizes a single `UserMetadataV1` *preferences* row with
+`minimumFaces=1` (all other fields mirror the client's defaults). It's emitted
+right after `UserV1` (the `userId` FK parent) and keyed off a constant cursor
+(`_USER_METADATA_CURSOR`) so the client acks it once and skips it thereafter;
+bump the cursor suffix to force a re-emit if the payload changes. `value` is the
+server's nested `UserPreferences` JSON shape (`value["people"]["minimumFaces"]`),
+which the client parses via `Preferences.fromMap`.
+
 ## Album Cover Handling
 
 `album_updated` events use the causally-consistent `album_cover_asset_id` from the event payload instead of the entity's current computed cover (which is derived at fetch time via a lateral join and may reference an asset outside the sync window). Payload cover asset IDs are verified against production the same way face person_ids are — 404s null the cover regardless of `AssetV1` checkpoint state.
@@ -66,6 +79,8 @@ The invariant tests in `test_sync_v2.py` assert that every V2 type in `_SYNC_TYP
 ## No-Op Request Types
 
 Immich sync types that are accepted but have no Gumnut equivalent (e.g., `AssetEditsV1` — we don't support editing) go in `_NOOP_REQUEST_TYPES` in `stream.py`. This prevents "unsupported type" warnings while making the no-op explicit. Do not just add them to `_SUPPORTED_REQUEST_TYPES` without `_SYNC_TYPE_ORDER` — that silently drops them.
+
+The v3 mobile client requests a broad set of these on **every** sync (partner-*, stacks-*, memories-*, `AssetMetadataV1`, `AssetOcrV1`, `AlbumAssetExifsV1`, the V2 partner/album-asset variants) — all no-ops for a single-user Gumnut backend with no sharing/stacks/memories/OCR. They all belong in `_NOOP_REQUEST_TYPES` so the per-sync "unsupported types" warning stays quiet. `UserMetadataV1` is the one requested type the adapter *does* synthesize (see "User Preferences" above), so it is deliberately **not** a no-op — it's handled specially alongside `UsersV1`/`AuthUsersV1`.
 
 ## Contract with the Gumnut API
 

--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -30,11 +30,12 @@ from the `UserMetadataV1` stream to decide which people appear in the People tab
 defaulting to **3** when absent — which would hide Gumnut clusters of 1–2 faces.
 The adapter synthesizes a single `UserMetadataV1` *preferences* row with
 `minimumFaces=1` (all other fields mirror the client's defaults). It's emitted
-right after `UserV1` (the `userId` FK parent) and keyed off a constant cursor
-(`_USER_METADATA_CURSOR`) so the client acks it once and skips it thereafter;
-bump the cursor suffix to force a re-emit if the payload changes. `value` is the
-server's nested `UserPreferences` JSON shape (`value["people"]["minimumFaces"]`),
-which the client parses via `Preferences.fromMap`.
+right after `UserV1` (the `userId` FK parent) and keyed off the **same
+`user_cursor` as `UserV1`** (the user's `updated_at`) — the payload is derived
+purely from the user, so it re-syncs exactly when the user record changes and
+otherwise acks once. `value` is the server's nested `UserPreferences` JSON shape
+(`value["people"]["minimumFaces"]`), which the client parses via
+`Preferences.fromMap`.
 
 Only the `preferences` key is synthesized. The client's other `UserMetadataV1`
 keys are deliberately not emitted: onboarding UI is gated on the login response's

--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Sync Stream Architecture"
-last-updated: 2026-07-13
+last-updated: 2026-07-14
 ---
 
 # Sync Stream Architecture
@@ -35,6 +35,12 @@ right after `UserV1` (the `userId` FK parent) and keyed off a constant cursor
 bump the cursor suffix to force a re-emit if the payload changes. `value` is the
 server's nested `UserPreferences` JSON shape (`value["people"]["minimumFaces"]`),
 which the client parses via `Preferences.fromMap`.
+
+Only the `preferences` key is synthesized. The client's other `UserMetadataV1`
+keys are deliberately not emitted: onboarding UI is gated on the login response's
+`isOnboarded`, not the synced `onboarding` row (no client reader consumes it), so
+a synthesized onboarding row would change nothing; and Gumnut has no `license`
+concept.
 
 ## Album Cover Handling
 

--- a/routers/api/sync/converters.py
+++ b/routers/api/sync/converters.py
@@ -146,10 +146,14 @@ def gumnut_user_to_sync_user_metadata_v1(owner_id: UUID) -> SyncUserMetadataV1:
     with at least one face is shown; all other fields mirror the client's own
     defaults.
 
-    ``value`` is the server's nested ``UserPreferences`` JSON shape — the client
-    parses it via ``Preferences.fromMap`` (reads ``value["people"]["minimumFaces"]``
-    etc.), storing the map verbatim. Only the keys the client reads are included;
-    it defensively defaults everything else.
+    ``value`` is the server's nested ``UserPreferences`` JSON shape, which the
+    client parses via ``Preferences.fromMap`` (reads
+    ``value["people"]["minimumFaces"]`` etc.) and stores verbatim.
+    ``Preferences.fromMap`` reads every section null-safely and falls back to its
+    own default for anything absent, so ``people.minimumFaces`` is the only
+    load-bearing field here. The other sections each restate the client's own
+    default and are included solely to mirror the full canonical shape a real
+    Immich server emits — none of them are required by ``Preferences.fromMap``.
     """
     return SyncUserMetadataV1(
         key=UserMetadataKey.preferences,

--- a/routers/api/sync/converters.py
+++ b/routers/api/sync/converters.py
@@ -28,7 +28,9 @@ from routers.immich_models import (
     SyncAssetV2,
     SyncAuthUserV1,
     SyncPersonV1,
+    SyncUserMetadataV1,
     SyncUserV1,
+    UserMetadataKey,
 )
 from routers.utils.asset_conversion import (
     duration_ms,
@@ -131,6 +133,36 @@ def gumnut_user_to_sync_user_v1(user: UserResponse) -> SyncUserV1:
         profileChangedAt=user.updated_at,
         avatarColor=None,
         deletedAt=None,
+    )
+
+
+def gumnut_user_to_sync_user_metadata_v1(owner_id: UUID) -> SyncUserMetadataV1:
+    """Synthesize a UserMetadata *preferences* row.
+
+    Gumnut has no per-user preferences, but the v3 mobile client reads the
+    ``people.minimumFaces`` threshold from this stream to decide which people
+    appear in the People tab — defaulting to 3 when absent, which would hide
+    Gumnut clusters of 1–2 faces. We emit ``minimumFaces=1`` so every person
+    with at least one face is shown; all other fields mirror the client's own
+    defaults.
+
+    ``value`` is the server's nested ``UserPreferences`` JSON shape — the client
+    parses it via ``Preferences.fromMap`` (reads ``value["people"]["minimumFaces"]``
+    etc.), storing the map verbatim. Only the keys the client reads are included;
+    it defensively defaults everything else.
+    """
+    return SyncUserMetadataV1(
+        key=UserMetadataKey.preferences,
+        userId=owner_id,
+        value={
+            "folders": {"enabled": False},
+            "memories": {"enabled": True},
+            "people": {"enabled": True, "minimumFaces": 1},
+            "ratings": {"enabled": False},
+            "sharedLinks": {"enabled": True},
+            "tags": {"enabled": False},
+            "purchase": {"showSupportBadge": True},
+        },
     )
 
 
@@ -329,7 +361,13 @@ def gumnut_album_to_sync_album_user_v1(
 
 
 def gumnut_face_to_sync_face_v1(face: FaceResponse) -> SyncAssetFaceV1:
-    """Convert Gumnut FaceResponse to Immich SyncAssetFaceV1 format."""
+    """Convert Gumnut FaceResponse to Immich SyncAssetFaceV1 format.
+
+    ``imageWidth``/``imageHeight`` are emitted as 0: the v3 mobile client stores
+    them but has no read path (face/person thumbnails are served from a server
+    URL, and there is no local bounding-box overlay). Emit real dimensions only
+    when a client consumer actually reads them.
+    """
     bounding_box = face.bounding_box
 
     person_id = None

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -147,7 +147,7 @@ _DELETE_TYPE_ORDER: list[SyncEntityType] = [
 #   - StacksV1:            Gumnut has no stacks; assets carry stackId=None and
 #                          render individually, so absent stack rows hide nothing.
 # UserMetadataV1 is deliberately NOT here — it is emitted (a synthesized
-# preferences row); see _stream_user_metadata.
+# preferences row); see gumnut_user_to_sync_user_metadata_v1.
 _NOOP_REQUEST_TYPES: dict[SyncRequestType, SyncEntityType] = {
     SyncRequestType.AssetEditsV1: SyncEntityType.AssetEditV1,
     SyncRequestType.AssetOcrV1: SyncEntityType.AssetOcrV1,
@@ -172,7 +172,7 @@ _USER_METADATA_CURSOR = "preferences-v1"
 # Supported SyncRequestTypes (used to detect unsupported types requested by
 # client). AuthUsersV1/UsersV1/UserMetadataV1 are handled specially (not via
 # _SYNC_TYPE_ORDER): the first two stream the user record, and UserMetadataV1
-# streams a synthesized preferences row (see _stream_user_metadata).
+# streams a synthesized preferences row (see gumnut_user_to_sync_user_metadata_v1).
 _SUPPORTED_REQUEST_TYPES: frozenset[SyncRequestType] = frozenset(
     {request_type for request_type, _, _ in _SYNC_TYPE_ORDER}
     | {

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -29,6 +29,7 @@ from services.checkpoint_store import Checkpoint
 from routers.api.constants import GUMNUT_API_MAX_PAGE_SIZE
 from routers.api.sync.converters import (
     gumnut_user_to_sync_auth_user_v1,
+    gumnut_user_to_sync_user_metadata_v1,
     gumnut_user_to_sync_user_v1,
 )
 from routers.api.sync.entity_fetch import fetch_entities_map
@@ -125,24 +126,60 @@ _DELETE_TYPE_ORDER: list[SyncEntityType] = [
 
 # Request types that are accepted but have no Gumnut equivalent, so nothing is
 # emitted for them (the client tolerates absence). Listing them here prevents an
-# "unsupported" warning and logs them as intentional no-ops instead.
-#   - AssetEditsV1:    Gumnut has no asset edit history.
-#   - AssetOcrV1:      Gumnut has no OCR text data (new v3 entity type).
-#   - PartnerAssetsV2: Gumnut is single-user; there is no partner sharing.
-#   - AlbumAssetsV2:   album assets are the user's own, already streamed via
-#                      AssetsV2 + AlbumToAssetsV1 (this stream is for assets
-#                      shared into an album by other users, which Gumnut lacks).
+# "unsupported" warning and logs them as intentional no-ops instead — the v3
+# mobile client requests all of these on every sync, so leaving them off this
+# list spams a misleading "unsupported types" warning each cycle.
+#   - AssetEditsV1:        Gumnut has no asset edit history.
+#   - AssetOcrV1:          Gumnut has no OCR text data (new v3 entity type).
+#   - AssetMetadataV1:     iCloud/device linking metadata; Gumnut has none, and
+#                          own-asset EXIF is delivered via AssetExifsV1 instead.
+#   - PartnerAssetsV2:     Gumnut is single-user; there is no partner sharing.
+#   - PartnersV1 /
+#     PartnerAssetExifsV1 /
+#     PartnerStacksV1:     partner-sharing streams — none for a single user.
+#   - AlbumAssetsV2:       album assets are the user's own, already streamed via
+#                          AssetsV2 + AlbumToAssetsV1 (this stream is for assets
+#                          shared into an album by other users, which Gumnut lacks).
+#   - AlbumAssetExifsV1:   EXIF for other users' album assets; own-album-photo
+#                          EXIF arrives via AssetExifsV1.
+#   - MemoriesV1 /
+#     MemoryToAssetsV1:    Gumnut has no memories feature; the tab renders empty.
+#   - StacksV1:            Gumnut has no stacks; assets carry stackId=None and
+#                          render individually, so absent stack rows hide nothing.
+# UserMetadataV1 is deliberately NOT here — it is emitted (a synthesized
+# preferences row); see _stream_user_metadata.
 _NOOP_REQUEST_TYPES: dict[SyncRequestType, SyncEntityType] = {
     SyncRequestType.AssetEditsV1: SyncEntityType.AssetEditV1,
     SyncRequestType.AssetOcrV1: SyncEntityType.AssetOcrV1,
+    SyncRequestType.AssetMetadataV1: SyncEntityType.AssetMetadataV1,
     SyncRequestType.PartnerAssetsV2: SyncEntityType.PartnerAssetV2,
+    SyncRequestType.PartnersV1: SyncEntityType.PartnerV1,
+    SyncRequestType.PartnerAssetExifsV1: SyncEntityType.PartnerAssetExifV1,
+    SyncRequestType.PartnerStacksV1: SyncEntityType.PartnerStackV1,
     SyncRequestType.AlbumAssetsV2: SyncEntityType.AlbumAssetCreateV2,
+    SyncRequestType.AlbumAssetExifsV1: SyncEntityType.AlbumAssetExifCreateV1,
+    SyncRequestType.MemoriesV1: SyncEntityType.MemoryV1,
+    SyncRequestType.MemoryToAssetsV1: SyncEntityType.MemoryToAssetV1,
+    SyncRequestType.StacksV1: SyncEntityType.StackV1,
 }
 
-# Supported SyncRequestTypes (used to detect unsupported types requested by client)
+# Cursor for the synthesized UserMetadataV1 preferences row. The payload is
+# static, so a constant cursor makes the client ack it once and skip it on every
+# subsequent sync. Bump the suffix if the emitted preferences change, to force a
+# one-time re-emit to already-synced clients.
+_USER_METADATA_CURSOR = "preferences-v1"
+
+# Supported SyncRequestTypes (used to detect unsupported types requested by
+# client). AuthUsersV1/UsersV1/UserMetadataV1 are handled specially (not via
+# _SYNC_TYPE_ORDER): the first two stream the user record, and UserMetadataV1
+# streams a synthesized preferences row (see _stream_user_metadata).
 _SUPPORTED_REQUEST_TYPES: frozenset[SyncRequestType] = frozenset(
     {request_type for request_type, _, _ in _SYNC_TYPE_ORDER}
-    | {SyncRequestType.AuthUsersV1, SyncRequestType.UsersV1}
+    | {
+        SyncRequestType.AuthUsersV1,
+        SyncRequestType.UsersV1,
+        SyncRequestType.UserMetadataV1,
+    }
     | _NOOP_REQUEST_TYPES.keys()
 )
 
@@ -565,6 +602,21 @@ async def generate_sync_stream(
                     user_cursor,
                 )
                 logger.debug("Streamed user", extra={"user_id": owner_id})
+
+        # Stream a synthesized user-preferences row if requested. Static payload
+        # keyed off a constant cursor, so the client acks it once and skips it
+        # thereafter. Emitted after UserV1 so its userId FK parent exists on the
+        # client. See gumnut_user_to_sync_user_metadata_v1 for the why.
+        if SyncRequestType.UserMetadataV1 in requested_types:
+            checkpoint = checkpoint_map.get(SyncEntityType.UserMetadataV1)
+            if checkpoint is None or checkpoint.cursor != _USER_METADATA_CURSOR:
+                sync_user_metadata = gumnut_user_to_sync_user_metadata_v1(owner_uuid)
+                yield make_sync_event(
+                    SyncEntityType.UserMetadataV1,
+                    sync_user_metadata.model_dump(mode="json"),
+                    _USER_METADATA_CURSOR,
+                )
+                logger.debug("Streamed user metadata", extra={"user_id": owner_id})
 
         # Capture sync start time to bound the query window
         sync_started_at = datetime.now(timezone.utc)

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -163,12 +163,6 @@ _NOOP_REQUEST_TYPES: dict[SyncRequestType, SyncEntityType] = {
     SyncRequestType.StacksV1: SyncEntityType.StackV1,
 }
 
-# Cursor for the synthesized UserMetadataV1 preferences row. The payload is
-# static, so a constant cursor makes the client ack it once and skip it on every
-# subsequent sync. Bump the suffix if the emitted preferences change, to force a
-# one-time re-emit to already-synced clients.
-_USER_METADATA_CURSOR = "preferences-v1"
-
 # Supported SyncRequestTypes (used to detect unsupported types requested by
 # client). AuthUsersV1/UsersV1/UserMetadataV1 are handled specially (not via
 # _SYNC_TYPE_ORDER): the first two stream the user record, and UserMetadataV1
@@ -603,18 +597,19 @@ async def generate_sync_stream(
                 )
                 logger.debug("Streamed user", extra={"user_id": owner_id})
 
-        # Stream a synthesized user-preferences row if requested. Static payload
-        # keyed off a constant cursor, so the client acks it once and skips it
-        # thereafter. Emitted after UserV1 so its userId FK parent exists on the
-        # client. See gumnut_user_to_sync_user_metadata_v1 for the why.
+        # Stream a synthesized user-preferences row if requested. Keyed off the
+        # same user_cursor as UserV1 — the payload is derived purely from the user,
+        # so it re-syncs exactly when the user record changes. Emitted after UserV1
+        # so its userId FK parent exists on the client. See
+        # gumnut_user_to_sync_user_metadata_v1 for the why.
         if SyncRequestType.UserMetadataV1 in requested_types:
             checkpoint = checkpoint_map.get(SyncEntityType.UserMetadataV1)
-            if checkpoint is None or checkpoint.cursor != _USER_METADATA_CURSOR:
+            if checkpoint is None or checkpoint.cursor != user_cursor:
                 sync_user_metadata = gumnut_user_to_sync_user_metadata_v1(owner_uuid)
                 yield make_sync_event(
                     SyncEntityType.UserMetadataV1,
                     sync_user_metadata.model_dump(mode="json"),
-                    _USER_METADATA_CURSOR,
+                    user_cursor,
                 )
                 logger.debug("Streamed user metadata", extra={"user_id": owner_id})
 

--- a/tests/unit/api/sync/test_sync_stream.py
+++ b/tests/unit/api/sync/test_sync_stream.py
@@ -1,6 +1,7 @@
 """Tests for sync stream generation, endpoint, reset, and pagination."""
 
 import json
+import logging
 from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock, Mock, call
@@ -13,6 +14,7 @@ from routers.api.sync.converters import gumnut_album_to_sync_album_user_v1
 from routers.api.sync.fk_integrity import SyncStreamStats
 from routers.api.sync.stream import (
     EVENTS_PAGE_SIZE,
+    _USER_METADATA_CURSOR,
     _stream_entity_type,
     generate_reset_stream,
     generate_sync_stream,
@@ -607,7 +609,7 @@ class TestGenerateSyncStream:
         checkpoint = Checkpoint(
             entity_type=SyncEntityType.UserMetadataV1,
             updated_at=updated_at,
-            cursor="preferences-v1",
+            cursor=_USER_METADATA_CURSOR,
         )
         checkpoint_map = {SyncEntityType.UserMetadataV1: checkpoint}
 
@@ -616,6 +618,80 @@ class TestGenerateSyncStream:
         )
 
         assert [e["type"] for e in events] == ["SyncCompleteV1"]
+
+    @pytest.mark.anyio
+    async def test_user_metadata_reemitted_when_cursor_changed(self):
+        """A client acked under a prior cursor (before the suffix was bumped) gets
+        the preferences row re-emitted — the constant-cursor design's forward-compat
+        path."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        mock_user = create_mock_user(updated_at)
+        mock_client = create_mock_gumnut_client(mock_user)
+
+        request = SyncStreamDto(types=[SyncRequestType.UserMetadataV1])
+        checkpoint = Checkpoint(
+            entity_type=SyncEntityType.UserMetadataV1,
+            updated_at=updated_at,
+            cursor="preferences-v0-stale",
+        )
+        checkpoint_map = {SyncEntityType.UserMetadataV1: checkpoint}
+
+        events = await collect_stream(
+            generate_sync_stream(mock_client, request, checkpoint_map, mock_user)
+        )
+
+        assert [e["type"] for e in events] == ["UserMetadataV1", "SyncCompleteV1"]
+        assert events[0]["ack"].startswith(f"UserMetadataV1|{_USER_METADATA_CURSOR}|")
+
+    @pytest.mark.anyio
+    async def test_streams_user_then_user_metadata_in_fk_order(self):
+        """When both are requested, UserV1 is emitted before UserMetadataV1 so the
+        userId FK parent exists on the client first; a reorder regression fails here."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        mock_user = create_mock_user(updated_at)
+        mock_client = create_mock_gumnut_client(mock_user)
+
+        request = SyncStreamDto(
+            types=[SyncRequestType.UsersV1, SyncRequestType.UserMetadataV1]
+        )
+        checkpoint_map: dict[SyncEntityType, Checkpoint] = {}
+
+        events = await collect_stream(
+            generate_sync_stream(mock_client, request, checkpoint_map, mock_user)
+        )
+
+        types = [e["type"] for e in events]
+        assert types == ["UserV1", "UserMetadataV1", "SyncCompleteV1"]
+
+    @pytest.mark.anyio
+    async def test_noop_request_types_emit_nothing_without_unsupported_log(
+        self, caplog
+    ):
+        """Requested-but-no-op v3 types stream nothing (just SyncCompleteV1) and do
+        not trip the 'unsupported types' log — the point of _NOOP_REQUEST_TYPES."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        mock_user = create_mock_user(updated_at)
+        mock_client = create_mock_gumnut_client(mock_user)
+
+        request = SyncStreamDto(
+            types=[
+                SyncRequestType.MemoriesV1,
+                SyncRequestType.StacksV1,
+                SyncRequestType.PartnersV1,
+                SyncRequestType.AssetMetadataV1,
+            ]
+        )
+        checkpoint_map: dict[SyncEntityType, Checkpoint] = {}
+
+        with caplog.at_level(logging.INFO, logger="routers.api.sync.stream"):
+            events = await collect_stream(
+                generate_sync_stream(mock_client, request, checkpoint_map, mock_user)
+            )
+
+        assert [e["type"] for e in events] == ["SyncCompleteV1"]
+        assert not any(
+            "unsupported sync types" in record.message for record in caplog.records
+        )
 
     @pytest.mark.anyio
     async def test_streams_album_assets_when_requested(self):

--- a/tests/unit/api/sync/test_sync_stream.py
+++ b/tests/unit/api/sync/test_sync_stream.py
@@ -14,7 +14,6 @@ from routers.api.sync.converters import gumnut_album_to_sync_album_user_v1
 from routers.api.sync.fk_integrity import SyncStreamStats
 from routers.api.sync.stream import (
     EVENTS_PAGE_SIZE,
-    _USER_METADATA_CURSOR,
     _stream_entity_type,
     generate_reset_stream,
     generate_sync_stream,
@@ -593,14 +592,14 @@ class TestGenerateSyncStream:
         assert data["key"] == "preferences"
         assert data["userId"] == str(TEST_UUID)  # owner == user, FK parent
         assert data["value"]["people"]["minimumFaces"] == 1
-        # Static payload keyed off a constant cursor (emit-once).
-        assert events[0]["ack"].startswith("UserMetadataV1|preferences-v1|")
+        # Cursor is the user's updated_at, same as UserV1.
+        assert events[0]["ack"] == f"UserMetadataV1|{updated_at.isoformat()}|"
         assert events[1]["type"] == "SyncCompleteV1"
 
     @pytest.mark.anyio
     async def test_user_metadata_skipped_when_checkpoint_matches(self):
-        """The static preferences row is not re-emitted once the client has acked
-        its constant cursor."""
+        """The preferences row is not re-emitted once the client has acked the
+        current user cursor (unchanged user record)."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)
@@ -609,7 +608,7 @@ class TestGenerateSyncStream:
         checkpoint = Checkpoint(
             entity_type=SyncEntityType.UserMetadataV1,
             updated_at=updated_at,
-            cursor=_USER_METADATA_CURSOR,
+            cursor=updated_at.isoformat(),
         )
         checkpoint_map = {SyncEntityType.UserMetadataV1: checkpoint}
 
@@ -620,10 +619,9 @@ class TestGenerateSyncStream:
         assert [e["type"] for e in events] == ["SyncCompleteV1"]
 
     @pytest.mark.anyio
-    async def test_user_metadata_reemitted_when_cursor_changed(self):
-        """A client acked under a prior cursor (before the suffix was bumped) gets
-        the preferences row re-emitted — the constant-cursor design's forward-compat
-        path."""
+    async def test_user_metadata_reemitted_when_user_changed(self):
+        """A client acked under an older user cursor gets the preferences row
+        re-emitted when the user record changes — same delta semantics as UserV1."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)
@@ -632,7 +630,7 @@ class TestGenerateSyncStream:
         checkpoint = Checkpoint(
             entity_type=SyncEntityType.UserMetadataV1,
             updated_at=updated_at,
-            cursor="preferences-v0-stale",
+            cursor="2020-01-01T00:00:00+00:00",  # acked under an older user cursor
         )
         checkpoint_map = {SyncEntityType.UserMetadataV1: checkpoint}
 
@@ -641,7 +639,7 @@ class TestGenerateSyncStream:
         )
 
         assert [e["type"] for e in events] == ["UserMetadataV1", "SyncCompleteV1"]
-        assert events[0]["ack"].startswith(f"UserMetadataV1|{_USER_METADATA_CURSOR}|")
+        assert events[0]["ack"] == f"UserMetadataV1|{updated_at.isoformat()}|"
 
     @pytest.mark.anyio
     async def test_streams_user_then_user_metadata_in_fk_order(self):

--- a/tests/unit/api/sync/test_sync_stream.py
+++ b/tests/unit/api/sync/test_sync_stream.py
@@ -571,6 +571,53 @@ class TestGenerateSyncStream:
         assert events[1]["type"] == "SyncCompleteV1"
 
     @pytest.mark.anyio
+    async def test_streams_user_metadata_preferences_with_min_faces(self):
+        """UserMetadataV1 emits a synthesized preferences row with minimumFaces=1
+        so people with 1-2 faces still appear in the client's People tab."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        mock_user = create_mock_user(updated_at)
+        mock_client = create_mock_gumnut_client(mock_user)
+
+        request = SyncStreamDto(types=[SyncRequestType.UserMetadataV1])
+        checkpoint_map: dict[SyncEntityType, Checkpoint] = {}
+
+        events = await collect_stream(
+            generate_sync_stream(mock_client, request, checkpoint_map, mock_user)
+        )
+
+        assert len(events) == 2
+        assert events[0]["type"] == "UserMetadataV1"
+        data = events[0]["data"]
+        assert data["key"] == "preferences"
+        assert data["userId"] == str(TEST_UUID)  # owner == user, FK parent
+        assert data["value"]["people"]["minimumFaces"] == 1
+        # Static payload keyed off a constant cursor (emit-once).
+        assert events[0]["ack"].startswith("UserMetadataV1|preferences-v1|")
+        assert events[1]["type"] == "SyncCompleteV1"
+
+    @pytest.mark.anyio
+    async def test_user_metadata_skipped_when_checkpoint_matches(self):
+        """The static preferences row is not re-emitted once the client has acked
+        its constant cursor."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        mock_user = create_mock_user(updated_at)
+        mock_client = create_mock_gumnut_client(mock_user)
+
+        request = SyncStreamDto(types=[SyncRequestType.UserMetadataV1])
+        checkpoint = Checkpoint(
+            entity_type=SyncEntityType.UserMetadataV1,
+            updated_at=updated_at,
+            cursor="preferences-v1",
+        )
+        checkpoint_map = {SyncEntityType.UserMetadataV1: checkpoint}
+
+        events = await collect_stream(
+            generate_sync_stream(mock_client, request, checkpoint_map, mock_user)
+        )
+
+        assert [e["type"] for e in events] == ["SyncCompleteV1"]
+
+    @pytest.mark.anyio
     async def test_streams_album_assets_when_requested(self):
         """Album-to-asset links are streamed when AlbumToAssetsV1 is requested."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)

--- a/tests/unit/api/sync/test_sync_v2.py
+++ b/tests/unit/api/sync/test_sync_v2.py
@@ -36,8 +36,10 @@ from routers.immich_models import (
     SyncAssetV2,
     SyncEntityType,
     SyncRequestType,
+    UserMetadataKey,
 )
 from routers.utils import asset_conversion
+from tests.unit.api.sync.conftest import TEST_UUID
 
 
 # --- Payload shape (model_fields only — no instantiation) --------------------
@@ -218,3 +220,42 @@ def test_album_user_converter_sets_owner_role():
     )
     # Role field exists on the DTO the converter builds.
     assert "role" in SyncAlbumUserV1.model_fields
+
+
+# --- Requested-but-empty v3 types: explicit no-ops, not "unsupported" logs -----
+
+
+def test_requested_empty_v3_types_are_explicit_noops():
+    """Every v3 type the client requests but the adapter has no data for is an
+    explicit no-op (so it is not logged "unsupported" on every sync). Excludes
+    UserMetadataV1, which is emitted, not a no-op."""
+    empty_requested = {
+        SyncRequestType.AssetMetadataV1,
+        SyncRequestType.PartnersV1,
+        SyncRequestType.PartnerAssetExifsV1,
+        SyncRequestType.PartnerStacksV1,
+        SyncRequestType.AlbumAssetExifsV1,
+        SyncRequestType.MemoriesV1,
+        SyncRequestType.MemoryToAssetsV1,
+        SyncRequestType.StacksV1,
+    }
+    assert empty_requested <= set(_NOOP_REQUEST_TYPES)
+    assert empty_requested <= _SUPPORTED_REQUEST_TYPES
+    # Never streamed (absent from the entity-producing order).
+    streamed = {rt for rt, _, _ in _SYNC_TYPE_ORDER}
+    assert empty_requested.isdisjoint(streamed)
+    # UserMetadataV1 is emitted, so it must NOT be a no-op, but still supported.
+    assert SyncRequestType.UserMetadataV1 not in _NOOP_REQUEST_TYPES
+    assert SyncRequestType.UserMetadataV1 in _SUPPORTED_REQUEST_TYPES
+
+
+# --- UserMetadataV1 preferences (minimumFaces override) ------------------------
+
+
+def test_user_metadata_converter_sets_min_faces_one():
+    """The synthesized preferences row nests minimumFaces=1 under people, matching
+    the shape the client's Preferences.fromMap reads."""
+    md = converters.gumnut_user_to_sync_user_metadata_v1(TEST_UUID)
+    assert md.key == UserMetadataKey.preferences
+    assert md.userId == TEST_UUID
+    assert md.value["people"]["minimumFaces"] == 1


### PR DESCRIPTION
## Summary

Refines how the adapter handles the sync request types the Immich v3 mobile client sends on every `/sync/stream` call. Two independent improvements, each verified against the v3.0.0 mobile client's actual read paths:

### 1. Quiet the false "unsupported types" warning
The v3 client requests a broad set of types with no equivalent in a single-user Gumnut library: `partnersV1`, `partnerAssetExifsV1`, `partnerStacksV1`, `partnerAssetsV2`, `stacksV1`, `memoriesV1`, `memoryToAssetsV1`, `assetMetadataV1`, `albumAssetExifsV1`. These were logged as `Client requested unsupported sync types` on **every** sync. They now live in `_NOOP_REQUEST_TYPES`, so the adapter records them as intentional no-ops (matching the existing `assetOcrV1` / `albumAssetsV2` handling) and the misleading warning stops. Logging-only change — nothing was ever streamed for them.

### 2. Show people with 1–2 faces in the mobile People tab
The v3 client reads `people.minimumFaces` from the `UserMetadataV1` sync stream to decide which people appear in its People tab, defaulting to **3** when the stream is absent — hiding clusters of 1–2 faces. The adapter now synthesizes a single `UserMetadataV1` *preferences* row with `minimumFaces=1`. Only `people.minimumFaces` is load-bearing; the other sections mirror the client's own `Preferences.fromMap` defaults (which the client applies to any absent section anyway). It is emitted right after `UserV1` (its `userId` FK parent) and keyed off the same user cursor as `UserV1` (the user's `updated_at`), so it acks once and re-syncs only when the user record changes. Only the `preferences` key is synthesized — onboarding UI is gated on the login response, not the sync stream.

## Testing
- Unit tests for both behaviors in `test_sync_stream.py` and `test_sync_v2.py`, including: `UserV1`→`UserMetadataV1` FK ordering when both are requested, re-emit when the user record changes, the emit-once skip when the checkpoint cursor matches, and a no-op request emitting nothing without tripping the "unsupported types" log.
- Full suite: **1154 passed**; `ruff check` / `ruff format` / `pyright` all clean.

## Notes
- Targets `migration/immichv3`, alongside the already-merged owner `AlbumUserV1` fix (#271).

🤖 Generated with [Claude Code](https://claude.com/claude-code)