### PR TITLE
Run daemons on schedule only, drop the PR-merge trigger

### DIFF
--- a/.agents/daemons/codebase-maintainer/DAEMON.md
+++ b/.agents/daemons/codebase-maintainer/DAEMON.md
@@ -2,7 +2,6 @@
 id: codebase-maintainer
 purpose: Keeps the codebase clean, secure, and current.
 watch:
-  - when a pull request is merged into main
   - when a security advisory is published for a dependency in this repo
 routines:
   - propose tested upgrade PRs for outdated dependencies

--- a/.agents/daemons/librarian/DAEMON.md
+++ b/.agents/daemons/librarian/DAEMON.md
@@ -1,8 +1,6 @@
 ---
 id: librarian
 purpose: Keeps this repo's documentation current and complete.
-watch:
-  - when a pull request is merged into main
 routines:
   - detect stale docs in this repo based on recent code changes and update them
   - create new docs for undocumented top-level features, routers, or services in this repo


### PR DESCRIPTION
The `codebase-maintainer` and `librarian` daemons were triggering on **every merge to main** in addition to their daily `0 9 * * *` schedule — more often than needed.

- Drop the `when a pull request is merged into main` watch from **both** daemons — they now run on the daily schedule only.
- `codebase-maintainer` keeps its `when a security advisory is published` watch, so the urgent 24h-SLA security path is unaffected.
- `librarian` becomes schedule-only (the spec allows `schedule` without `watch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vc8Vf2urTDkN5wTbu3NUiE