### PR TITLE
Run CI checks automatically before agent pushes

### DIFF
--- a/.claude/hooks/pre-push-checks.sh
+++ b/.claude/hooks/pre-push-checks.sh
@@ -67,27 +67,41 @@ cmd = payload.get("tool_input", {}).get("command", "")
 def mask_quotes(s):
     # Blank quoted contents, keeping quote chars and all offsets intact.
     # ("\x27" is a single quote — spelled as an escape because this program
-    # is embedded in a single-quoted shell string.) Two deliberate
-    # carve-outs:
+    # is embedded in a single-quoted shell string.) Deliberate carve-outs:
+    #   - Backslash escapes are honored: outside quotes, an escaped quote
+    #     does not open a span; inside double quotes it does not close one.
     #   - A double-quoted span containing $( or ` re-enters command context
-    #     (command substitution: "$(git push)" really pushes) — left
-    #     unmasked. Single-quoted spans are pure data in shell.
-    #   - If a quote never terminates, this masker cannot trust its read of
-    #     the rest (backslash escapes and heredocs it does not model) —
-    #     return the RAW string and err broad: over-matching runs checks
-    #     needlessly; masking away a real push would fail open.
+    #     (command substitution really pushes) — left unmasked.
+    #   - If a quote never terminates, return the RAW string and err broad:
+    #     masking away a real push would fail open.
     out = []
     i, n = 0, len(s)
     while i < n:
         ch = s[i]
-        if ch in "\"\x27":
+        if ch == "\\" and i + 1 < n:
+            out.append(s[i:i + 2])
+            i += 2
+        elif ch == "\x27":
             j = i + 1
-            while j < n and s[j] != ch:
+            while j < n and s[j] != "\x27":
                 j += 1
             if j >= n:
                 return s
-            content = s[i + 1:j]
-            if ch == "\"" and ("$(" in content or "`" in content):
+            out.append(ch + " " * (j - i - 1) + ch)
+            i = j + 1
+        elif ch == "\"":
+            j = i + 1
+            cmdsub = False
+            while j < n and s[j] != "\"":
+                if s[j] == "\\" and j + 1 < n:
+                    j += 2
+                    continue
+                if s[j] == "`" or (s[j] == "$" and j + 1 < n and s[j + 1] == "("):
+                    cmdsub = True
+                j += 1
+            if j >= n:
+                return s
+            if cmdsub:
                 out.append(s[i:j + 1])
             else:
                 out.append(ch + " " * (j - i - 1) + ch)
@@ -100,12 +114,58 @@ def mask_quotes(s):
 masked = mask_quotes(cmd)
 masked = re.sub(r"(?<![\w./-])stash\s+push(?![\w./-])",
                 lambda m: " " * len(m.group(0)), masked)
-if not re.search(r"(?<![\w./-])git(?![\w./-])[^|;&\n]*(?<![\w./-])push(?![\w./-])", masked):
+
+# `git` must sit in command position; `push` must be a standalone token. A
+# QUOTED subcommand (`git "push"`) still executes a push after shell quote
+# removal, so a second pass over the ORIGINAL text catches it. Residual
+# over-match: an unquoted free-text `push` argument to a real git command
+# still matches — err broad; the fix is quoting the message.
+CMD_POS = r"(?:^|[;&|\n(])\s*(?:(?:env|command|exec)\s+)*(?:[A-Za-z_][A-Za-z_0-9]*=(?:[^\s;|&]|\"[^\"]*\"|\x27[^\x27]*\x27)*\s+)*"
+# Optional path prefix: `/usr/bin/git push` is still a push.
+GIT_TOKEN = r"(?:[^\s;|&]*/)?git(?![\w./-])"
+PUSH_RE = CMD_POS + GIT_TOKEN + r"[^|;&\n]*?(?<![\w./-])push(?![\w./-])"
+QPUSH_RE = CMD_POS + GIT_TOKEN + r"[^|;&\n]*?[\"\x27]push[\"\x27]"
+
+pushes = list(re.finditer(PUSH_RE, masked))
+starts = set(p.start() for p in pushes)
+pushes += [m for m in re.finditer(QPUSH_RE, cmd) if m.start() not in starts]
+pushes.sort(key=lambda m: m.start())
+if not pushes:
     sys.exit(NOT_A_PUSH)
-# Any command-position assignment anywhere in the command counts (even one
-# not syntactically applied to the push): an unquoted deliberate assignment
-# is a clear statement of intent. Quoted mentions never count (masked).
-if re.search(r"(?:^|[;&|\n(])\s*(?:export\s+|env\s+)?GUMNUT_SKIP_PUSH_CHECKS=1(?!\w)", masked):
+
+# Shell scope model for exports: chains computed at match END (the match
+# START is the anchor, which may itself be the paren opening the scope).
+def stack_at(pos):
+    st = []
+    for k in range(pos):
+        c = masked[k]
+        if c == "(":
+            st.append(k)
+        elif c == ")" and st:
+            st.pop()
+    return st
+
+def applies(x, p):
+    if x.start() >= p.start():
+        return False
+    xs, ps = stack_at(x.end()), stack_at(p.end())
+    return xs == ps[:len(xs)]
+
+# Skip semantics, per push (a quoted mention never counts — masked): the
+# segment of the push itself is prefixed with the assignment, or an
+# `export GUMNUT_SKIP_PUSH_CHECKS=1` precedes it in an applicable scope.
+# A bare assignment on another command does not persist and skips nothing;
+# a partial skip leaves the other pushes checked.
+exports = list(re.finditer(r"(?:^|[;&|\n(])\s*export\s+GUMNUT_SKIP_PUSH_CHECKS=1(?!\w)", masked))
+
+def is_skipped(p):
+    seg = masked[p.start():p.end()]
+    git_at = re.search(GIT_TOKEN, seg)
+    if git_at and "GUMNUT_SKIP_PUSH_CHECKS=1" in seg[:git_at.start()]:
+        return True
+    return any(applies(e, p) for e in exports)
+
+if all(is_skipped(p) for p in pushes):
     sys.exit(SKIPPED)
 sys.exit(0)
 '

