### PR TITLE
Accept x-api-key for Immich API-key clients (immich-go)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ Detailed docs live in subdirectories: `docs/architecture/` (system architecture)
 |-------|----------|-----------------|
 | Running with Immich Web | `docs/guides/running-with-immich-web.md` | Setting up the full local stack (Immich web + adapter + the Gumnut API + Clerk OAuth) |
 | Running with Immich Mobile | `docs/guides/running-with-immich-mobile.md` | Self-signed certs, HTTPS setup, connecting the Immich mobile app |
+| Importing with immich-go | `docs/guides/importing-with-immich-go.md` | Bulk-importing a library with the immich-go CLI, `x-api-key` auth via a Gumnut API key |
 
 ## References
 

--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -71,6 +71,8 @@ For mobile, OAuth providers that don't support custom URL schemes (e.g., `app.im
 5. On response, middleware checks for `x-new-access-token` header (backend JWT refresh)
 6. If present, updates the stored JWT in Redis — the client's session token remains unchanged
 
+**API-key clients (e.g. immich-go).** A request carrying an `x-api-key` header takes a separate, sessionless branch. The header value is a Gumnut API key (`apikey_...`) that the backend validates directly, so the middleware forwards it straight through as the SDK credential — it does **not** look up Redis, and there is no session token. Because there is no session, the JWT-refresh step (5–6) is a no-op for these requests: API keys are long-lived and non-refreshing, and the backend does not emit `x-new-access-token` for them. The `x-api-key` header is checked before the session-token sources above; Immich web (cookie) and mobile (Bearer / `x-immich-user-token`) never send it. Key *management* through the Immich API-keys endpoints remains stubbed — minting a Gumnut key requires a first-party browser session that the adapter's delegated OAuth token can't perform (see `docs/guides/importing-with-immich-go.md`).
+
 ### Request observability
 
 `ObservabilityTagsMiddleware` is registered last in `main.py`, so it wraps outermost and can annotate requests even when `AuthMiddleware` returns a 401 before a route handler runs.

--- a/docs/design-docs/auth-design.md
+++ b/docs/design-docs/auth-design.md
@@ -21,6 +21,8 @@ Earlier iterations passed the Gumnut JWT directly to clients and derived session
 
 The adapter now generates a stable UUID session token at login and returns that token to clients instead of the raw JWT. The Gumnut JWT is encrypted and stored in Redis, keyed by the session token. On each request, the middleware extracts the session token, looks up the stored JWT, and forwards it to the backend. When the backend refreshes the JWT, the adapter updates the stored value in Redis while keeping the client's session token unchanged. This keeps sessions and checkpoints stable across JWT refresh cycles, enables immediate session revocation, and ensures raw JWTs are never exposed to clients.
 
+**API-key clients are the exception.** The session-token model above governs the interactive web and mobile clients. Headless Immich API-key clients (e.g. the immich-go CLI) instead send an `x-api-key` header carrying a Gumnut API key (`apikey_...`); the middleware forwards that value straight to the backend as the caller credential, with no Redis session and no JWT refresh (the key is long-lived and the backend does not refresh it). Nothing is stored adapter-side for these requests. This branch is checked ahead of the session-token sources and is documented in `docs/guides/importing-with-immich-go.md`; the sections below describe the session-token path.
+
 ## Design Constraints
 
 ### Immich Client Compatibility Requirements
@@ -222,6 +224,8 @@ User → Web Client → Adapter → Backend → OAuth Provider → Clerk
 ```
 User → Web/Mobile Client → Adapter Middleware → Backend → Gumnut API
 ```
+
+> This flow describes the session-token clients (web/mobile). API-key clients skip session lookup and refresh entirely — see "API-key clients are the exception" under *Implemented Architecture*.
 
 **Sequence:**
 

