### PR TITLE
Support criterion-less POST /api/search/metadata (immich-go enumeration)

### DIFF
--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -169,6 +169,7 @@ Mobile reads only the `people` array. A third-party client assuming upstream's `
 | `GET /api/albums` | `client.albums.list(limit=GUMNUT_API_MAX_PAGE_SIZE)` | Convert all to list, no pagination exposed |
 | `GET /api/albums/statistics` | `client.albums.list(limit=GUMNUT_API_MAX_PAGE_SIZE)` | Count total albums from the full set |
 | `GET /api/assets/statistics` | `client.assets.list(limit=GUMNUT_API_MAX_PAGE_SIZE)` | Count total/images/videos from full set |
+| `POST /api/search/metadata` (criterion-less) | `client.assets.list(state=…, limit=GUMNUT_API_MAX_PAGE_SIZE)` | Full-library enumeration (immich-go's asset sweep): load all → filter visibility / order → slice `page`/`size` → real `total` + `nextPage`. A request carrying a real criterion instead uses `client.search.search` (which mandates one). |
 
 **Performance implications:** Memory usage scales with total entity count, not page size. For a library with 10,000 people, every `GET /api/people` request loads all 10,000 into memory. This is acceptable for current Gumnut library sizes but will need optimization (e.g., server-side sorting support in the Gumnut API) as libraries grow.
 

--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Immich Adapter Architecture"
-last-updated: 2026-07-20
+last-updated: 2026-07-22
 ---
 
 # Immich Adapter Architecture
@@ -172,6 +172,8 @@ Mobile reads only the `people` array. A third-party client assuming upstream's `
 | `POST /api/search/metadata` (criterion-less) | `client.assets.list(state=…, limit=GUMNUT_API_MAX_PAGE_SIZE)` | Full-library enumeration (immich-go's asset sweep): load all → filter visibility / order → slice `page`/`size` → real `total` + `nextPage`. A request carrying a real criterion instead uses `client.search.search` (which mandates one). |
 
 **Performance implications:** Memory usage scales with total entity count, not page size. For a library with 10,000 people, every `GET /api/people` request loads all 10,000 into memory. This is acceptable for current Gumnut library sizes but will need optimization (e.g., server-side sorting support in the Gumnut API) as libraries grow.
+
+The criterion-less `POST /api/search/metadata` enumeration is a heavier case of this pattern: unlike the fetch-once endpoints above (each loaded once per client action), a client *pages through* it. immich-go requests `size:1000` (clamped to 200) and follows `nextPage` to the end, so the full library is re-loaded and re-converted on every page — cost scales with `library_size × page_count` for one bulk sweep. It's bounded and one-time (a library import), and the Gumnut API's cursor-only listing offers no stateless offset to page against, so load-all is the pragmatic choice today; cursor-based paging or a short-lived per-sweep cache is the optimization path if bulk-import cost against the Gumnut API becomes a concern.
 
 ### Pattern 2: Server-side cursor pagination
 

--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -321,6 +321,22 @@ async def _list_all_assets(
     with no total, while Immich clients page by offset and read `total` /
     `nextPage`, so the full set is loaded once and sliced here.
     """
+    # Every Gumnut asset converts to `timeline` visibility (hardcoded in
+    # `convert_gumnut_asset_to_immich`), so a non-timeline query matches nothing.
+    # immich-go sweeps archive/timeline/hidden, so 4 of its 6 enumeration queries
+    # are non-timeline — short-circuit here, before the load, so those don't each
+    # fetch the whole library only to discard it.
+    if (
+        request.visibility is not None
+        and request.visibility != AssetVisibility.timeline
+    ):
+        return SearchResponseDto(
+            albums=SearchAlbumResponseDto(count=0, facets=[], items=[], total=0),
+            assets=SearchAssetResponseDto(
+                count=0, facets=[], items=[], nextPage=None, total=0
+            ),
+        )
+
     # `withDeleted` widens to live+trashed; immich-go's trashed pass instead
     # sends `trashedAfter` (a min date meaning "all trashed ever"). The Gumnut
     # API has no trash-date filter, so `trashedAfter`'s value isn't honored —
@@ -356,16 +372,6 @@ async def _list_all_assets(
             for asset in all_assets
             if asset.trashed_at is None or asset.trashed_at >= request.trashedAfter
         ]
-
-    # Every Gumnut asset converts to `timeline` visibility (hardcoded in
-    # `convert_gumnut_asset_to_immich`), so a non-timeline query — immich-go
-    # sweeps archive/timeline/hidden — matches nothing rather than returning the
-    # live/trashed set once per visibility.
-    if (
-        request.visibility is not None
-        and request.visibility != AssetVisibility.timeline
-    ):
-        all_assets = []
 
     # The Gumnut API lists in descending order (capture time for live/all, trash
     # time for trashed); honor an explicit ascending request by reversing it

--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -249,6 +249,31 @@ async def search_asset_statistics(
     return SearchStatisticsResponseDto(total=total)
 
 
+# Fields on MetadataSearchDto that a plain asset listing can honor (or that
+# don't restrict the result set), so their presence does NOT disqualify a
+# request from the criterion-less enumeration path: pagination, response-shape
+# hints, sort order, and the visibility/trash selectors `_list_all_assets`
+# translates. Every *other* field is a restricting filter. Framing this as an
+# allow-list (rather than enumerating the restricting fields) fails safe:
+# MetadataSearchDto is generated from Immich's OpenAPI spec and regenerated on
+# version bumps, so a newly added filter is absent from this set and therefore
+# treated as restricting — it keeps the existing search path instead of being
+# silently ignored by an enumeration that returns the whole library.
+_ENUMERATION_HONORABLE_FIELDS = frozenset(
+    {
+        "page",
+        "size",
+        "order",
+        "visibility",
+        "trashedAfter",
+        "withDeleted",
+        "withExif",
+        "withPeople",
+        "withStacked",
+    }
+)
+
+
 def _is_criterion_less_enumeration(request: MetadataSearchDto) -> bool:
     """True when a metadata search is a filter-less full-library enumeration.
 
@@ -261,58 +286,27 @@ def _is_criterion_less_enumeration(request: MetadataSearchDto) -> bool:
     criterion-less enumeration to a plain asset listing instead
     (`_list_all_assets`).
 
-    Any *restricting* filter disqualifies the request, which then keeps the
-    existing `search.search` path — that path serves query/date/person and 400s
-    on the rest, exactly as before. Gating on the absence of every restricting
-    filter (rather than ignoring the ones the listing can't honor) means the
-    enumeration branch never silently drops a filter and returns everything.
-    `page`/`size`/`withExif`/`order`/`visibility`/`trashedAfter`/`withDeleted`
-    are enumeration-honorable (handled in `_list_all_assets`) and so are absent
-    from the restricting set below.
+    A request is criterion-less only when every populated field is
+    enumeration-honorable (see `_ENUMERATION_HONORABLE_FIELDS`). Any restricting
+    filter keeps the request on the existing `search.search` path — which serves
+    query/date/person and 400s on the rest, exactly as before. Gating on the
+    absence of every restricting filter (rather than ignoring the ones the
+    listing can't honor) means the enumeration branch never silently drops a
+    filter and returns everything.
     """
-    restricting_values = (
-        request.description,
-        request.albumIds,
-        request.checksum,
-        request.city,
-        request.country,
-        request.createdAfter,
-        request.createdBefore,
-        request.encodedVideoPath,
-        request.id,
-        request.lensModel,
-        request.libraryId,
-        request.make,
-        request.model,
-        request.ocr,
-        request.originalFileName,
-        request.originalPath,
-        request.personIds,
-        request.previewPath,
-        request.rating,
-        request.state,
-        request.tagIds,
-        request.takenAfter,
-        request.takenBefore,
-        request.thumbnailPath,
-        request.trashedBefore,
-        request.type,
-        request.updatedAfter,
-        request.updatedBefore,
-    )
-    # Booleans count only when explicitly true: `False` narrows nothing (the
-    # backing features don't exist in the Gumnut API), so it doesn't disqualify
-    # the enumeration — same posture as `search_random`.
-    restricting_flags = (
-        request.isEncoded,
-        request.isFavorite,
-        request.isMotion,
-        request.isNotInAlbum,
-        request.isOffline,
-    )
-    return not (
-        any(value is not None for value in restricting_values) or any(restricting_flags)
-    )
+    for field_name, value in request:
+        if field_name in _ENUMERATION_HONORABLE_FIELDS:
+            continue
+        # Boolean filters (isFavorite/isMotion/…) restrict only when explicitly
+        # true: `False` narrows nothing (the backing features don't exist in the
+        # Gumnut API), so it doesn't disqualify the enumeration — same posture as
+        # `search_random`.
+        if isinstance(value, bool):
+            if value:
+                return False
+        elif value is not None:
+            return False
+    return True
 
 
 async def _list_all_assets(
@@ -361,8 +355,9 @@ async def _list_all_assets(
             asset for asset in immich_assets if asset.visibility == request.visibility
         ]
 
-    # The Gumnut API lists newest-first; honor an explicit ascending request
-    # (immich-go sends order="asc"). Mirrors the timeline endpoint.
+    # The Gumnut API lists in descending order (capture time for live/all,
+    # trash time for trashed); honor an explicit ascending request by reversing
+    # that order (immich-go sends order="asc"). Mirrors the timeline endpoint.
     if request.order == AssetOrder.asc:
         immich_assets.reverse()
 
@@ -402,9 +397,6 @@ async def search_assets(
     current_user: UserResponseDto = Depends(get_current_user),
 ) -> SearchResponseDto:
     """Search for assets by metadata filters."""
-    # A criterion-less request is a full-library enumeration (immich-go's asset
-    # sweep). The Gumnut API's search requires a criterion and 400s on an empty
-    # one, so route these to a plain listing instead.
     if _is_criterion_less_enumeration(request):
         return await _list_all_assets(request, client, current_user)
 

--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -342,26 +342,38 @@ async def _list_all_assets(
         )
     ]
 
-    immich_assets = [
-        convert_gumnut_asset_to_immich(asset, current_user) for asset in all_assets
-    ]
-
-    # The Gumnut API listing can't filter by visibility, and every asset
-    # converts to `timeline` visibility, so a non-timeline query (immich-go
-    # sweeps archive/timeline/hidden) correctly matches nothing here rather than
-    # returning the live/trashed set once per visibility.
-    if request.visibility is not None:
-        immich_assets = [
-            asset for asset in immich_assets if asset.visibility == request.visibility
+    # Honor a `trashedAfter` lower bound. The Gumnut API can't filter the trashed
+    # set by trash time, so drop assets trashed before the requested instant
+    # here. immich-go sends the min sentinel ("all trashed ever"), for which this
+    # keeps everything; a real bound (e.g. "deleted since last week") is honored
+    # rather than silently widened to the whole trash. Live assets (`trashed_at`
+    # is None) are always kept — the bound only restricts trashed ones — so this
+    # is correct for both `state="trashed"` and the `withDeleted` `state="all"`
+    # case (live + trash), which can also carry `trashedAfter`.
+    if request.trashedAfter is not None:
+        all_assets = [
+            asset
+            for asset in all_assets
+            if asset.trashed_at is None or asset.trashed_at >= request.trashedAfter
         ]
 
-    # The Gumnut API lists in descending order (capture time for live/all,
-    # trash time for trashed); honor an explicit ascending request by reversing
-    # that order (immich-go sends order="asc"). Mirrors the timeline endpoint.
-    if request.order == AssetOrder.asc:
-        immich_assets.reverse()
+    # Every Gumnut asset converts to `timeline` visibility (hardcoded in
+    # `convert_gumnut_asset_to_immich`), so a non-timeline query — immich-go
+    # sweeps archive/timeline/hidden — matches nothing rather than returning the
+    # live/trashed set once per visibility.
+    if (
+        request.visibility is not None
+        and request.visibility != AssetVisibility.timeline
+    ):
+        all_assets = []
 
-    total = len(immich_assets)
+    # The Gumnut API lists in descending order (capture time for live/all, trash
+    # time for trashed); honor an explicit ascending request by reversing it
+    # (immich-go sends order="asc"). Mirrors the timeline endpoint.
+    if request.order == AssetOrder.asc:
+        all_assets.reverse()
+
+    total = len(all_assets)
     # Clamp at the Gumnut API per-page ceiling. The Immich client default is
     # 1000; the adapter pages the client through the library at 200 per page.
     size = (
@@ -371,7 +383,15 @@ async def _list_all_assets(
     )
     page = int(request.page) if request.page is not None else 1
     start = (page - 1) * size
-    page_items = immich_assets[start : start + size]
+    # Convert only the requested page, not the whole library, so the heavy Immich
+    # DTOs are built for at most `size` assets even when the library is large.
+    # The listing itself is still fully loaded — offset paging over the Gumnut
+    # API's cursor listing needs the full ordered set for `total` and slicing
+    # (native offset/order support is tracked as a follow-up).
+    page_items = [
+        convert_gumnut_asset_to_immich(asset, current_user)
+        for asset in all_assets[start : start + size]
+    ]
 
     # `nextPage` is a JSON string (immich-go decodes it as `nextPage,string`);
     # `None` — never "" — on the last page keeps the mobile client's

--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -21,6 +21,7 @@ from routers.immich_models import (
     SearchExploreItem,
     SearchExploreResponseDto,
     AssetResponseDto,
+    AssetOrder,
     AssetTypeEnum,
     AssetVisibility,
     SearchResponseDto,
@@ -248,6 +249,152 @@ async def search_asset_statistics(
     return SearchStatisticsResponseDto(total=total)
 
 
+def _is_criterion_less_enumeration(request: MetadataSearchDto) -> bool:
+    """True when a metadata search is a filter-less full-library enumeration.
+
+    immich-go lists every server asset with a criterion-less
+    `POST /api/search/metadata` — its body carries only pagination plus
+    `visibility`/`order`/`withExif` and (for its trashed pass) `trashedAfter`,
+    no query/date/person/etc. Real Immich returns *all* assets for such a
+    request, but the Gumnut API's `search.search` mandates a criterion and 400s
+    on an empty one, aborting immich-go before it uploads anything. So route a
+    criterion-less enumeration to a plain asset listing instead
+    (`_list_all_assets`).
+
+    Any *restricting* filter disqualifies the request, which then keeps the
+    existing `search.search` path — that path serves query/date/person and 400s
+    on the rest, exactly as before. Gating on the absence of every restricting
+    filter (rather than ignoring the ones the listing can't honor) means the
+    enumeration branch never silently drops a filter and returns everything.
+    `page`/`size`/`withExif`/`order`/`visibility`/`trashedAfter`/`withDeleted`
+    are enumeration-honorable (handled in `_list_all_assets`) and so are absent
+    from the restricting set below.
+    """
+    restricting_values = (
+        request.description,
+        request.albumIds,
+        request.checksum,
+        request.city,
+        request.country,
+        request.createdAfter,
+        request.createdBefore,
+        request.encodedVideoPath,
+        request.id,
+        request.lensModel,
+        request.libraryId,
+        request.make,
+        request.model,
+        request.ocr,
+        request.originalFileName,
+        request.originalPath,
+        request.personIds,
+        request.previewPath,
+        request.rating,
+        request.state,
+        request.tagIds,
+        request.takenAfter,
+        request.takenBefore,
+        request.thumbnailPath,
+        request.trashedBefore,
+        request.type,
+        request.updatedAfter,
+        request.updatedBefore,
+    )
+    # Booleans count only when explicitly true: `False` narrows nothing (the
+    # backing features don't exist in the Gumnut API), so it doesn't disqualify
+    # the enumeration — same posture as `search_random`.
+    restricting_flags = (
+        request.isEncoded,
+        request.isFavorite,
+        request.isMotion,
+        request.isNotInAlbum,
+        request.isOffline,
+    )
+    return not (
+        any(value is not None for value in restricting_values) or any(restricting_flags)
+    )
+
+
+async def _list_all_assets(
+    request: MetadataSearchDto,
+    client: AsyncGumnut,
+    current_user: UserResponseDto,
+) -> SearchResponseDto:
+    """Serve a criterion-less metadata search as a plain, paginated asset listing.
+
+    Follows the adapter's load-all + client-side pagination pattern (as in
+    `/api/assets/statistics`): the Gumnut API's asset listing is cursor-based
+    with no total, while Immich clients page by offset and read `total` /
+    `nextPage`, so the full set is loaded once and sliced here.
+    """
+    # `withDeleted` widens to live+trashed; immich-go's trashed pass instead
+    # sends `trashedAfter` (a min date meaning "all trashed ever"). The Gumnut
+    # API has no trash-date filter, so `trashedAfter`'s value isn't honored —
+    # its presence just selects the trashed set, which is exactly immich-go's
+    # all-trashed intent.
+    if request.withDeleted:
+        state = "all"
+    elif request.trashedAfter is not None:
+        state = "trashed"
+    else:
+        state = "live"
+
+    all_assets = [
+        asset
+        async for asset in client.assets.list(
+            state=state,
+            limit=GUMNUT_API_MAX_PAGE_SIZE,
+            include=ASSET_INCLUDE,
+        )
+    ]
+
+    immich_assets = [
+        convert_gumnut_asset_to_immich(asset, current_user) for asset in all_assets
+    ]
+
+    # The Gumnut API listing can't filter by visibility, and every asset
+    # converts to `timeline` visibility, so a non-timeline query (immich-go
+    # sweeps archive/timeline/hidden) correctly matches nothing here rather than
+    # returning the live/trashed set once per visibility.
+    if request.visibility is not None:
+        immich_assets = [
+            asset for asset in immich_assets if asset.visibility == request.visibility
+        ]
+
+    # The Gumnut API lists newest-first; honor an explicit ascending request
+    # (immich-go sends order="asc"). Mirrors the timeline endpoint.
+    if request.order == AssetOrder.asc:
+        immich_assets.reverse()
+
+    total = len(immich_assets)
+    # Clamp at the Gumnut API per-page ceiling. The Immich client default is
+    # 1000; the adapter pages the client through the library at 200 per page.
+    size = (
+        min(int(request.size), GUMNUT_API_MAX_PAGE_SIZE)
+        if request.size is not None
+        else GUMNUT_API_MAX_PAGE_SIZE
+    )
+    page = int(request.page) if request.page is not None else 1
+    start = (page - 1) * size
+    page_items = immich_assets[start : start + size]
+
+    # `nextPage` is a JSON string (immich-go decodes it as `nextPage,string`);
+    # `None` — never "" — on the last page keeps the mobile client's
+    # `nextPage?.toInt()` from throwing (see `test_response_next_page_is_none`).
+    next_page = str(page + 1) if start + size < total else None
+
+    return SearchResponseDto(
+        albums=SearchAlbumResponseDto(count=0, facets=[], items=[], total=0),
+        assets=SearchAssetResponseDto(
+            count=len(page_items),
+            facets=[],
+            items=page_items,
+            nextPage=next_page,
+            total=total,
+        ),
+    )
+
+
 @router.post("/metadata")
 async def search_assets(
     request: MetadataSearchDto,
@@ -255,6 +402,12 @@ async def search_assets(
     current_user: UserResponseDto = Depends(get_current_user),
 ) -> SearchResponseDto:
     """Search for assets by metadata filters."""
+    # A criterion-less request is a full-library enumeration (immich-go's asset
+    # sweep). The Gumnut API's search requires a criterion and 400s on an empty
+    # one, so route these to a plain listing instead.
+    if _is_criterion_less_enumeration(request):
+        return await _list_all_assets(request, client, current_user)
+
     person_ids = None
     if request.personIds:
         person_ids = [uuid_to_gumnut_person_id(pid) for pid in request.personIds]

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -863,6 +863,9 @@ class TestSearchMetadataEnumeration:
         )
         assert archived.assets.count == 0
         assert archived.assets.total == 0
+        # The empty result is returned before loading the library, so the
+        # archive/hidden sweeps don't each fetch and discard the whole listing.
+        mock_client.assets.list.assert_not_called()
 
         timeline = await search_assets(
             request=MetadataSearchDto(visibility=AssetVisibility.timeline),

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -652,6 +652,67 @@ class TestSearchMetadataEnumeration:
         assert page3.assets.nextPage is None
 
     @pytest.mark.anyio
+    async def test_exact_full_final_page_has_no_next_page(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """When total is an exact multiple of size, the last full page ends the
+        walk — nextPage is None (the `start + size < total` boundary, not `<=`)."""
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        assets = [_make_search_asset(now) for _ in range(4)]
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(return_value=mock_sync_cursor_page(assets))
+
+        result = await search_assets(
+            request=MetadataSearchDto(size=2, page=2),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert result.assets.count == 2
+        assert result.assets.total == 4
+        assert result.assets.nextPage is None
+
+    @pytest.mark.anyio
+    async def test_page_past_end_is_empty(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """A page beyond the last returns no items and no nextPage, so immich-go
+        stops rather than looping."""
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        assets = [_make_search_asset(now) for _ in range(3)]
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(return_value=mock_sync_cursor_page(assets))
+
+        result = await search_assets(
+            request=MetadataSearchDto(size=2, page=4),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert result.assets.count == 0
+        assert result.assets.total == 3
+        assert result.assets.nextPage is None
+
+    @pytest.mark.anyio
+    async def test_empty_library_returns_empty_page(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        mock_client = Mock()
+        mock_client.assets.list = Mock(return_value=mock_sync_cursor_page([]))
+
+        result = await search_assets(
+            request=MetadataSearchDto(),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert result.assets.count == 0
+        assert result.assets.total == 0
+        assert result.assets.nextPage is None
+
+    @pytest.mark.anyio
     async def test_clamps_size_to_ceiling(
         self, mock_sync_cursor_page, mock_current_user
     ):

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 
 from routers.api.search import (
     _fetch_month_assets_at_offsets,
+    _is_criterion_less_enumeration,
     get_explore_data,
     search_person,
     search_assets,
@@ -15,6 +16,7 @@ from routers.api.search import (
     search_smart,
 )
 from routers.immich_models import (
+    AssetOrder,
     AssetTypeEnum,
     AssetVisibility,
     MetadataSearchDto,
@@ -398,7 +400,9 @@ class TestSearchMetadata:
             side_effect=make_sdk_status_error(500, "boom")
         )
 
-        request = MetadataSearchDto()
+        # A description keeps this on the search.search path (a criterion-less
+        # request instead enumerates via assets.list — see TestSearchMetadataEnumeration).
+        request = MetadataSearchDto(description="boom")
 
         with pytest.raises(APIStatusError):
             await search_assets(
@@ -521,6 +525,268 @@ def _counts_response(buckets: list[Mock]) -> Mock:
     response.data = buckets
     response.has_more = False
     return response
+
+
+class TestCriterionLessEnumeration:
+    """Test the classifier that routes a filter-less metadata search to a listing."""
+
+    def test_empty_request_is_enumeration(self):
+        assert _is_criterion_less_enumeration(MetadataSearchDto()) is True
+
+    def test_enumeration_honorable_fields_do_not_disqualify(self):
+        # The fields immich-go's asset sweep sends, plus withDeleted.
+        assert (
+            _is_criterion_less_enumeration(
+                MetadataSearchDto(
+                    page=1,
+                    size=1000,
+                    withExif=True,
+                    order=AssetOrder.asc,
+                    visibility=AssetVisibility.timeline,
+                    trashedAfter=datetime(1, 1, 1, tzinfo=timezone.utc),
+                )
+            )
+            is True
+        )
+        assert (
+            _is_criterion_less_enumeration(MetadataSearchDto(withDeleted=True)) is True
+        )
+
+    def test_false_flags_do_not_disqualify(self):
+        # A false boolean narrows nothing, so it stays an enumeration.
+        assert (
+            _is_criterion_less_enumeration(
+                MetadataSearchDto(isFavorite=False, isNotInAlbum=False)
+            )
+            is True
+        )
+
+    @pytest.mark.parametrize(
+        "request_kwargs",
+        [
+            {"description": "sunset"},
+            {"takenAfter": datetime(2024, 1, 1, tzinfo=timezone.utc)},
+            {"takenBefore": datetime(2024, 1, 1, tzinfo=timezone.utc)},
+            {"personIds": [uuid4()]},
+            {"albumIds": [uuid4()]},
+            {"tagIds": [uuid4()]},
+            {"city": "Paris"},
+            {"make": "Canon"},
+            {"checksum": "abc123"},
+            {"rating": 5},
+            {"type": AssetTypeEnum.IMAGE},
+            {"state": "California"},
+            {"isFavorite": True},
+            {"isNotInAlbum": True},
+        ],
+    )
+    def test_restricting_filters_disqualify(self, request_kwargs):
+        assert (
+            _is_criterion_less_enumeration(MetadataSearchDto(**request_kwargs)) is False
+        )
+
+
+class TestSearchMetadataEnumeration:
+    """Test that a criterion-less /search/metadata enumerates via a plain listing."""
+
+    @pytest.mark.anyio
+    async def test_criterion_less_routes_to_listing(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """A filter-less request lists assets instead of hitting search.search
+        (which 400s on an empty criterion and aborts immich-go)."""
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        assets = [_make_search_asset(now) for _ in range(3)]
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(return_value=mock_sync_cursor_page(assets))
+        mock_client.search.search = AsyncMock()
+
+        result = await search_assets(
+            request=MetadataSearchDto(withExif=True),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        mock_client.search.search.assert_not_called()
+        list_kwargs = mock_client.assets.list.call_args.kwargs
+        assert list_kwargs["state"] == "live"
+        assert list_kwargs["limit"] == 200
+        assert list_kwargs["include"] == ASSET_INCLUDE
+        assert result.assets.count == 3
+        assert result.assets.total == 3
+        assert result.assets.nextPage is None
+        assert len(result.assets.items) == 3
+
+    @pytest.mark.anyio
+    async def test_paginates_with_string_next_page(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """total counts the full set; nextPage is a string until the last page,
+        then None — the throwaway eval patch returned nextPage=None always and
+        so truncated any library larger than one page."""
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        assets = [_make_search_asset(now) for _ in range(5)]
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(return_value=mock_sync_cursor_page(assets))
+
+        async def _search(page: int):
+            return await search_assets(
+                request=MetadataSearchDto(size=2, page=page),
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+        page1 = await _search(1)
+        assert page1.assets.count == 2
+        assert page1.assets.total == 5
+        assert page1.assets.nextPage == "2"
+
+        page2 = await _search(2)
+        assert page2.assets.count == 2
+        assert page2.assets.nextPage == "3"
+
+        page3 = await _search(3)
+        assert page3.assets.count == 1
+        assert page3.assets.nextPage is None
+
+    @pytest.mark.anyio
+    async def test_clamps_size_to_ceiling(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """size=1000 is clamped to the 200 per-page ceiling, so a >200 library
+        is paged rather than dumped in one oversized page."""
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        assets = [_make_search_asset(now) for _ in range(201)]
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(return_value=mock_sync_cursor_page(assets))
+
+        result = await search_assets(
+            request=MetadataSearchDto(size=1000, page=1),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert result.assets.count == 200
+        assert result.assets.total == 201
+        assert result.assets.nextPage == "2"
+
+    @pytest.mark.anyio
+    async def test_trashed_after_reads_trashed_state(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """immich-go's trashed pass sends trashedAfter; it selects the trashed set."""
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        trashed = _make_search_asset(now)
+        trashed.trashed_at = now
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(return_value=mock_sync_cursor_page([trashed]))
+        mock_client.search.search = AsyncMock()
+
+        result = await search_assets(
+            request=MetadataSearchDto(
+                trashedAfter=datetime(1, 1, 1, tzinfo=timezone.utc)
+            ),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        mock_client.search.search.assert_not_called()
+        assert mock_client.assets.list.call_args.kwargs["state"] == "trashed"
+        assert result.assets.count == 1
+
+    @pytest.mark.anyio
+    async def test_with_deleted_reads_all_state(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        mock_client = Mock()
+        mock_client.assets.list = Mock(
+            return_value=mock_sync_cursor_page([_make_search_asset(now)])
+        )
+
+        await search_assets(
+            request=MetadataSearchDto(withDeleted=True),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert mock_client.assets.list.call_args.kwargs["state"] == "all"
+
+    @pytest.mark.anyio
+    async def test_non_timeline_visibility_filters_to_empty(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """All Gumnut assets convert to timeline visibility, so immich-go's
+        archive/hidden sweeps correctly return nothing rather than the live set."""
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        assets = [_make_search_asset(now) for _ in range(3)]
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(return_value=mock_sync_cursor_page(assets))
+
+        archived = await search_assets(
+            request=MetadataSearchDto(visibility=AssetVisibility.archive),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+        assert archived.assets.count == 0
+        assert archived.assets.total == 0
+
+        timeline = await search_assets(
+            request=MetadataSearchDto(visibility=AssetVisibility.timeline),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+        assert timeline.assets.count == 3
+
+    @pytest.mark.anyio
+    async def test_order_asc_reverses_newest_first_listing(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """assets.list is newest-first; order=asc must reverse to oldest-first."""
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        assets = [_make_search_asset(now) for _ in range(3)]
+        expected_desc = [safe_uuid_from_asset_id(a.id) for a in assets]
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(return_value=mock_sync_cursor_page(assets))
+
+        desc = await search_assets(
+            request=MetadataSearchDto(order=AssetOrder.desc),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+        assert [item.id for item in desc.assets.items] == expected_desc
+
+        asc = await search_assets(
+            request=MetadataSearchDto(order=AssetOrder.asc),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+        assert [item.id for item in asc.assets.items] == list(reversed(expected_desc))
+
+    @pytest.mark.anyio
+    async def test_real_criterion_still_uses_search(self, mock_current_user):
+        """A description keeps the existing semantic-search path; no listing."""
+        search_response = Mock()
+        search_response.data = []
+
+        mock_client = Mock()
+        mock_client.search.search = AsyncMock(return_value=search_response)
+        mock_client.assets.list = Mock()
+
+        await search_assets(
+            request=MetadataSearchDto(description="sunset"),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        mock_client.search.search.assert_called_once()
+        mock_client.assets.list.assert_not_called()
 
 
 class TestSearchExplore:

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -760,6 +760,36 @@ class TestSearchMetadataEnumeration:
         assert result.assets.count == 1
 
     @pytest.mark.anyio
+    async def test_trashed_after_honors_real_lower_bound(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """A real trashedAfter drops assets trashed before it (the min sentinel
+        immich-go sends keeps everything, but a genuine bound is respected)."""
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        old = _make_search_asset(now)
+        old.trashed_at = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        recent = _make_search_asset(now)
+        recent.trashed_at = datetime(2024, 6, 20, tzinfo=timezone.utc)
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(
+            return_value=mock_sync_cursor_page([recent, old])
+        )
+
+        result = await search_assets(
+            request=MetadataSearchDto(
+                trashedAfter=datetime(2024, 6, 10, tzinfo=timezone.utc)
+            ),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        # Only the asset trashed after 2024-06-10 survives.
+        assert result.assets.count == 1
+        assert result.assets.total == 1
+        assert result.assets.items[0].id == safe_uuid_from_asset_id(recent.id)
+
+    @pytest.mark.anyio
     async def test_with_deleted_reads_all_state(
         self, mock_sync_cursor_page, mock_current_user
     ):
@@ -776,6 +806,43 @@ class TestSearchMetadataEnumeration:
         )
 
         assert mock_client.assets.list.call_args.kwargs["state"] == "all"
+
+    @pytest.mark.anyio
+    async def test_with_deleted_honors_trashed_after_and_keeps_live(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """state=all (withDeleted) with a real trashedAfter keeps live assets and
+        recently-trashed ones, but drops trash older than the bound — the bound
+        isn't silently ignored just because withDeleted selected state=all."""
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        live = _make_search_asset(now)  # trashed_at is None
+        old_trash = _make_search_asset(now)
+        old_trash.trashed_at = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        recent_trash = _make_search_asset(now)
+        recent_trash.trashed_at = datetime(2024, 6, 20, tzinfo=timezone.utc)
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(
+            return_value=mock_sync_cursor_page([live, recent_trash, old_trash])
+        )
+
+        result = await search_assets(
+            request=MetadataSearchDto(
+                withDeleted=True,
+                trashedAfter=datetime(2024, 6, 10, tzinfo=timezone.utc),
+            ),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert mock_client.assets.list.call_args.kwargs["state"] == "all"
+        returned = {item.id for item in result.assets.items}
+        assert returned == {
+            safe_uuid_from_asset_id(live.id),
+            safe_uuid_from_asset_id(recent_trash.id),
+        }
+        assert safe_uuid_from_asset_id(old_trash.id) not in returned
+        assert result.assets.total == 2
 
     @pytest.mark.anyio
     async def test_non_timeline_visibility_filters_to_empty(


### PR DESCRIPTION
## What
- Route a **criterion-less** `POST /api/search/metadata` to a plain asset listing instead of the Gumnut API's `search.search`. immich-go enumerates the whole library this way (its body carries only pagination + `visibility`/`order`/`withExif`, and for its trashed pass `trashedAfter` — no query/date/person).
- `_list_all_assets` follows the adapter's documented **Pattern 1** (load-all + client-side pagination, like `/api/assets/statistics`): maps `withDeleted→all` / `trashedAfter→trashed` / else `live` for the Gumnut `state`, filters `visibility` in memory, honors `order=asc`, slices `page`/`size` (clamped to 200), and returns a real `total` plus a string `nextPage` (`None` on the last page).
- A request carrying any real criterion keeps the existing `search.search` path unchanged. The classifier is an **allow-list** of enumeration-honorable fields, so a future OpenAPI-regenerated filter field fails safe onto the search path rather than being silently ignored.

## Why
- The Gumnut API's search mandates a criterion and returns 400 ("At least one search criterion must be provided") on an empty one, so immich-go's asset sweep aborted before uploading anything. Real Immich returns *all* assets for a filter-less metadata search; this makes the adapter match that contract.
- This is the adapter-side, production-ready replacement for a throwaway evaluation patch whose `nextPage=None` / `total=len(page)` only worked for a single-page library — real pagination here carries a client correctly through libraries larger than one page.

## Test plan
- [x] `uv run pytest` — 1209 passed (new `TestCriterionLessEnumeration` + `TestSearchMetadataEnumeration`: routing, multi-page `nextPage`/`total`, size clamp 1000→200, trashed/withDeleted state mapping, visibility filter, order reverse, real-criterion routing, and boundary cases — exact-full-final-page, page-past-end, empty library)
- [x] `uv run ruff format` / `uv run ruff check` / `uv run pyright` clean

Generated by an AI coding agent.