--- a/.claude/hooks/pre-push-checks.sh
+++ b/.claude/hooks/pre-push-checks.sh
@@ -117,17 +117,18 @@ masked = re.sub(r"(?<![\w./-])stash\s+push(?![\w./-])",
 
 # `git` must sit in command position; `push` must be a standalone token. A
 # QUOTED subcommand (`git "push"`) still executes a push after shell quote
-# removal, so a second pass over the ORIGINAL text catches it. Residual
-# over-match: an unquoted free-text `push` argument to a real git command
-# still matches — err broad; the fix is quoting the message.
-CMD_POS = r"(?:^|[;&|\n(]|(?<![\w-])(?:then|do|else|elif)\s)\s*(?:(?:env|command|exec)\s+)*(?:[A-Za-z_][A-Za-z_0-9]*=(?:[^\s;|&]|\"[^\"]*\"|\x27[^\x27]*\x27)*\s+)*"
+# removal, so a second pass over the ORIGINAL text catches it. push must sit in
+# SUBCOMMAND position (git, then only flag/value tokens), so `git log
+# --grep=push` and `git grep push` are data, not pushes.
+CMD_POS = r"(?:^|[;&|\n({]|(?<![\w-])(?:then|do|else|elif)\s)\s*(?:(?:env|command|exec)\s+)*(?:[A-Za-z_][A-Za-z_0-9]*=(?:[^\s;|&]|\"[^\"]*\"|\x27[^\x27]*\x27)*\s+)*"
 # Optional path prefix: `/usr/bin/git push` is still a push.
 GIT_TOKEN = r"(?:[^\s;|&]*/)?git(?![\w./-])"
-PUSH_RE = CMD_POS + GIT_TOKEN + r"[^|;&\n]*?(?<![\w./-])push(?![\w./-])"
+GIT_FLAGS = r"(?:\s+-{1,2}[^\s;|&]+(?:\s+(?:[^\s;|&\"\x27-][^\s;|&]*|\"[^\"]*\"|\x27[^\x27]*\x27))?)*"
+PUSH_RE = CMD_POS + GIT_TOKEN + GIT_FLAGS + r"\s+push(?![\w./-])"
 # Quoted-push fallback is restricted to SUBCOMMAND position (git, then
 # only flag tokens, then the quoted word) — `git commit -m "push"` and
 # `git grep "push"` have a non-flag token first and are data, not pushes.
-QPUSH_RE = CMD_POS + GIT_TOKEN + r"(?:\s+-{1,2}[^\s;|&]+(?:\s+[^\s;|&\"\x27-][^\s;|&]*)?)*\s+[\"\x27]push[\"\x27]"
+QPUSH_RE = CMD_POS + GIT_TOKEN + GIT_FLAGS + r"\s+[\"\x27]push[\"\x27]"
 
 pushes = list(re.finditer(PUSH_RE, masked))
 starts = set(p.start() for p in pushes)
@@ -159,7 +160,7 @@ def applies(x, p):
 # `export GUMNUT_SKIP_PUSH_CHECKS=1` precedes it in an applicable scope.
 # A bare assignment on another command does not persist and skips nothing;
 # a partial skip leaves the other pushes checked.
-exports = list(re.finditer(r"(?:^|[;&|\n(]|(?<![\w-])(?:then|do|else|elif)\s)\s*export\s+GUMNUT_SKIP_PUSH_CHECKS=1(?!\w)", masked))
+exports = list(re.finditer(r"(?:^|[;&|\n({]|(?<![\w-])(?:then|do|else|elif)\s)\s*export\s+GUMNUT_SKIP_PUSH_CHECKS=1(?!\w)", masked))
 
 def is_skipped(p):
     seg = masked[p.start():p.end()]

--- a/.claude/hooks/pre-push-checks.sh
+++ b/.claude/hooks/pre-push-checks.sh
@@ -156,7 +156,7 @@ masked = re.sub(r"(?<![\w./-])stash\s+push(?![\w./-])",
 # removal, so a second pass over the ORIGINAL text catches it. push must sit in
 # SUBCOMMAND position (git, then only flag/value tokens), so `git log
 # --grep=push` and `git grep push` are data, not pushes.
-CMD_POS = r"(?:^|[;&|\n({\"\x27]|(?<![\w-])(?:then|do|else|elif)\s)\s*(?:(?:env|command|exec|time)(?:\s+-p)?\s+)*(?:[A-Za-z_][A-Za-z_0-9]*=(?:[^\s;|&]|\"[^\"]*\"|\x27[^\x27]*\x27)*\s+)*"
+CMD_POS = r"(?:^|[;&|\n({\"\x27]|(?<![\w-])(?:then|do|else|elif|if|while|until)\s)\s*(?:!\s+)?(?:(?:env|command|exec|time)(?:\s+-p)?\s+)*(?:[A-Za-z_][A-Za-z_0-9]*=(?:[^\s;|&]|\"[^\"]*\"|\x27[^\x27]*\x27)*\s+)*"
 # Optional path prefix: `/usr/bin/git push` is still a push.
 GIT_TOKEN = r"(?:[^\s;|&]*/)?git(?![\w./-])"
 GIT_FLAGS = r"(?:\s+-{1,2}[^\s;|&]+(?:\s+(?:[^\s;|&\"\x27-][^\s;|&]*|\"[^\"]*\"|\x27[^\x27]*\x27))?)*"
@@ -196,7 +196,7 @@ def applies(x, p):
 # `export GUMNUT_SKIP_PUSH_CHECKS=1` precedes it in an applicable scope.
 # A bare assignment on another command does not persist and skips nothing;
 # a partial skip leaves the other pushes checked.
-exports = list(re.finditer(r"(?:^|[;&|\n({\"\x27]|(?<![\w-])(?:then|do|else|elif)\s)\s*export\s+GUMNUT_SKIP_PUSH_CHECKS=1(?!\w)", masked))
+exports = list(re.finditer(r"(?:^|[;&|\n({\"\x27]|(?<![\w-])(?:then|do|else|elif|if|while|until)\s)\s*export\s+GUMNUT_SKIP_PUSH_CHECKS=1(?!\w)", masked))
 
 def is_skipped(p):
     seg = masked[p.start():p.end()]

--- a/.claude/hooks/pre-push-checks.sh
+++ b/.claude/hooks/pre-push-checks.sh
@@ -120,11 +120,14 @@ masked = re.sub(r"(?<![\w./-])stash\s+push(?![\w./-])",
 # removal, so a second pass over the ORIGINAL text catches it. Residual
 # over-match: an unquoted free-text `push` argument to a real git command
 # still matches — err broad; the fix is quoting the message.
-CMD_POS = r"(?:^|[;&|\n(])\s*(?:(?:env|command|exec)\s+)*(?:[A-Za-z_][A-Za-z_0-9]*=(?:[^\s;|&]|\"[^\"]*\"|\x27[^\x27]*\x27)*\s+)*"
+CMD_POS = r"(?:^|[;&|\n(]|(?<![\w-])(?:then|do|else|elif)\s)\s*(?:(?:env|command|exec)\s+)*(?:[A-Za-z_][A-Za-z_0-9]*=(?:[^\s;|&]|\"[^\"]*\"|\x27[^\x27]*\x27)*\s+)*"
 # Optional path prefix: `/usr/bin/git push` is still a push.
 GIT_TOKEN = r"(?:[^\s;|&]*/)?git(?![\w./-])"
 PUSH_RE = CMD_POS + GIT_TOKEN + r"[^|;&\n]*?(?<![\w./-])push(?![\w./-])"
-QPUSH_RE = CMD_POS + GIT_TOKEN + r"[^|;&\n]*?[\"\x27]push[\"\x27]"
+# Quoted-push fallback is restricted to SUBCOMMAND position (git, then
+# only flag tokens, then the quoted word) — `git commit -m "push"` and
+# `git grep "push"` have a non-flag token first and are data, not pushes.
+QPUSH_RE = CMD_POS + GIT_TOKEN + r"(?:\s+-{1,2}[^\s;|&]+(?:\s+[^\s;|&\"\x27-][^\s;|&]*)?)*\s+[\"\x27]push[\"\x27]"
 
 pushes = list(re.finditer(PUSH_RE, masked))
 starts = set(p.start() for p in pushes)
@@ -156,7 +159,7 @@ def applies(x, p):
 # `export GUMNUT_SKIP_PUSH_CHECKS=1` precedes it in an applicable scope.
 # A bare assignment on another command does not persist and skips nothing;
 # a partial skip leaves the other pushes checked.
-exports = list(re.finditer(r"(?:^|[;&|\n(])\s*export\s+GUMNUT_SKIP_PUSH_CHECKS=1(?!\w)", masked))
+exports = list(re.finditer(r"(?:^|[;&|\n(]|(?<![\w-])(?:then|do|else|elif)\s)\s*export\s+GUMNUT_SKIP_PUSH_CHECKS=1(?!\w)", masked))
 
 def is_skipped(p):
     seg = masked[p.start():p.end()]

--- a/.claude/hooks/pre-push-checks.sh
+++ b/.claude/hooks/pre-push-checks.sh
@@ -28,49 +28,104 @@ esac
 # Stdin carried the PreToolUse payload: {"tool_input": {"command": "..."}, ...}.
 # python3 does the JSON parsing AND the push matching: unlike jq it's present
 # on every macOS/Linux dev and cloud image this repo targets, and unlike
-# sed/grep its \b regex semantics don't vary between BSD and GNU tools.
+# sed/grep its regex semantics don't vary between BSD and GNU tools.
+# Matching principles:
+#   - Quoted spans are DATA, not command: they are masked (offset-preserving)
+#     before any matching, so a commit message mentioning "git push" or the
+#     skip flag can neither trigger nor bypass the hook.
+#   - `push` must be a standalone token ((?<![\w./-]) / (?![\w./-])), so
+#     "pre-push-checks.sh" or "pre-push checks" never match.
+#   - `git stash push` is blanked first — a stash is what an agent reaches
+#     for when the tree is dirty, i.e. exactly when checks would fail.
+#   - The skip flag counts only as a command-position assignment
+#     (`GUMNUT_SKIP_PUSH_CHECKS=1 ...`, optionally export/env-prefixed).
+# A remaining over-match (a push targeting a *different* repo via
+# `git -C ../other-repo push`) still runs this repo's checks — the skip
+# assignment is the remedy. Under-matching would let a real push through
+# unchecked, so err broad.
 #
-# Match `git push` allowing intervening flags (`git -C x push`) and compound
-# commands (`git add ... && git push`), but not `git stash push` — a stash is
-# what an agent reaches for when the tree is dirty, i.e. exactly when checks
-# would fail, so a false match there would block an unrelated command.
-# Remaining over-matches cost a needless check run when checks pass but DO
-# block the command when checks fail — notably a push targeting a *different*
-# repo from a session in this one (`git -C ../other-repo push`), which this
-# repo's failures would block with confusing errors; the
-# GUMNUT_SKIP_PUSH_CHECKS=1 escape hatch is the remedy. Under-matching would
-# let a real push through unchecked, so still err broad.
-#
-# python3 exit codes: 0 = push detected, 1 = not a push. Anything else means
-# python3 itself is missing/broken — treat that as push-detected (fail
-# closed, per the err-broad posture) rather than silently disabling the
-# guard forever on that environment.
+# python3 exit codes: 0 = push detected; 3 = not a push; 4 = skip flag
+# applied; 5 = payload did not parse as JSON (the payload producer is Claude
+# Code itself, so malformed means something changed — warn, then fail
+# closed). "Not a push" is deliberately NOT exit 1: a broken interpreter
+# shim or a syntax error in this embedded program exits 1, and mapping that
+# to "not a push" would silently disable the guard forever — any exit
+# outside {0,3,4,5} warns and fails closed (runs the checks).
 printf '%s' "$payload" | python3 -c '
 import json, re, sys
+
+NOT_A_PUSH = 3
+SKIPPED = 4
+PARSE_FAILURE = 5
+
 try:
     payload = json.load(sys.stdin)
 except Exception:
-    sys.exit(1)
+    sys.exit(PARSE_FAILURE)
 cmd = payload.get("tool_input", {}).get("command", "")
-cmd = re.sub(r"\bstash\s+push\b", "", cmd)
-sys.exit(0 if re.search(r"\bgit\b[^|;&\n]*\bpush\b", cmd) else 1)
+
+def mask_quotes(s):
+    # Blank quoted contents, keeping quote chars and all offsets intact.
+    # ("\x27" is a single quote — spelled as an escape because this program
+    # is embedded in a single-quoted shell string.) Two deliberate
+    # carve-outs:
+    #   - A double-quoted span containing $( or ` re-enters command context
+    #     (command substitution: "$(git push)" really pushes) — left
+    #     unmasked. Single-quoted spans are pure data in shell.
+    #   - If a quote never terminates, this masker cannot trust its read of
+    #     the rest (backslash escapes and heredocs it does not model) —
+    #     return the RAW string and err broad: over-matching runs checks
+    #     needlessly; masking away a real push would fail open.
+    out = []
+    i, n = 0, len(s)
+    while i < n:
+        ch = s[i]
+        if ch in "\"\x27":
+            j = i + 1
+            while j < n and s[j] != ch:
+                j += 1
+            if j >= n:
+                return s
+            content = s[i + 1:j]
+            if ch == "\"" and ("$(" in content or "`" in content):
+                out.append(s[i:j + 1])
+            else:
+                out.append(ch + " " * (j - i - 1) + ch)
+            i = j + 1
+        else:
+            out.append(ch)
+            i += 1
+    return "".join(out)
+
+masked = mask_quotes(cmd)
+masked = re.sub(r"(?<![\w./-])stash\s+push(?![\w./-])",
+                lambda m: " " * len(m.group(0)), masked)
+if not re.search(r"(?<![\w./-])git(?![\w./-])[^|;&\n]*(?<![\w./-])push(?![\w./-])", masked):
+    sys.exit(NOT_A_PUSH)
+# Any command-position assignment anywhere in the command counts (even one
+# not syntactically applied to the push): an unquoted deliberate assignment
+# is a clear statement of intent. Quoted mentions never count (masked).
+if re.search(r"(?:^|[;&|\n(])\s*(?:export\s+|env\s+)?GUMNUT_SKIP_PUSH_CHECKS=1(?!\w)", masked):
+    sys.exit(SKIPPED)
+sys.exit(0)
 '
 rc=$?
-if [ "$rc" = "1" ]; then
+if [ "$rc" = "3" ]; then
   exit 0
+elif [ "$rc" = "4" ]; then
+  echo "pre-push-checks: skipped (GUMNUT_SKIP_PUSH_CHECKS=1)" >&2
+  exit 0
+elif [ "$rc" = "5" ]; then
+  echo "pre-push-checks adapter: hook payload did not parse as JSON — this should not happen (the payload comes from Claude Code itself); investigate. Running checks anyway (fail closed)." >&2
 elif [ "$rc" != "0" ]; then
   echo "pre-push-checks adapter: python3 failed (exit $rc); treating command as a push and running checks (fail closed)" >&2
 fi
 
-# Honor the escape hatch whether exported or written inline in the command
-# (the checker itself also honors the exported form).
-if printf '%s' "$payload" | grep -q 'GUMNUT_SKIP_PUSH_CHECKS=1'; then
-  echo "pre-push-checks: skipped (GUMNUT_SKIP_PUSH_CHECKS=1)" >&2
-  exit 0
-fi
-
+# Checker output goes to stderr (1>&2): on exit 2 the hook contract feeds
+# stderr — not stdout — back to the model, and the failure text is the
+# actionable part.
 script_dir=$(cd "$(dirname "$0")" && pwd)
-if "$script_dir/../../scripts/pre-push-checks.sh"; then
+if "$script_dir/../../scripts/pre-push-checks.sh" 1>&2; then
   exit 0
 else
   exit 2

--- a/.claude/hooks/pre-push-checks.sh
+++ b/.claude/hooks/pre-push-checks.sh
@@ -120,7 +120,34 @@ def mask_quotes(s):
             i += 1
     return "".join(out)
 
-masked = mask_quotes(cmd)
+def mask_heredocs(s):
+    # Heredoc bodies are data: blank every line between <<DELIM and the
+    # closing delimiter line (offset-preserving; newlines kept). Openers may
+    # be quoted (<<'EOF') or dash-led (<<-EOF). Openers that fall inside an
+    # already-blanked body are ignored.
+    out = list(s)
+    for m in re.finditer(r"<<-?\s*([\"\x27]?)(\w+)\1", s):
+        if out[m.start()] == " ":
+            continue
+        delim = m.group(2)
+        nl = s.find("\n", m.end())
+        if nl == -1:
+            break
+        i = nl + 1
+        while i < len(s):
+            j = s.find("\n", i)
+            line_end = len(s) if j == -1 else j
+            if s[i:line_end].strip() == delim:
+                break
+            for k in range(i, line_end):
+                out[k] = " "
+            if j == -1:
+                break
+            i = j + 1
+    return "".join(out)
+
+cmd_hd = mask_heredocs(cmd)
+masked = mask_quotes(cmd_hd)
 masked = re.sub(r"(?<![\w./-])stash\s+push(?![\w./-])",
                 lambda m: " " * len(m.group(0)), masked)
 
@@ -129,7 +156,7 @@ masked = re.sub(r"(?<![\w./-])stash\s+push(?![\w./-])",
 # removal, so a second pass over the ORIGINAL text catches it. push must sit in
 # SUBCOMMAND position (git, then only flag/value tokens), so `git log
 # --grep=push` and `git grep push` are data, not pushes.
-CMD_POS = r"(?:^|[;&|\n({\"\x27]|(?<![\w-])(?:then|do|else|elif)\s)\s*(?:(?:env|command|exec)\s+)*(?:[A-Za-z_][A-Za-z_0-9]*=(?:[^\s;|&]|\"[^\"]*\"|\x27[^\x27]*\x27)*\s+)*"
+CMD_POS = r"(?:^|[;&|\n({\"\x27]|(?<![\w-])(?:then|do|else|elif)\s)\s*(?:(?:env|command|exec|time)(?:\s+-p)?\s+)*(?:[A-Za-z_][A-Za-z_0-9]*=(?:[^\s;|&]|\"[^\"]*\"|\x27[^\x27]*\x27)*\s+)*"
 # Optional path prefix: `/usr/bin/git push` is still a push.
 GIT_TOKEN = r"(?:[^\s;|&]*/)?git(?![\w./-])"
 GIT_FLAGS = r"(?:\s+-{1,2}[^\s;|&]+(?:\s+(?:[^\s;|&\"\x27-][^\s;|&]*|\"[^\"]*\"|\x27[^\x27]*\x27))?)*"
@@ -141,7 +168,7 @@ QPUSH_RE = CMD_POS + GIT_TOKEN + GIT_FLAGS + r"\s+[\"\x27]push[\"\x27]"
 
 pushes = list(re.finditer(PUSH_RE, masked))
 starts = set(p.start() for p in pushes)
-pushes += [m for m in re.finditer(QPUSH_RE, cmd) if m.start() not in starts]
+pushes += [m for m in re.finditer(QPUSH_RE, cmd_hd) if m.start() not in starts]
 pushes.sort(key=lambda m: m.start())
 if not pushes:
     sys.exit(NOT_A_PUSH)

--- a/.claude/hooks/pre-push-checks.sh
+++ b/.claude/hooks/pre-push-checks.sh
@@ -74,6 +74,12 @@ def mask_quotes(s):
     #     (command substitution really pushes) — left unmasked.
     #   - If a quote never terminates, return the RAW string and err broad:
     #     masking away a real push would fail open.
+    def shell_c_before(prefix):
+        # A quote directly following `bash -lc` / `sh -c` / `eval` (or their
+        # env/command-wrapped forms) opens a SCRIPT, not data — its content
+        # will execute in a nested shell, so it stays unmasked.
+        return re.search(r"(?<![\w./-])(?:bash|sh|zsh|dash|eval)\s+(?:-[^\s;|&]+\s+)*$", prefix) is not None
+
     out = []
     i, n = 0, len(s)
     while i < n:
@@ -87,7 +93,10 @@ def mask_quotes(s):
                 j += 1
             if j >= n:
                 return s
-            out.append(ch + " " * (j - i - 1) + ch)
+            if shell_c_before(s[:i]):
+                out.append(s[i:j + 1])
+            else:
+                out.append(ch + " " * (j - i - 1) + ch)
             i = j + 1
         elif ch == "\"":
             j = i + 1
@@ -101,7 +110,7 @@ def mask_quotes(s):
                 j += 1
             if j >= n:
                 return s
-            if cmdsub:
+            if cmdsub or shell_c_before(s[:i]):
                 out.append(s[i:j + 1])
             else:
                 out.append(ch + " " * (j - i - 1) + ch)
@@ -120,7 +129,7 @@ masked = re.sub(r"(?<![\w./-])stash\s+push(?![\w./-])",
 # removal, so a second pass over the ORIGINAL text catches it. push must sit in
 # SUBCOMMAND position (git, then only flag/value tokens), so `git log
 # --grep=push` and `git grep push` are data, not pushes.
-CMD_POS = r"(?:^|[;&|\n({]|(?<![\w-])(?:then|do|else|elif)\s)\s*(?:(?:env|command|exec)\s+)*(?:[A-Za-z_][A-Za-z_0-9]*=(?:[^\s;|&]|\"[^\"]*\"|\x27[^\x27]*\x27)*\s+)*"
+CMD_POS = r"(?:^|[;&|\n({\"\x27]|(?<![\w-])(?:then|do|else|elif)\s)\s*(?:(?:env|command|exec)\s+)*(?:[A-Za-z_][A-Za-z_0-9]*=(?:[^\s;|&]|\"[^\"]*\"|\x27[^\x27]*\x27)*\s+)*"
 # Optional path prefix: `/usr/bin/git push` is still a push.
 GIT_TOKEN = r"(?:[^\s;|&]*/)?git(?![\w./-])"
 GIT_FLAGS = r"(?:\s+-{1,2}[^\s;|&]+(?:\s+(?:[^\s;|&\"\x27-][^\s;|&]*|\"[^\"]*\"|\x27[^\x27]*\x27))?)*"
@@ -160,12 +169,12 @@ def applies(x, p):
 # `export GUMNUT_SKIP_PUSH_CHECKS=1` precedes it in an applicable scope.
 # A bare assignment on another command does not persist and skips nothing;
 # a partial skip leaves the other pushes checked.
-exports = list(re.finditer(r"(?:^|[;&|\n({]|(?<![\w-])(?:then|do|else|elif)\s)\s*export\s+GUMNUT_SKIP_PUSH_CHECKS=1(?!\w)", masked))
+exports = list(re.finditer(r"(?:^|[;&|\n({\"\x27]|(?<![\w-])(?:then|do|else|elif)\s)\s*export\s+GUMNUT_SKIP_PUSH_CHECKS=1(?!\w)", masked))
 
 def is_skipped(p):
     seg = masked[p.start():p.end()]
     git_at = re.search(GIT_TOKEN, seg)
-    if git_at and "GUMNUT_SKIP_PUSH_CHECKS=1" in seg[:git_at.start()]:
+    if git_at and re.search(r"(?:^|\s|[;&|\n({])(?:export\s+|env\s+)?GUMNUT_SKIP_PUSH_CHECKS=1(?!\S)", seg[:git_at.start()]):
         return True
     return any(applies(e, p) for e in exports)
 

--- a/.claude/hooks/pre-push-checks.sh
+++ b/.claude/hooks/pre-push-checks.sh
@@ -53,7 +53,7 @@ except Exception:
     sys.exit(1)
 cmd = payload.get("tool_input", {}).get("command", "")
 cmd = re.sub(r"\bstash\s+push\b", "", cmd)
-sys.exit(0 if re.search(r"\bgit\b[^|;&]*\bpush\b", cmd) else 1)
+sys.exit(0 if re.search(r"\bgit\b[^|;&\n]*\bpush\b", cmd) else 1)
 '
 rc=$?
 if [ "$rc" = "1" ]; then

--- a/.claude/hooks/pre-push-checks.sh
+++ b/.claude/hooks/pre-push-checks.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# .claude/hooks/pre-push-checks.sh
+#
+# Claude Code adapter for scripts/pre-push-checks.sh (the platform-neutral
+# checker — all check logic lives there). Wired in `.claude/settings.json` as
+# a PreToolUse hook on the Bash tool, so it fires for EVERY Bash command:
+# this adapter reads the tool-call JSON on stdin and exits 0 immediately
+# unless the command is a `git push`. Because it intercepts the tool call
+# itself, `git push --no-verify` does not bypass it (that flag only skips
+# `.git/hooks/*`). Runs in local Claude Code and in claude.ai/code cloud
+# sessions alike — the settings file ships with the clone.
+#
+# Exit codes (Claude Code hook contract):
+#   0 — allow the push (not a push command, checks passed, or skipped)
+#   2 — block the push; stderr is fed back to Claude to fix and retry
+
+set -uo pipefail
+
+# This adapter runs for EVERY Bash tool call, so the common path must be
+# cheap: a raw substring pre-filter decides whether the payload could even
+# mention a push before paying the ~80ms python3 spawn for real JSON parsing.
+payload=$(cat)
+case "$payload" in
+  *push*) ;;
+  *) exit 0 ;;
+esac
+
+# Stdin carried the PreToolUse payload: {"tool_input": {"command": "..."}, ...}.
+# python3 does the JSON parsing AND the push matching: unlike jq it's present
+# on every macOS/Linux dev and cloud image this repo targets, and unlike
+# sed/grep its \b regex semantics don't vary between BSD and GNU tools.
+#
+# Match `git push` allowing intervening flags (`git -C x push`) and compound
+# commands (`git add ... && git push`), but not `git stash push` — a stash is
+# what an agent reaches for when the tree is dirty, i.e. exactly when checks
+# would fail, so a false match there would block an unrelated command.
+# Remaining over-matches cost a needless check run when checks pass but DO
+# block the command when checks fail — notably a push targeting a *different*
+# repo from a session in this one (`git -C ../other-repo push`), which this
+# repo's failures would block with confusing errors; the
+# GUMNUT_SKIP_PUSH_CHECKS=1 escape hatch is the remedy. Under-matching would
+# let a real push through unchecked, so still err broad.
+#
+# python3 exit codes: 0 = push detected, 1 = not a push. Anything else means
+# python3 itself is missing/broken — treat that as push-detected (fail
+# closed, per the err-broad posture) rather than silently disabling the
+# guard forever on that environment.
+printf '%s' "$payload" | python3 -c '
+import json, re, sys
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+cmd = payload.get("tool_input", {}).get("command", "")
+cmd = re.sub(r"\bstash\s+push\b", "", cmd)
+sys.exit(0 if re.search(r"\bgit\b[^|;&]*\bpush\b", cmd) else 1)
+'
+rc=$?
+if [ "$rc" = "1" ]; then
+  exit 0
+elif [ "$rc" != "0" ]; then
+  echo "pre-push-checks adapter: python3 failed (exit $rc); treating command as a push and running checks (fail closed)" >&2
+fi
+
+# Honor the escape hatch whether exported or written inline in the command
+# (the checker itself also honors the exported form).
+if printf '%s' "$payload" | grep -q 'GUMNUT_SKIP_PUSH_CHECKS=1'; then
+  echo "pre-push-checks: skipped (GUMNUT_SKIP_PUSH_CHECKS=1)" >&2
+  exit 0
+fi
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+if "$script_dir/../../scripts/pre-push-checks.sh"; then
+  exit 0
+else
+  exit 2
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-push-checks.sh",
+            "timeout": 600
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
       - name: Run type checker
         run: uv run pyright
 
+      # Guards the pre-push tooling (scripts/pre-push-checks.sh and its
+      # Claude Code adapter), which mirrors this job's checks — hermetic,
+      # needs only bash + git + python3.
+      - name: Run pre-push tooling tests
+        run: scripts/pre-push-checks_test.sh
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
       - name: Run tests
         run: uv run pytest
 
+  # NOTE: mirrored by scripts/pre-push-checks.sh's immich-version-sync
+  # check — update both.
   check-immich-version-sync:
     name: Check Immich version sync
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ Run from the `immich-adapter/` directory:
 - **Type check**: `uv run pyright`
 - **Test**: `uv run pytest`
 
+**Before pushing**: run `scripts/pre-push-checks.sh` — the fast subset of CI (ruff check/format, pyright, Immich version-sync; no tests). Claude Code sessions opened in this repo run it automatically on every `git push` (via the `.claude/hooks/pre-push-checks.sh` adapter wired as a `PreToolUse` hook in `.claude/settings.json`; `git push --no-verify` does not bypass it). Sessions opened elsewhere and agents on other platforms run it themselves before pushing or finishing a task. Emergency skip: `GUMNUT_SKIP_PUSH_CHECKS=1 git push` (use sparingly; CI still runs everything).
+
 # Documentation Map
 
 This file is a concise quick-reference. Detailed content belongs in the appropriate `docs/` subdirectory, not here. Add new topics to the table below and create a corresponding doc file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,4 +65,4 @@ Detailed docs live in subdirectories: `docs/architecture/` (system architecture)
 | Session & checkpoint reference | `docs/references/session-checkpoint-reference.md` | Session/checkpoint object shapes, field definitions |
 | Immich sync communication | `docs/references/immich-sync-communication.md` | Immich client-server sync protocol, message formats |
 | Uvicorn settings | `docs/references/uvicorn-settings.md` | Server configuration, worker settings, timeouts |
-| Development tools | `docs/references/development-tools.md` | Model generation, API compatibility, OpenAPI spec, Renovate automation |
+| Development tools | `docs/references/development-tools.md` | Model generation, API compatibility, OpenAPI spec, pre-push checks, Renovate automation |

--- a/docs/references/development-tools.md
+++ b/docs/references/development-tools.md
@@ -1,6 +1,6 @@
 ---
 title: "Development Tools"
-last-updated: 2026-07-15
+last-updated: 2026-07-17
 ---
 
 # Development Tools
@@ -101,6 +101,12 @@ uv run tools/dump_openapi_json.py | sed -n '/^{/,$p' > /tmp/spec.json
 ```
 
 Importing the app emits log lines to **stdout** ahead of the JSON, so a bare `> /tmp/spec.json` yields a file the validator rejects (`Extra data: line 1 column 5`). Strip everything before the first `{`, then feed the result to the compatibility validator via `--adapter-spec=/tmp/spec.json`.
+
+## Pre-push Checks
+
+`scripts/pre-push-checks.sh` runs the fast subset of CI in parallel before a push — `ruff check`, `ruff format --check`, `pyright` (all with `--locked`, matching CI's `uv sync --locked`), and the `.immich-container-tag` ↔ Dockerfile version-sync check. Tests and the API compatibility workflow stay CI-only.
+
+Claude Code sessions opened in this repo run it automatically on every `git push`: `.claude/hooks/pre-push-checks.sh` (wired as a `PreToolUse` hook in `.claude/settings.json`) intercepts the push tool call and blocks it when checks fail. Other agents and humans run the script directly. Emergency skip: `GUMNUT_SKIP_PUSH_CHECKS=1 git push`. See the script headers for the full behavior contract; `scripts/pre-push-checks_test.sh` (run by CI's lint job) guards it.
 
 ## Dependency Update Automation
 

--- a/scripts/pre-push-checks.sh
+++ b/scripts/pre-push-checks.sh
@@ -35,8 +35,9 @@ repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
   exit 1
 }
 cd "$repo_root" || exit 1
-# Exported for the group scripts below: embedding the path literally in the
-# bash -c strings would break on clone paths containing quotes.
+# Exported for the group scripts below, which reference it UNEXPANDED
+# (\$PRE_PUSH_REPO_ROOT) so only the inner shell expands it once — embedding
+# the literal path would break on clone paths containing quotes or $.
 export PRE_PUSH_REPO_ROOT="$repo_root"
 
 tmpdir=$(mktemp -d) || exit 1
@@ -58,13 +59,13 @@ run_check() {
 # --locked mirrors CI's `uv sync --locked`: a stale uv.lock must fail here
 # too (bare `uv run` would silently re-lock it and green-light a push that
 # CI then rejects).
-run_check "ruff-check" "cd \"$PRE_PUSH_REPO_ROOT\" && uv run --locked ruff check"
-run_check "ruff-format" "cd \"$PRE_PUSH_REPO_ROOT\" && uv run --locked ruff format --check"
-run_check "pyright" "cd \"$PRE_PUSH_REPO_ROOT\" && uv run --locked pyright"
+run_check "ruff-check" "cd \"\$PRE_PUSH_REPO_ROOT\" && uv run --locked ruff check"
+run_check "ruff-format" "cd \"\$PRE_PUSH_REPO_ROOT\" && uv run --locked ruff format --check"
+run_check "pyright" "cd \"\$PRE_PUSH_REPO_ROOT\" && uv run --locked pyright"
 # Mirrors ci.yml's check-immich-version-sync job; see
 # docs/references/code-practices.md § "Bumping the Immich Version".
 run_check "immich-version-sync" "
-  cd \"$PRE_PUSH_REPO_ROOT\" &&
+  cd \"\$PRE_PUSH_REPO_ROOT\" &&
   TAG=\$(cat .immich-container-tag) &&
   DOCKERFILE_VERSION=\$(grep -E '^ARG IMMICH_VERSION=' Dockerfile | cut -d= -f2) &&
   if [ \"\$TAG\" != \"\$DOCKERFILE_VERSION\" ]; then

--- a/scripts/pre-push-checks.sh
+++ b/scripts/pre-push-checks.sh
@@ -35,6 +35,9 @@ repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
   exit 1
 }
 cd "$repo_root" || exit 1
+# Exported for the group scripts below: embedding the path literally in the
+# bash -c strings would break on clone paths containing quotes.
+export PRE_PUSH_REPO_ROOT="$repo_root"
 
 tmpdir=$(mktemp -d) || exit 1
 trap 'rm -rf "$tmpdir"' EXIT
@@ -55,13 +58,13 @@ run_check() {
 # --locked mirrors CI's `uv sync --locked`: a stale uv.lock must fail here
 # too (bare `uv run` would silently re-lock it and green-light a push that
 # CI then rejects).
-run_check "ruff-check" "cd '$repo_root' && uv run --locked ruff check"
-run_check "ruff-format" "cd '$repo_root' && uv run --locked ruff format --check"
-run_check "pyright" "cd '$repo_root' && uv run --locked pyright"
+run_check "ruff-check" "cd \"$PRE_PUSH_REPO_ROOT\" && uv run --locked ruff check"
+run_check "ruff-format" "cd \"$PRE_PUSH_REPO_ROOT\" && uv run --locked ruff format --check"
+run_check "pyright" "cd \"$PRE_PUSH_REPO_ROOT\" && uv run --locked pyright"
 # Mirrors ci.yml's check-immich-version-sync job; see
 # docs/references/code-practices.md § "Bumping the Immich Version".
 run_check "immich-version-sync" "
-  cd '$repo_root' &&
+  cd \"$PRE_PUSH_REPO_ROOT\" &&
   TAG=\$(cat .immich-container-tag) &&
   DOCKERFILE_VERSION=\$(grep -E '^ARG IMMICH_VERSION=' Dockerfile | cut -d= -f2) &&
   if [ \"\$TAG\" != \"\$DOCKERFILE_VERSION\" ]; then

--- a/scripts/pre-push-checks.sh
+++ b/scripts/pre-push-checks.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# scripts/pre-push-checks.sh
+#
+# Run the fast subset of CI before pushing, so failures surface locally
+# instead of burning a CI round. Platform-neutral: any agent (or human) runs
+# it directly before pushing or finishing a task. Claude Code runs it
+# automatically on every `git push` via the `.claude/hooks/pre-push-checks.sh`
+# PreToolUse adapter.
+#
+# What runs (mirroring ci.yml's lint-and-typecheck and version-sync jobs):
+#   - uv run ruff check
+#   - uv run ruff format --check
+#   - uv run pyright
+#   - .immich-container-tag ↔ Dockerfile IMMICH_VERSION match
+# Deliberate exclusions: pytest (the slow part; CI covers it) and the API
+# compatibility workflow (fetches the Immich spec — CI-only).
+#
+# The checks validate the *working tree*; CI validates the pushed commits.
+# This repo is a single project, so there is no changed-file scoping — the
+# full set runs on every push (~4s warm).
+#
+# Escape hatch (emergencies only): GUMNUT_SKIP_PUSH_CHECKS=1
+#
+# Exit codes: 0 — all checks passed (or skipped); 1 — a check failed.
+
+set -uo pipefail
+
+if [ "${GUMNUT_SKIP_PUSH_CHECKS:-0}" = "1" ]; then
+  echo "pre-push-checks: skipped (GUMNUT_SKIP_PUSH_CHECKS=1)" >&2
+  exit 0
+fi
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "pre-push-checks: not inside a git repository" >&2
+  exit 1
+}
+cd "$repo_root" || exit 1
+
+tmpdir=$(mktemp -d) || exit 1
+trap 'rm -rf "$tmpdir"' EXIT
+
+declare -a check_names=()
+
+# run_check <name> <script>: run one check in the background, capturing
+# combined output and exit code. `uv run` self-syncs the environment.
+run_check() {
+  local name="$1" script="$2"
+  (
+    bash -c "$script" >"$tmpdir/$name.out" 2>&1
+    echo $? >"$tmpdir/$name.code"
+  ) &
+  check_names+=("$name")
+}
+
+run_check "ruff-check" "cd '$repo_root' && uv run ruff check"
+run_check "ruff-format" "cd '$repo_root' && uv run ruff format --check"
+run_check "pyright" "cd '$repo_root' && uv run pyright"
+# Mirrors ci.yml's check-immich-version-sync job; see
+# docs/references/code-practices.md § "Bumping the Immich Version".
+run_check "immich-version-sync" "
+  cd '$repo_root' &&
+  TAG=\$(cat .immich-container-tag) &&
+  DOCKERFILE_VERSION=\$(grep -E '^ARG IMMICH_VERSION=' Dockerfile | cut -d= -f2) &&
+  if [ \"\$TAG\" != \"\$DOCKERFILE_VERSION\" ]; then
+    echo \"Mismatch: .immich-container-tag=\$TAG but Dockerfile ARG IMMICH_VERSION=\$DOCKERFILE_VERSION.\"
+    echo \"See docs/references/code-practices.md § 'Bumping the Immich Version'.\"
+    exit 1
+  fi"
+
+wait
+
+failed=0
+for name in "${check_names[@]}"; do
+  code=$(cat "$tmpdir/$name.code" 2>/dev/null || echo 1)
+  if [ "$code" != "0" ]; then
+    failed=1
+    {
+      echo "=== pre-push check FAILED: $name (exit $code) ==="
+      cat "$tmpdir/$name.out" 2>/dev/null
+      echo
+    } >&2
+  fi
+done
+
+if [ "$failed" = "1" ]; then
+  {
+    echo "pre-push-checks: fix the failures above before pushing."
+    echo "(These are the same checks CI runs; pushing now would fail CI.)"
+  } >&2
+  exit 1
+fi
+
+echo "pre-push-checks: all checks passed (${check_names[*]})" >&2
+exit 0

--- a/scripts/pre-push-checks.sh
+++ b/scripts/pre-push-checks.sh
@@ -52,9 +52,12 @@ run_check() {
   check_names+=("$name")
 }
 
-run_check "ruff-check" "cd '$repo_root' && uv run ruff check"
-run_check "ruff-format" "cd '$repo_root' && uv run ruff format --check"
-run_check "pyright" "cd '$repo_root' && uv run pyright"
+# --locked mirrors CI's `uv sync --locked`: a stale uv.lock must fail here
+# too (bare `uv run` would silently re-lock it and green-light a push that
+# CI then rejects).
+run_check "ruff-check" "cd '$repo_root' && uv run --locked ruff check"
+run_check "ruff-format" "cd '$repo_root' && uv run --locked ruff format --check"
+run_check "pyright" "cd '$repo_root' && uv run --locked pyright"
 # Mirrors ci.yml's check-immich-version-sync job; see
 # docs/references/code-practices.md § "Bumping the Immich Version".
 run_check "immich-version-sync" "

--- a/scripts/pre-push-checks_test.sh
+++ b/scripts/pre-push-checks_test.sh
@@ -105,6 +105,18 @@ out=$(payload 'git \"push\"' | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
 out=$(payload "printf git push" | "$ADAPTER" 2>&1); rc=$?
 [ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: printf git push must not match (rc=$rc out=$out)"
 
+# Shell control-structure bodies are command positions.
+out=$(payload "if true; then git push; fi" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter: if/then git push must be detected (rc=$rc out=$out)"
+
+# Quoted-push fallback is subcommand-position only: a quoted "push"
+# ARGUMENT to a non-push git command is data.
+out=$(payload 'git grep \"push\"' | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: git grep \"push\" must not match (rc=$rc out=$out)"
+
+out=$(payload 'git commit -m \"push\"' | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: git commit -m \"push\" must not match (rc=$rc out=$out)"
+
 # An unterminated quote (apostrophe in prose) falls back to raw matching —
 # a real push after it must still be detected (never fail open).
 out=$(payload "echo don't forget >> notes.txt\ngit push" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?

--- a/scripts/pre-push-checks_test.sh
+++ b/scripts/pre-push-checks_test.sh
@@ -52,6 +52,10 @@ out=$(payload "git stash push -m wip" | "$ADAPTER" 2>&1); rc=$?
 out=$(printf 'push but not json' | "$ADAPTER" 2>&1); rc=$?
 [ "$rc" -eq 0 ] && ok || fail "adapter: invalid JSON should no-op"
 
+# "push" on a separate line is a different command, not this git's argument.
+out=$(payload "git commit -m msg\necho push" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: newline-separated push should no-op (rc=$rc out=$out)"
+
 # --- adapter: inline skip flag ---
 out=$(payload "GUMNUT_SKIP_PUSH_CHECKS=1 git push" | "$ADAPTER" 2>&1); rc=$?
 [ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter: inline skip flag should skip"

--- a/scripts/pre-push-checks_test.sh
+++ b/scripts/pre-push-checks_test.sh
@@ -120,6 +120,14 @@ out=$(payload "{ git push; }" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$
 out=$(payload "bash -lc 'git push'" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
 [ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter: bash -lc 'git push' must be detected (rc=$rc out=$out)"
 
+# A timed push is still a push.
+out=$(payload "time git push" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter: time git push must be detected (rc=$rc out=$out)"
+
+# Heredoc bodies are data.
+out=$(payload "cat >doc.md <<'EOF'\ngit push\nEOF" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: heredoc body mentioning git push must no-op (rc=$rc out=$out)"
+
 # The skip flag must be its own assignment — a mention inside another
 # assignment's VALUE does not skip (the checker runs).
 out=$(payload "FOO=GUMNUT_SKIP_PUSH_CHECKS=1 git push" | "$ADAPTER" 2>&1); rc=$?

--- a/scripts/pre-push-checks_test.sh
+++ b/scripts/pre-push-checks_test.sh
@@ -124,6 +124,10 @@ out=$(payload "bash -lc 'git push'" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1)
 out=$(payload "time git push" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
 [ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter: time git push must be detected (rc=$rc out=$out)"
 
+# A negated push still executes the push.
+out=$(payload "if ! git push; then echo failed; fi" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter: ! git push must be detected (rc=$rc out=$out)"
+
 # Heredoc bodies are data.
 out=$(payload "cat >doc.md <<'EOF'\ngit push\nEOF" | "$ADAPTER" 2>&1); rc=$?
 [ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: heredoc body mentioning git push must no-op (rc=$rc out=$out)"
@@ -211,6 +215,23 @@ rm -rf "$STUBBIN"
 echo "$out" | grep -q "FAILED: immich-version-sync" && ok || fail "version mismatch should be reported"
 echo "$out" | grep -q "Mismatch: .immich-container-tag=v1.2.3" && ok || fail "mismatch message should show both values"
 rm -f .immich-container-tag Dockerfile
+
+# --- checker: clone paths containing quotes or $ must not break the group
+# scripts (repo root is passed unexpanded via env, expanded once inside) ---
+EXOTIC="$REPO/o'con\$nor"
+mkdir -p "$EXOTIC/repo-e"
+git -C "$EXOTIC/repo-e" -c init.defaultBranch=main init -q
+git -C "$EXOTIC/repo-e" config user.email t@example.com
+git -C "$EXOTIC/repo-e" config user.name T
+echo "v1.2.3" >"$EXOTIC/repo-e/.immich-container-tag"
+printf 'ARG IMMICH_VERSION=v1.2.3\nFROM scratch\n' >"$EXOTIC/repo-e/Dockerfile"
+git -C "$EXOTIC/repo-e" add -A && git -C "$EXOTIC/repo-e" commit -qm base
+STUBBIN=$(mktemp -d "${TMPDIR:-/tmp}/prepushstub.XXXXXX")
+printf '#!/usr/bin/env bash\nexit 0\n' >"$STUBBIN/uv"
+chmod +x "$STUBBIN/uv"
+out=$(cd "$EXOTIC/repo-e" && PATH="$STUBBIN:$PATH" "$CHECKER" 2>&1); rc=$?
+rm -rf "$STUBBIN"
+[ "$rc" -eq 0 ] && echo "$out" | grep -q "all checks passed" && ok || fail "checker must pass from a quote/dollar clone path (rc=$rc out=$out)"
 
 echo ""
 if [ "$failed" -gt 0 ]; then

--- a/scripts/pre-push-checks_test.sh
+++ b/scripts/pre-push-checks_test.sh
@@ -105,6 +105,17 @@ out=$(payload 'git \"push\"' | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
 out=$(payload "printf git push" | "$ADAPTER" 2>&1); rc=$?
 [ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: printf git push must not match (rc=$rc out=$out)"
 
+# Unquoted push must also be in subcommand position.
+out=$(payload "git grep push" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: git grep push must not match (rc=$rc out=$out)"
+
+out=$(payload "git log --grep=push" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: git log --grep=push must not match (rc=$rc out=$out)"
+
+# Brace groups are command positions.
+out=$(payload "{ git push; }" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter: { git push; } must be detected (rc=$rc out=$out)"
+
 # Shell control-structure bodies are command positions.
 out=$(payload "if true; then git push; fi" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
 [ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter: if/then git push must be detected (rc=$rc out=$out)"

--- a/scripts/pre-push-checks_test.sh
+++ b/scripts/pre-push-checks_test.sh
@@ -82,6 +82,26 @@ out=$(payload "git push" | "$ADAPTER" 2>&1); rc=$?
 echo "$out" | grep -q "FAILED: immich-version-sync" && ok || fail "failure report should name the failing check"
 echo "$out" | grep -q "fix the failures above" && ok || fail "failure report should include the remediation trailer"
 
+# --- checker: hermetic happy path (stub uv + matching version files) ---
+# A stub uv that succeeds silently, plus a matching tag/Dockerfile pair,
+# drives every check green: rc=0 and the pass message lists all four.
+echo "v1.2.3" >.immich-container-tag
+printf 'ARG IMMICH_VERSION=v1.2.3\nFROM scratch\n' >Dockerfile
+STUBBIN=$(mktemp -d "${TMPDIR:-/tmp}/prepushstub.XXXXXX")
+printf '#!/usr/bin/env bash\nexit 0\n' >"$STUBBIN/uv"
+chmod +x "$STUBBIN/uv"
+out=$(PATH="$STUBBIN:$PATH" "$CHECKER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && ok || fail "checker should exit 0 when all checks pass (rc=$rc)"
+echo "$out" | grep -q "all checks passed (ruff-check ruff-format pyright immich-version-sync)" && ok || fail "pass message should list all four checks"
+
+# --- checker: version-sync mismatch fails even when the uv checks pass ---
+printf 'ARG IMMICH_VERSION=v9.9.9\nFROM scratch\n' >Dockerfile
+out=$(PATH="$STUBBIN:$PATH" "$CHECKER" 2>&1); rc=$?
+rm -rf "$STUBBIN"
+[ "$rc" -eq 1 ] && ok || fail "version mismatch should fail the checker (rc=$rc)"
+echo "$out" | grep -q "FAILED: immich-version-sync" && ok || fail "version mismatch should be reported"
+echo "$out" | grep -q "Mismatch: .immich-container-tag=v1.2.3" && ok || fail "mismatch message should show both values"
+
 echo ""
 if [ "$failed" -gt 0 ]; then
   echo "pre-push-checks_test: ${passed} passed, ${failed} FAILED" >&2

--- a/scripts/pre-push-checks_test.sh
+++ b/scripts/pre-push-checks_test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# scripts/pre-push-checks_test.sh
+#
+# Tests for the Claude Code pre-push adapter (.claude/hooks/pre-push-checks.sh)
+# and the checker's skip/failure contract. Uses a throwaway git repo; cases
+# that would reach the real toolchain short-circuit via the exported
+# GUMNUT_SKIP_PUSH_CHECKS flag, keeping the suite hermetic (bash + git +
+# python3 only). Run: scripts/pre-push-checks_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+CHECKER="$SCRIPT_DIR/pre-push-checks.sh"
+ADAPTER="$SCRIPT_DIR/../.claude/hooks/pre-push-checks.sh"
+
+passed=0
+failed=0
+
+fail() {
+  echo "  FAIL: $1" >&2
+  failed=$((failed + 1))
+}
+ok() {
+  passed=$((passed + 1))
+}
+
+REPO=$(mktemp -d "${TMPDIR:-/tmp}/prepushtest.XXXXXX")
+trap 'rm -rf "$REPO"' EXIT
+cd "$REPO" || exit 1
+git -c init.defaultBranch=main init -q
+git config user.email test@example.com
+git config user.name "Test"
+echo base >README.md
+git add -A && git commit -qm baseline
+
+payload() { printf '{"tool_input":{"command":"%s"}}' "$1"; }
+
+# --- checker: skip flag ---
+out=$(GUMNUT_SKIP_PUSH_CHECKS=1 "$CHECKER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "checker should skip on GUMNUT_SKIP_PUSH_CHECKS=1 (rc=$rc)"
+
+# --- adapter: non-push commands no-op silently ---
+out=$(payload "ls -la" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: non-push command should no-op (rc=$rc out=$out)"
+
+out=$(payload "git status" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: git non-push should no-op"
+
+out=$(payload "git stash push -m wip" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: git stash push should no-op (rc=$rc out=$out)"
+
+out=$(printf 'push but not json' | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && ok || fail "adapter: invalid JSON should no-op"
+
+# --- adapter: inline skip flag ---
+out=$(payload "GUMNUT_SKIP_PUSH_CHECKS=1 git push" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter: inline skip flag should skip"
+
+# --- adapter: push detection positives (exported skip keeps it hermetic;
+# the checker's "skipped" message proves the adapter reached it) ---
+for cmd in "git push" "git push -u origin HEAD" "git -C /tmp/x push" "git add -A && git commit -m msg && git push"; do
+  out=$(payload "$cmd" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
+  [ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter should detect push in: $cmd"
+done
+
+# --- adapter: fail closed when python3 is broken ---
+STUBBIN=$(mktemp -d "${TMPDIR:-/tmp}/prepushstub.XXXXXX")
+printf '#!/usr/bin/env bash\nexit 127\n' >"$STUBBIN/python3"
+chmod +x "$STUBBIN/python3"
+out=$(payload "git push" | PATH="$STUBBIN:$PATH" GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
+rm -rf "$STUBBIN"
+[ "$rc" -eq 0 ] && ok || fail "fail-closed path should still honor the checker's skip (rc=$rc)"
+echo "$out" | grep -q "fail closed" && ok || fail "broken python3 should emit the fail-closed warning"
+echo "$out" | grep -q "skipped" && ok || fail "fail-closed path should reach the checker"
+
+# --- adapter: failure mapping (checker exit 1 -> adapter exit 2) ---
+# In this bare temp repo the checker deterministically fails (no
+# .immich-container-tag, no project for the uv checks), which exercises the
+# failure path end-to-end without needing the real toolchain to succeed.
+out=$(payload "git push" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 2 ] && ok || fail "adapter should map checker failure to exit 2 (rc=$rc)"
+echo "$out" | grep -q "FAILED: immich-version-sync" && ok || fail "failure report should name the failing check"
+echo "$out" | grep -q "fix the failures above" && ok || fail "failure report should include the remediation trailer"
+
+echo ""
+if [ "$failed" -gt 0 ]; then
+  echo "pre-push-checks_test: ${passed} passed, ${failed} FAILED" >&2
+  exit 1
+fi
+echo "pre-push-checks_test: ${passed} passed"

--- a/scripts/pre-push-checks_test.sh
+++ b/scripts/pre-push-checks_test.sh
@@ -116,6 +116,15 @@ out=$(payload "git log --grep=push" | "$ADAPTER" 2>&1); rc=$?
 out=$(payload "{ git push; }" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
 [ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter: { git push; } must be detected (rc=$rc out=$out)"
 
+# A nested shell script argument is command context, not data.
+out=$(payload "bash -lc 'git push'" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter: bash -lc 'git push' must be detected (rc=$rc out=$out)"
+
+# The skip flag must be its own assignment — a mention inside another
+# assignment's VALUE does not skip (the checker runs).
+out=$(payload "FOO=GUMNUT_SKIP_PUSH_CHECKS=1 git push" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 2 ] && echo "$out" | grep -q "FAILED: immich-version-sync" && ok || fail "adapter: skip text inside another assignment value must NOT skip (rc=$rc out=$out)"
+
 # Shell control-structure bodies are command positions.
 out=$(payload "if true; then git push; fi" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
 [ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter: if/then git push must be detected (rc=$rc out=$out)"

--- a/scripts/pre-push-checks_test.sh
+++ b/scripts/pre-push-checks_test.sh
@@ -85,6 +85,26 @@ out=$(payload "git commit -m 'document GUMNUT_SKIP_PUSH_CHECKS=1' && git push" |
 out=$(payload "grep -r GUMNUT_SKIP_PUSH_CHECKS=1 docs && git push" | "$ADAPTER" 2>&1); rc=$?
 [ "$rc" -eq 2 ] && echo "$out" | grep -q "FAILED: immich-version-sync" && ok || fail "adapter: argument-position skip-flag text must NOT bypass (rc=$rc out=$out)"
 
+# An assignment scoped to a DIFFERENT command does not skip the push.
+out=$(payload "GUMNUT_SKIP_PUSH_CHECKS=1 true && git push" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 2 ] && echo "$out" | grep -q "FAILED: immich-version-sync" && ok || fail "adapter: assignment on another command must NOT skip (rc=$rc out=$out)"
+
+# Partial skip: an unskipped push in the chain still runs the checks.
+out=$(payload "GUMNUT_SKIP_PUSH_CHECKS=1 git push && git push" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 2 ] && echo "$out" | grep -q "FAILED: immich-version-sync" && ok || fail "adapter: partial skip must still run checks (rc=$rc out=$out)"
+
+# Escaped quotes inside a double-quoted message stay masked.
+out=$(payload 'git commit -m \"release \\\"git push\\\"\"' | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: escaped quotes in a message must stay masked (rc=$rc out=$out)"
+
+# A quoted SUBCOMMAND still executes a push after quote removal — detected.
+out=$(payload 'git \"push\"' | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter: git \"push\" quoted subcommand must be detected (rc=$rc out=$out)"
+
+# git not in command position is not a push.
+out=$(payload "printf git push" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: printf git push must not match (rc=$rc out=$out)"
+
 # An unterminated quote (apostrophe in prose) falls back to raw matching —
 # a real push after it must still be detected (never fail open).
 out=$(payload "echo don't forget >> notes.txt\ngit push" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
@@ -96,7 +116,7 @@ out=$(payload "out=\\\"\$(git push origin HEAD 2>&1)\\\"" | GUMNUT_SKIP_PUSH_CHE
 
 # --- adapter: push detection positives (exported skip keeps it hermetic;
 # the checker's "skipped" message proves the adapter reached it) ---
-for cmd in "git push" "git push -u origin HEAD" "git -C /tmp/x push" "git add -A && git commit -m msg && git push" "git stash push -m wip && git push"; do
+for cmd in "git push" "git push -u origin HEAD" "git -C /tmp/x push" "git add -A && git commit -m msg && git push" "git stash push -m wip && git push" "/usr/bin/git push"; do
   out=$(payload "$cmd" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
   [ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter should detect push in: $cmd"
 done

--- a/scripts/pre-push-checks_test.sh
+++ b/scripts/pre-push-checks_test.sh
@@ -49,33 +49,71 @@ out=$(payload "git status" | "$ADAPTER" 2>&1); rc=$?
 out=$(payload "git stash push -m wip" | "$ADAPTER" 2>&1); rc=$?
 [ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: git stash push should no-op (rc=$rc out=$out)"
 
+# Malformed payload: warn and fail closed (run the checks) — the payload
+# producer is Claude Code itself, so malformed means something changed. In
+# this bare temp repo the checker deterministically fails, so the fail-closed
+# fall-through surfaces as a block (rc 2) with the warning attached.
 out=$(printf 'push but not json' | "$ADAPTER" 2>&1); rc=$?
-[ "$rc" -eq 0 ] && ok || fail "adapter: invalid JSON should no-op"
+[ "$rc" -eq 2 ] && echo "$out" | grep -q "did not parse as JSON" && ok || fail "adapter: invalid JSON should warn and fail closed (rc=$rc out=$out)"
 
 # "push" on a separate line is a different command, not this git's argument.
 out=$(payload "git commit -m msg\necho push" | "$ADAPTER" 2>&1); rc=$?
 [ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: newline-separated push should no-op (rc=$rc out=$out)"
 
-# --- adapter: inline skip flag ---
+# Quoted text is data: push mentions inside quotes must not trigger.
+out=$(payload "git commit -m 'release notes mention git push'" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: quoted 'git push' mention should no-op (rc=$rc out=$out)"
+
+out=$(payload "git commit -m \\\"pre-push checks\\\"" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: quoted 'pre-push checks' should no-op (rc=$rc out=$out)"
+
+# push embedded in a filename token is not the push subcommand.
+out=$(payload "git add scripts/pre-push-checks_test.sh && git commit -m msg" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && [ -z "$out" ] && ok || fail "adapter: pre-push filename should no-op (rc=$rc out=$out)"
+
+# --- adapter: inline skip flag (command-position assignment) ---
 out=$(payload "GUMNUT_SKIP_PUSH_CHECKS=1 git push" | "$ADAPTER" 2>&1); rc=$?
 [ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter: inline skip flag should skip"
 
+# A QUOTED mention of the skip flag is data, not an assignment — the checker
+# must still run (its deterministic failure here proves it; the
+# accidental-bypass case).
+out=$(payload "git commit -m 'document GUMNUT_SKIP_PUSH_CHECKS=1' && git push" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 2 ] && echo "$out" | grep -q "FAILED: immich-version-sync" && ok || fail "adapter: quoted skip-flag mention must NOT bypass the checker (rc=$rc out=$out)"
+
+# An UNQUOTED mention in argument position is not an assignment either.
+out=$(payload "grep -r GUMNUT_SKIP_PUSH_CHECKS=1 docs && git push" | "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 2 ] && echo "$out" | grep -q "FAILED: immich-version-sync" && ok || fail "adapter: argument-position skip-flag text must NOT bypass (rc=$rc out=$out)"
+
+# An unterminated quote (apostrophe in prose) falls back to raw matching —
+# a real push after it must still be detected (never fail open).
+out=$(payload "echo don't forget >> notes.txt\ngit push" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter: unterminated quote must not mask a real push (rc=$rc out=$out)"
+
+# A double-quoted command substitution really pushes — must be detected.
+out=$(payload "out=\\\"\$(git push origin HEAD 2>&1)\\\"" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter: \"\$(git push)\" substitution must be detected (rc=$rc out=$out)"
+
 # --- adapter: push detection positives (exported skip keeps it hermetic;
 # the checker's "skipped" message proves the adapter reached it) ---
-for cmd in "git push" "git push -u origin HEAD" "git -C /tmp/x push" "git add -A && git commit -m msg && git push"; do
+for cmd in "git push" "git push -u origin HEAD" "git -C /tmp/x push" "git add -A && git commit -m msg && git push" "git stash push -m wip && git push"; do
   out=$(payload "$cmd" | GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
   [ "$rc" -eq 0 ] && echo "$out" | grep -q "skipped" && ok || fail "adapter should detect push in: $cmd"
 done
 
-# --- adapter: fail closed when python3 is broken ---
-STUBBIN=$(mktemp -d "${TMPDIR:-/tmp}/prepushstub.XXXXXX")
-printf '#!/usr/bin/env bash\nexit 127\n' >"$STUBBIN/python3"
-chmod +x "$STUBBIN/python3"
-out=$(payload "git push" | PATH="$STUBBIN:$PATH" GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
-rm -rf "$STUBBIN"
-[ "$rc" -eq 0 ] && ok || fail "fail-closed path should still honor the checker's skip (rc=$rc)"
-echo "$out" | grep -q "fail closed" && ok || fail "broken python3 should emit the fail-closed warning"
-echo "$out" | grep -q "skipped" && ok || fail "fail-closed path should reach the checker"
+# --- adapter: fail closed when python3 is broken (exit 127 AND exit 1 — a
+# broken shim or a syntax error in the embedded program exits 1, which must
+# never be conflated with "not a push") ---
+for stub_rc in 127 1; do
+  STUBBIN=$(mktemp -d "${TMPDIR:-/tmp}/prepushstub.XXXXXX")
+  printf '#!/usr/bin/env bash\nexit %s\n' "$stub_rc" >"$STUBBIN/python3"
+  chmod +x "$STUBBIN/python3"
+  out=$(payload "git push" | PATH="$STUBBIN:$PATH" GUMNUT_SKIP_PUSH_CHECKS=1 "$ADAPTER" 2>&1); rc=$?
+  rm -rf "$STUBBIN"
+  [ "$rc" -eq 0 ] && ok || fail "fail-closed path (python3 exit $stub_rc) should still honor the checker's skip (rc=$rc)"
+  echo "$out" | grep -q "fail closed" && ok || fail "python3 exiting $stub_rc should emit the fail-closed warning"
+  echo "$out" | grep -q "skipped" && ok || fail "fail-closed path (python3 exit $stub_rc) should reach the checker"
+done
 
 # --- adapter: failure mapping (checker exit 1 -> adapter exit 2) ---
 # In this bare temp repo the checker deterministically fails (no

--- a/scripts/pre-push-checks_test.sh
+++ b/scripts/pre-push-checks_test.sh
@@ -83,16 +83,23 @@ echo "$out" | grep -q "FAILED: immich-version-sync" && ok || fail "failure repor
 echo "$out" | grep -q "fix the failures above" && ok || fail "failure report should include the remediation trailer"
 
 # --- checker: hermetic happy path (stub uv + matching version files) ---
-# A stub uv that succeeds silently, plus a matching tag/Dockerfile pair,
-# drives every check green: rc=0 and the pass message lists all four.
+# NOTE: cases from here down run in a *populated* repo (version files
+# written below); earlier cases depend on the bare repo, so new bare-repo
+# cases must go above this line.
+# A stub uv that succeeds silently (logging its args), plus a matching
+# tag/Dockerfile pair, drives every check green: rc=0 and the pass message
+# lists all four.
 echo "v1.2.3" >.immich-container-tag
 printf 'ARG IMMICH_VERSION=v1.2.3\nFROM scratch\n' >Dockerfile
 STUBBIN=$(mktemp -d "${TMPDIR:-/tmp}/prepushstub.XXXXXX")
-printf '#!/usr/bin/env bash\nexit 0\n' >"$STUBBIN/uv"
+printf '#!/usr/bin/env bash\necho "$*" >>"%s/calls"\nexit 0\n' "$STUBBIN" >"$STUBBIN/uv"
 chmod +x "$STUBBIN/uv"
 out=$(PATH="$STUBBIN:$PATH" "$CHECKER" 2>&1); rc=$?
 [ "$rc" -eq 0 ] && ok || fail "checker should exit 0 when all checks pass (rc=$rc)"
 echo "$out" | grep -q "all checks passed (ruff-check ruff-format pyright immich-version-sync)" && ok || fail "pass message should list all four checks"
+# CI-parity guard: every uv invocation must carry --locked (bare `uv run`
+# silently re-locks a stale uv.lock that CI's `uv sync --locked` rejects).
+[ "$(grep -c -- '--locked' "$STUBBIN/calls" 2>/dev/null)" -eq 3 ] && ok || fail "all three uv invocations should carry --locked"
 
 # --- checker: version-sync mismatch fails even when the uv checks pass ---
 printf 'ARG IMMICH_VERSION=v9.9.9\nFROM scratch\n' >Dockerfile
@@ -101,6 +108,7 @@ rm -rf "$STUBBIN"
 [ "$rc" -eq 1 ] && ok || fail "version mismatch should fail the checker (rc=$rc)"
 echo "$out" | grep -q "FAILED: immich-version-sync" && ok || fail "version mismatch should be reported"
 echo "$out" | grep -q "Mismatch: .immich-container-tag=v1.2.3" && ok || fail "mismatch message should show both values"
+rm -f .immich-container-tag Dockerfile
 
 echo ""
 if [ "$failed" -gt 0 ]; then


### PR DESCRIPTION
## What

- **`scripts/pre-push-checks.sh`** — runs the fast subset of CI in parallel before a push (~3s warm): `uv run --locked ruff check`, `uv run --locked ruff format --check`, `uv run --locked pyright`, and the `.immich-container-tag` ↔ Dockerfile version-sync check. `--locked` mirrors CI's `uv sync --locked`, so a stale `uv.lock` fails here instead of green-lighting a push CI rejects. Tests and the API compatibility workflow stay CI-only (they're the slow parts). Emergency skip: `GUMNUT_SKIP_PUSH_CHECKS=1`.
- **`.claude/hooks/pre-push-checks.sh` + `.claude/settings.json`** — Claude Code `PreToolUse` hook that intercepts `git push` Bash tool calls and blocks them (exit 2, failure output fed back) when the checker fails. Ships with the clone, so it runs in local and cloud Claude Code sessions; `git push --no-verify` cannot bypass it. Fails closed if python3 is unavailable; `git stash push` is excluded from matching.
- **`scripts/pre-push-checks_test.sh`** — 22 hermetic cases (adapter matching/exit-code contract, skip flags, failure-report shape, stub-`uv` happy path with a `--locked` parity guard, version-sync mismatch), wired as a step in ci.yml's lint job.
- AGENTS.md documents the workflow; `docs/references/development-tools.md` gets a Pre-push Checks section.

## Why

Development here is agent-driven, and conventional git pre-push hooks don't reliably fire for agents — several agent platforms push via the GitHub API or platform-side integrations where `.git/hooks/*` never run, and hooks need per-clone install steps regardless. Intercepting the push at the agent-tool-call layer (with CI as the deterministic backstop) catches lint/type/format failures before the push instead of burning a CI round, with no per-machine setup.

## Test plan

- [x] `scripts/pre-push-checks_test.sh` — 22 cases green locally (macOS bash 3.2) and runs in this PR's CI lint job (ubuntu)
- [x] Real checker green on this branch (~3s); failure paths verified end-to-end (checker exit 1 → hook exit 2 with actionable output)
- [x] zizmor clean on the ci.yml change

Generated by an AI coding agent.