--- a/docs/design-docs/immich-adapter-gap-analysis.md
+++ b/docs/design-docs/immich-adapter-gap-analysis.md
@@ -393,15 +393,15 @@ Immich job and queue endpoints manage background processing (thumbnail generatio
 
 Immich API keys allow programmatic access without OAuth.
 
-**Current behavior**: All 6 endpoints return fake data.
+**Current behavior**: The 6 `/api/api-keys` *management* endpoints return fake data (key CRUD is still stubbed). However, **inbound `x-api-key` authentication is now supported**: `AuthMiddleware` reads the `x-api-key` header and forwards its value to the Gumnut API as the caller's credential, so a client such as immich-go can authenticate with a Gumnut API key (`apikey_...`). See `docs/guides/importing-with-immich-go.md`.
 
-**User impact**: **Low** — API keys are a developer/power-user feature. All current access is through OAuth.
+**User impact**: **Low** — API keys are a developer/power-user feature. Interactive access is through OAuth; headless clients can now use a Gumnut API key.
 
-**Dependency**: **Both** — Gumnut would need an API key concept for the Gumnut API.
+**Dependency**: Inbound auth was **Adapter-only** — the Gumnut API already validates `apikey_...` bearer tokens, so the adapter just forwards the header. Key *management* through the Immich UI remains **out of scope**: minting a key is a credential-management operation the Gumnut API only permits from a first-party browser session, and the adapter authenticates with a delegated OAuth token that cannot mint keys. Users mint keys in the Gumnut app instead, so the `/api/api-keys` CRUD stubs stay as-is.
 
-**Effort**: **M** — Backend needs API key generation, storage, and authentication. Adapter translation is S.
+**Effort**: Inbound auth was **S** (done). Wiring the CRUD endpoints is not planned (blocked by the first-party-session requirement above).
 
-**Recommendation**: **Revisit later** — Low priority unless third-party integrations need non-OAuth access.
+**Recommendation**: **Closed** for inbound `x-api-key` auth. The management-endpoint stubs are an intentional gap — key minting lives in the Gumnut app.
 
 ---
 

--- a/docs/design-docs/immich-adapter-gap-analysis.md
+++ b/docs/design-docs/immich-adapter-gap-analysis.md
@@ -2,7 +2,7 @@
 title: "Immich Adapter Gap Analysis"
 status: active
 created: 2026-04-15
-last-updated: 2026-07-19
+last-updated: 2026-07-22
 ---
 
 # Immich Adapter Gap Analysis

--- a/docs/guides/importing-with-immich-go.md
+++ b/docs/guides/importing-with-immich-go.md
@@ -1,0 +1,72 @@
+---
+title: "Importing with immich-go"
+last-updated: 2026-07-22
+---
+
+# Importing with immich-go
+
+[immich-go](https://github.com/simulot/immich-go) is a standalone CLI that pushes
+a photo/video library into an Immich server directly over the REST API — no web
+or mobile app involved. It works against the adapter, so it can bulk-import a
+local folder (or a Google Photos Takeout archive) into the Gumnut API.
+
+## Authentication: use a Gumnut API key
+
+immich-go authenticates with the `x-api-key` header on every request. The adapter
+accepts that header and forwards its value to the Gumnut API as the caller's
+credential (see `routers/middleware/auth_middleware.py`). The value must be a
+**Gumnut API key** (an `apikey_...` string), which the Gumnut backend validates
+directly — the adapter does not mint, store, or verify keys itself.
+
+**Get a key from the Gumnut app, not from Immich.** Mint a Gumnut API key with
+**write** access from your Gumnut account, then pass it to immich-go. Minting a
+key is a credential-management operation that the Gumnut API only allows from a
+first-party (browser) session, so the adapter's own Immich "API Keys" settings
+page cannot create one — the adapter authenticates to the Gumnut API with a
+delegated OAuth token, which is not permitted to mint keys. That Immich-side page
+is therefore a non-functional stub; ignore it and use the key from your Gumnut
+account.
+
+A key needs **write** scope to upload; add **delete** scope too if you plan to use
+immich-go subcommands that remove or replace assets.
+
+## Running an import
+
+Point immich-go at a running adapter and pass your key:
+
+```bash
+immich-go upload from-folder \
+  --server http://localhost:3001 \
+  --api-key apikey_your_key_here \
+  /path/to/photos
+```
+
+immich-go prefixes every request with `/api`, so `--server` is the adapter's base
+URL (no `/api` suffix). Against a deployed adapter, use its public URL instead of
+`localhost:3001`.
+
+## What immich-go does under the hood
+
+For a `upload from-folder` run, immich-go:
+
+1. Handshakes: `GET /api/server/ping` (expects `{"res":"pong"}`), `GET /api/users/me`,
+   `GET /api/server/media-types`, then `GET /api/server/about` — whose `version`
+   must be a valid semver string (the adapter reports the Immich version from
+   `.immich-container-tag`, which satisfies this).
+2. Builds a client-side index of what the server already has via paginated
+   `POST /api/search/metadata`, and skips assets whose checksum (base64 SHA-1) or
+   filename+size already match. Modern immich-go does **not** call
+   `/api/assets/bulk-upload-check`.
+3. Uploads each new asset with `POST /api/assets` (multipart `assetData`), sending
+   an `x-immich-checksum` header so the server can reject an already-stored file.
+4. Optionally creates albums (`POST /api/albums`) and adds assets to them
+   (`PUT /api/albums/{id}/assets`).
+
+## Troubleshooting
+
+- **401 on every call after the ping succeeds**: the `x-api-key` value isn't a
+  valid Gumnut API key, or it lacks write scope. The unauthenticated ping/version
+  endpoints answer without a key, so a bad key first surfaces at `GET /api/users/me`.
+- **"invalid semantic version" at connect time**: `.immich-container-tag` must hold
+  a semver value (e.g. `v3.0.3`); immich-go parses `/api/server/about`'s `version`
+  and aborts if it can't.

--- a/routers/middleware/auth_middleware.py
+++ b/routers/middleware/auth_middleware.py
@@ -104,66 +104,66 @@ class AuthMiddleware(BaseHTTPMiddleware):
         # a self-contained, long-lived backend credential. Forward it directly as
         # the Gumnut credential — there is no Redis session to look up, because API
         # keys are minted and validated by the Gumnut backend, not by the adapter.
-        # Checked first because it is unambiguous and cheap: Immich web (cookie) and
-        # mobile (Bearer / x-immich-user-token) never send this header, so there is
-        # no precedence conflict with the session-token clients below.
+        # Checked first because it is unambiguous: Immich web (cookie) and mobile
+        # (Bearer / x-immich-user-token) never send this header, so there is no
+        # precedence conflict with the session-token clients below.
         api_key = request.headers.get(self.API_KEY_HEADER)
+        auth_header = request.headers.get(self.AUTH_HEADER)
         if api_key:
             jwt_token = api_key
+        # Check for Authorization header (standard Bearer token)
+        elif auth_header and auth_header.lower().startswith("bearer "):
+            session_token = auth_header[7:]  # Remove "Bearer " prefix
+            is_web_client = False
+        # Check for Immich mobile client custom header
+        elif "x-immich-user-token" in request.headers:
+            session_token = request.headers.get("x-immich-user-token")
+            is_web_client = False
+        # Check for cookie (web client)
+        elif self.COOKIE_NAME in request.cookies:
+            session_token = request.cookies[self.COOKIE_NAME]
+            is_web_client = True
         else:
-            # Check for Authorization header (standard Bearer token)
-            auth_header = request.headers.get(self.AUTH_HEADER)
-            if auth_header and auth_header.lower().startswith("bearer "):
-                session_token = auth_header[7:]  # Remove "Bearer " prefix
-                is_web_client = False
-            # Check for Immich mobile client custom header
-            elif "x-immich-user-token" in request.headers:
-                session_token = request.headers.get("x-immich-user-token")
-                is_web_client = False
-            # Check for cookie (web client)
-            elif self.COOKIE_NAME in request.cookies:
-                session_token = request.cookies[self.COOKIE_NAME]
-                is_web_client = True
-            else:
-                logger.warning(
-                    "No session token found in request",
-                    extra={
-                        "path": path,
-                        "cookies": list(request.cookies.keys()),
+            logger.warning(
+                "No session token found in request",
+                extra={
+                    "path": path,
+                    "cookies": list(request.cookies.keys()),
+                },
+            )
+
+        # Look up session and decrypt JWT. Only session-token clients reach this;
+        # the api-key path above leaves session_token None and skips the lookup.
+        if session_token:
+            try:
+                session_store = await get_session_store()
+                session = await session_store.get_by_id(session_token)
+
+                if session:
+                    jwt_token = session.get_jwt()
+                else:
+                    logger.warning(
+                        "Session not found for token",
+                        extra={"path": path},
+                    )
+                    return self._invalid_token_response()
+            except Exception:
+                logger.error(
+                    "Error during session lookup",
+                    exc_info=True,
+                )
+                # An exception thrown inside dispatch will get wrapped
+                # by Starlette and not handled by our global exception handler.
+                # We need the response to be in the expected Immich format,
+                # so we return it directly here.
+                return JSONResponse(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    content={
+                        "message": "Internal server error",
+                        "statusCode": status.HTTP_500_INTERNAL_SERVER_ERROR,
+                        "error": "Internal Server Error",
                     },
                 )
-
-            # Look up session and decrypt JWT
-            if session_token:
-                try:
-                    session_store = await get_session_store()
-                    session = await session_store.get_by_id(session_token)
-
-                    if session:
-                        jwt_token = session.get_jwt()
-                    else:
-                        logger.warning(
-                            "Session not found for token",
-                            extra={"path": path},
-                        )
-                        return self._invalid_token_response()
-                except Exception:
-                    logger.error(
-                        "Error during session lookup",
-                        exc_info=True,
-                    )
-                    # An exception thrown inside dispatch will get wrapped
-                    # by Starlette and not handled by our global exception handler.
-                    # We need the response to be in the expected Immich format,
-                    # so we return it directly here.
-                    return JSONResponse(
-                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                        content={
-                            "message": "Internal server error",
-                            "statusCode": status.HTTP_500_INTERNAL_SERVER_ERROR,
-                            "error": "Internal Server Error",
-                        },
-                    )
 
         # Store in request state for dependency injection
         request.state.jwt_token = jwt_token

--- a/routers/middleware/auth_middleware.py
+++ b/routers/middleware/auth_middleware.py
@@ -19,15 +19,20 @@ class AuthMiddleware(BaseHTTPMiddleware):
     Middleware that handles session token extraction and JWT refresh for all requests.
 
     This middleware:
-    1. Detects client type (web vs mobile)
-    2. Extracts session token from cookies (web) or Authorization header (mobile)
-    3. Looks up the session in Redis and decrypts the stored JWT
-    4. Stores the JWT in request.state for dependency injection
+    1. Detects client type (web, mobile, or API-key client)
+    2. Extracts the caller's credential: a Gumnut API key from the `x-api-key`
+       header (immich-go and other Immich API-key clients), or a session token
+       from cookies (web) or the Authorization header (mobile)
+    3. For session tokens, looks up the session in Redis and decrypts the stored
+       JWT; for API keys, forwards the key straight through as the credential
+    4. Stores the resulting credential in request.state for dependency injection
     5. Handles JWT refresh from backend by updating stored JWT in session
+       (session-token clients only; API keys are non-refreshing)
     """
 
     COOKIE_NAME = "immich_access_token"
     AUTH_HEADER = "authorization"
+    API_KEY_HEADER = "x-api-key"
     REFRESH_HEADER = "x-new-access-token"
 
     # Auth middleware ONLY applies to paths starting with these prefixes.
@@ -89,64 +94,76 @@ class AuthMiddleware(BaseHTTPMiddleware):
         if path in self.UNAUTHENTICATED_PATHS:
             return await call_next(request)
 
-        # Detect client type and extract session token
+        # Detect client type and extract the caller's credential
         session_token = None
         is_web_client = False
-
-        # Check for Authorization header (standard Bearer token)
-        auth_header = request.headers.get(self.AUTH_HEADER)
-        if auth_header and auth_header.lower().startswith("bearer "):
-            session_token = auth_header[7:]  # Remove "Bearer " prefix
-            is_web_client = False
-        # Check for Immich mobile client custom header
-        elif "x-immich-user-token" in request.headers:
-            session_token = request.headers.get("x-immich-user-token")
-            is_web_client = False
-        # Check for cookie (web client)
-        elif self.COOKIE_NAME in request.cookies:
-            session_token = request.cookies[self.COOKIE_NAME]
-            is_web_client = True
-        else:
-            logger.warning(
-                "No session token found in request",
-                extra={
-                    "path": path,
-                    "cookies": list(request.cookies.keys()),
-                },
-            )
-
-        # Look up session and decrypt JWT
         jwt_token = None
-        if session_token:
-            try:
-                session_store = await get_session_store()
-                session = await session_store.get_by_id(session_token)
 
-                if session:
-                    jwt_token = session.get_jwt()
-                else:
-                    logger.warning(
-                        "Session not found for token",
-                        extra={"path": path},
-                    )
-                    return self._invalid_token_response()
-            except Exception:
-                logger.error(
-                    "Error during session lookup",
-                    exc_info=True,
-                )
-                # An exception thrown inside dispatch will get wrapped
-                # by Starlette and not handled by our global exception handler.
-                # We need the response to be in the expected Immich format,
-                # so we return it directly here.
-                return JSONResponse(
-                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    content={
-                        "message": "Internal server error",
-                        "statusCode": status.HTTP_500_INTERNAL_SERVER_ERROR,
-                        "error": "Internal Server Error",
+        # API-key auth (e.g. the immich-go CLI and other Immich API-key clients):
+        # the `x-api-key` header carries a Gumnut API key (`apikey_...`), which is
+        # a self-contained, long-lived backend credential. Forward it directly as
+        # the Gumnut credential — there is no Redis session to look up, because API
+        # keys are minted and validated by the Gumnut backend, not by the adapter.
+        # Checked first because it is unambiguous and cheap: Immich web (cookie) and
+        # mobile (Bearer / x-immich-user-token) never send this header, so there is
+        # no precedence conflict with the session-token clients below.
+        api_key = request.headers.get(self.API_KEY_HEADER)
+        if api_key:
+            jwt_token = api_key
+        else:
+            # Check for Authorization header (standard Bearer token)
+            auth_header = request.headers.get(self.AUTH_HEADER)
+            if auth_header and auth_header.lower().startswith("bearer "):
+                session_token = auth_header[7:]  # Remove "Bearer " prefix
+                is_web_client = False
+            # Check for Immich mobile client custom header
+            elif "x-immich-user-token" in request.headers:
+                session_token = request.headers.get("x-immich-user-token")
+                is_web_client = False
+            # Check for cookie (web client)
+            elif self.COOKIE_NAME in request.cookies:
+                session_token = request.cookies[self.COOKIE_NAME]
+                is_web_client = True
+            else:
+                logger.warning(
+                    "No session token found in request",
+                    extra={
+                        "path": path,
+                        "cookies": list(request.cookies.keys()),
                     },
                 )
+
+            # Look up session and decrypt JWT
+            if session_token:
+                try:
+                    session_store = await get_session_store()
+                    session = await session_store.get_by_id(session_token)
+
+                    if session:
+                        jwt_token = session.get_jwt()
+                    else:
+                        logger.warning(
+                            "Session not found for token",
+                            extra={"path": path},
+                        )
+                        return self._invalid_token_response()
+                except Exception:
+                    logger.error(
+                        "Error during session lookup",
+                        exc_info=True,
+                    )
+                    # An exception thrown inside dispatch will get wrapped
+                    # by Starlette and not handled by our global exception handler.
+                    # We need the response to be in the expected Immich format,
+                    # so we return it directly here.
+                    return JSONResponse(
+                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                        content={
+                            "message": "Internal server error",
+                            "statusCode": status.HTTP_500_INTERNAL_SERVER_ERROR,
+                            "error": "Internal Server Error",
+                        },
+                    )
 
         # Store in request state for dependency injection
         request.state.jwt_token = jwt_token

--- a/tests/unit/middleware/test_auth_middleware.py
+++ b/tests/unit/middleware/test_auth_middleware.py
@@ -238,6 +238,63 @@ class TestAuthMiddleware:
         assert response.status_code == 200
         assert response.json() == {"message": "login page"}
 
+    def test_api_key_used_directly_without_session_lookup(
+        self, client_with_mocks, mock_session_store
+    ):
+        """API-key clients (immich-go): x-api-key is forwarded as the credential.
+
+        The key must become request.state.jwt_token verbatim, with no Redis
+        session lookup and no session_token recorded.
+        """
+        api_key = "apikey_abc123"
+        headers = {"x-api-key": api_key}
+
+        response = client_with_mocks.get("/api/test/protected", headers=headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["jwt_token"] == api_key
+        assert data["session_token"] is None
+        assert data["is_web_client"] is False
+        # API keys are self-contained backend credentials — no session lookup.
+        mock_session_store.get_by_id.assert_not_awaited()
+
+    def test_api_key_takes_precedence_over_session_token(
+        self, client_with_mocks, mock_session_store
+    ):
+        """x-api-key wins over Bearer/cookie and skips the session lookup."""
+        api_key = "apikey_abc123"
+        headers = {
+            "x-api-key": api_key,
+            "Authorization": f"Bearer {TEST_SESSION_ID}",
+        }
+        client_with_mocks.cookies = {"immich_access_token": str(TEST_SESSION_ID)}
+
+        response = client_with_mocks.get("/api/test/protected", headers=headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["jwt_token"] == api_key
+        assert data["session_token"] is None
+        mock_session_store.get_by_id.assert_not_awaited()
+
+    def test_invalid_api_key_still_reaches_backend(
+        self, client_with_mocks, mock_session_store
+    ):
+        """The adapter does not validate the key shape — the Gumnut backend does.
+
+        Even a non-apikey_ value is forwarded verbatim; rejection happens upstream
+        when the credential is used, not in the middleware.
+        """
+        headers = {"x-api-key": "not-a-real-key"}
+
+        response = client_with_mocks.get("/api/test/protected", headers=headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["jwt_token"] == "not-a-real-key"
+        mock_session_store.get_by_id.assert_not_awaited()
+
 
 class TestTokenRefresh:
     """Test cases for JWT refresh handling."""

--- a/tests/unit/middleware/test_auth_middleware.py
+++ b/tests/unit/middleware/test_auth_middleware.py
@@ -278,6 +278,30 @@ class TestAuthMiddleware:
         assert data["session_token"] is None
         mock_session_store.get_by_id.assert_not_awaited()
 
+    def test_empty_api_key_falls_through_to_session_auth(
+        self, client_with_mocks, mock_session_store
+    ):
+        """An empty x-api-key is falsy, so it must not shadow the session path.
+
+        The branch hinges on Python truthiness (`if api_key:`), so an empty header
+        value must fall through to the Bearer/cookie session lookup rather than
+        being used as a (blank) credential — locking that boundary in.
+        """
+        session_token = str(TEST_SESSION_ID)
+        headers = {
+            "x-api-key": "",
+            "Authorization": f"Bearer {session_token}",
+        }
+
+        response = client_with_mocks.get("/api/test/protected", headers=headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        # Resolved via the session store, not the empty api key.
+        assert data["jwt_token"] == TEST_JWT
+        assert data["session_token"] == session_token
+        mock_session_store.get_by_id.assert_awaited_once()
+
     def test_invalid_api_key_still_reaches_backend(
         self, client_with_mocks, mock_session_store
     ):


### PR DESCRIPTION
## What
- `AuthMiddleware` now reads the `x-api-key` header and forwards its value to the Gumnut API as the caller's credential, so Immich API-key clients (e.g. the `immich-go` CLI) can authenticate. Previously only OAuth-derived session tokens (cookie / `Authorization: Bearer` / `x-immich-user-token`) were recognized, so every authenticated call from such a client returned 401.
- Stateless pass-through: the value is a Gumnut API key (`apikey_...`) that the Gumnut backend already validates end-to-end — no Redis session lookup, no key storage in the adapter. The header is checked first and short-circuits the session path; web (cookie) and mobile (Bearer / `x-immich-user-token`) clients never send it, so there is no precedence conflict.
- Adds a "Importing with immich-go" guide and updates the API-keys gap-analysis note. Key *management* through the Immich UI stays stubbed — minting a Gumnut API key requires a first-party browser session that the adapter's delegated OAuth token can't perform, so users mint keys in the Gumnut app.

## Why
Headless import/backup tools in the Immich ecosystem (immich-go and similar) authenticate exclusively with `x-api-key`. Supporting the header lets those tools work against the adapter with an unmodified binary and a Gumnut API key, without exposing any new backend surface. Verified end-to-end: with this change, a real `immich-go upload from-folder` run authenticates and uploads to the Gumnut API successfully.

## Test plan
- [x] `uv run ruff format` / `uv run ruff check` clean
- [x] `uv run pyright` clean on changed files
- [x] `uv run pytest` — full suite (1181 passing), including new middleware tests: `x-api-key` used directly without a session lookup, precedence over Bearer/cookie, verbatim forwarding of a non-`apikey_` value, and an empty `x-api-key` falling through to session auth
- [x] Manual: bogus `x-api-key` reaches the backend and returns its "Invalid API key" 401 (proves forwarding); a real key authenticates and uploads via `immich-go`

Generated by an AI coding agent.