### PR TITLE
Forward asset listing order to Gumnut API

### DIFF
--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -169,7 +169,7 @@ Mobile reads only the `people` array. A third-party client assuming upstream's `
 | `GET /api/albums` | `client.albums.list(limit=GUMNUT_API_MAX_PAGE_SIZE)` | Convert all to list, no pagination exposed |
 | `GET /api/albums/statistics` | `client.albums.list(limit=GUMNUT_API_MAX_PAGE_SIZE)` | Count total albums from the full set |
 | `GET /api/assets/statistics` | `client.assets.list(limit=GUMNUT_API_MAX_PAGE_SIZE)` | Count total/images/videos from full set |
-| `POST /api/search/metadata` (criterion-less) | `client.assets.list(state=…, limit=GUMNUT_API_MAX_PAGE_SIZE)` | Full-library enumeration (immich-go's asset sweep): load all → filter visibility / order → slice `page`/`size` → real `total` + `nextPage`. A request carrying a real criterion instead uses `client.search.search` (which mandates one). |
+| `POST /api/search/metadata` (criterion-less) | `client.assets.list(state=…, limit=GUMNUT_API_MAX_PAGE_SIZE, extra_query={"order": request.order.value})` | Full-library enumeration (immich-go's asset sweep): load in the requested native order → apply any `trashedAfter` lower bound → slice `page`/`size` → real `total` + `nextPage`. A request carrying a real criterion instead uses `client.search.search` (which mandates one). |
 
 **Performance implications:** Memory usage scales with total entity count, not page size. For a library with 10,000 people, every `GET /api/people` request loads all 10,000 into memory. This is acceptable for current Gumnut library sizes but will need optimization (e.g., server-side sorting support in the Gumnut API) as libraries grow.
 
@@ -253,7 +253,7 @@ Timeline bucket contents are returned in reverse chronological order by default 
 
 ### Album and asset ordering
 
-Albums and assets use Gumnut's default ordering and are not re-sorted by the adapter.
+Albums use Gumnut's default ordering. Criterion-less asset enumeration forwards the Immich request's ascending/descending order to the Gumnut API and does not re-sort the returned assets in the adapter.
 
 ## Trash and Deletion Semantics
 

--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -169,7 +169,7 @@ Mobile reads only the `people` array. A third-party client assuming upstream's `
 | `GET /api/albums` | `client.albums.list(limit=GUMNUT_API_MAX_PAGE_SIZE)` | Convert all to list, no pagination exposed |
 | `GET /api/albums/statistics` | `client.albums.list(limit=GUMNUT_API_MAX_PAGE_SIZE)` | Count total albums from the full set |
 | `GET /api/assets/statistics` | `client.assets.list(limit=GUMNUT_API_MAX_PAGE_SIZE)` | Count total/images/videos from full set |
-| `POST /api/search/metadata` (criterion-less) | `client.assets.list(state=…, limit=GUMNUT_API_MAX_PAGE_SIZE, extra_query={"order": request.order.value})` | Full-library enumeration (immich-go's asset sweep): load in the requested native order → apply any `trashedAfter` lower bound → slice `page`/`size` → real `total` + `nextPage`. A request carrying a real criterion instead uses `client.search.search` (which mandates one). |
+| `POST /api/search/metadata` (criterion-less) | `client.assets.list(state=…, limit=GUMNUT_API_MAX_PAGE_SIZE)` + requested `order` query | Full-library enumeration (immich-go's asset sweep): load in the requested native order → apply any `trashedAfter` lower bound → slice `page`/`size` → real `total` + `nextPage`. A request carrying a real criterion instead uses `client.search.search` (which mandates one). |
 
 **Performance implications:** Memory usage scales with total entity count, not page size. For a library with 10,000 people, every `GET /api/people` request loads all 10,000 into memory. This is acceptable for current Gumnut library sizes but will need optimization (e.g., server-side sorting support in the Gumnut API) as libraries grow.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.14"
 dependencies = [
     "cryptography>=46.0.0",
     "fastapi[standard]>=0.138.1",
-    "gumnut-sdk>=0.120.0",
+    "gumnut-sdk>=0.131.0",
     "pydantic-settings>=2.10.1",
     "pytest>=8.4.2",
     "python-socketio>=5.13.0",

--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -21,7 +21,6 @@ from routers.immich_models import (
     SearchExploreItem,
     SearchExploreResponseDto,
     AssetResponseDto,
-    AssetOrder,
     AssetTypeEnum,
     AssetVisibility,
     SearchResponseDto,
@@ -355,6 +354,9 @@ async def _list_all_assets(
             state=state,
             limit=GUMNUT_API_MAX_PAGE_SIZE,
             include=ASSET_INCLUDE,
+            # The deployed SDK predates the typed `order` parameter. Forward it
+            # through Stainless's escape hatch until the post-deploy regen lands.
+            extra_query={"order": request.order.value},
         )
     ]
 
@@ -373,12 +375,6 @@ async def _list_all_assets(
             if asset.trashed_at is None or asset.trashed_at >= request.trashedAfter
         ]
 
-    # The Gumnut API lists in descending order (capture time for live/all, trash
-    # time for trashed); honor an explicit ascending request by reversing it
-    # (immich-go sends order="asc"). Mirrors the timeline endpoint.
-    if request.order == AssetOrder.asc:
-        all_assets.reverse()
-
     total = len(all_assets)
     # Clamp at the Gumnut API per-page ceiling. The Immich client default is
     # 1000; the adapter pages the client through the library at 200 per page.
@@ -393,7 +389,7 @@ async def _list_all_assets(
     # DTOs are built for at most `size` assets even when the library is large.
     # The listing itself is still fully loaded — offset paging over the Gumnut
     # API's cursor listing needs the full ordered set for `total` and slicing
-    # (native offset/order support is tracked as a follow-up).
+    # (native offset/total support is tracked as a follow-up).
     page_items = [
         convert_gumnut_asset_to_immich(asset, current_user)
         for asset in all_assets[start : start + size]

--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -354,9 +354,7 @@ async def _list_all_assets(
             state=state,
             limit=GUMNUT_API_MAX_PAGE_SIZE,
             include=ASSET_INCLUDE,
-            # The deployed SDK predates the typed `order` parameter. Forward it
-            # through Stainless's escape hatch until the post-deploy regen lands.
-            extra_query={"order": request.order.value},
+            order=request.order.value,
         )
     ]
 

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -875,10 +875,10 @@ class TestSearchMetadataEnumeration:
         assert timeline.assets.count == 3
 
     @pytest.mark.anyio
-    async def test_order_asc_reverses_newest_first_listing(
+    async def test_order_is_forwarded_to_gumnut_listing(
         self, mock_sync_cursor_page, mock_current_user
     ):
-        """assets.list is newest-first; order=asc must reverse to oldest-first."""
+        """The Gumnut API owns ordering; the adapter must not reorder results."""
         now = datetime(2024, 6, 1, tzinfo=timezone.utc)
         assets = [_make_search_asset(now) for _ in range(3)]
         expected_desc = [safe_uuid_from_asset_id(a.id) for a in assets]
@@ -892,13 +892,19 @@ class TestSearchMetadataEnumeration:
             current_user=mock_current_user,
         )
         assert [item.id for item in desc.assets.items] == expected_desc
+        assert mock_client.assets.list.call_args.kwargs["extra_query"] == {
+            "order": "desc"
+        }
 
         asc = await search_assets(
             request=MetadataSearchDto(order=AssetOrder.asc),
             client=mock_client,
             current_user=mock_current_user,
         )
-        assert [item.id for item in asc.assets.items] == list(reversed(expected_desc))
+        assert [item.id for item in asc.assets.items] == expected_desc
+        assert mock_client.assets.list.call_args.kwargs["extra_query"] == {
+            "order": "asc"
+        }
 
     @pytest.mark.anyio
     async def test_real_criterion_still_uses_search(self, mock_current_user):

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -892,9 +892,7 @@ class TestSearchMetadataEnumeration:
             current_user=mock_current_user,
         )
         assert [item.id for item in desc.assets.items] == expected_desc
-        assert mock_client.assets.list.call_args.kwargs["extra_query"] == {
-            "order": "desc"
-        }
+        assert mock_client.assets.list.call_args.kwargs["order"] == "desc"
 
         asc = await search_assets(
             request=MetadataSearchDto(order=AssetOrder.asc),
@@ -902,9 +900,7 @@ class TestSearchMetadataEnumeration:
             current_user=mock_current_user,
         )
         assert [item.id for item in asc.assets.items] == expected_desc
-        assert mock_client.assets.list.call_args.kwargs["extra_query"] == {
-            "order": "asc"
-        }
+        assert mock_client.assets.list.call_args.kwargs["order"] == "asc"
 
     @pytest.mark.anyio
     async def test_real_criterion_still_uses_search(self, mock_current_user):

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-07-08T23:33:10.191818Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -302,7 +302,7 @@ wheels = [
 
 [[package]]
 name = "gumnut-sdk"
-version = "0.120.0"
+version = "0.131.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -312,9 +312,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/97/c20c2bfb95764c49daff34e53129f0aabaa1e319e3d6f9413b484a4c7c32/gumnut_sdk-0.120.0.tar.gz", hash = "sha256:b86adfc3350ab616c87745619b86f20d19a0ccf074bef3312c6227f60182d19e", size = 308015, upload-time = "2026-07-02T17:28:46.816Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/37/04ca3dfc8d46dc739d1c2b66362100c72054df9779254303008e8832f041/gumnut_sdk-0.131.0.tar.gz", hash = "sha256:f0c1f8eaa280f2fc7dc4ed10998e14d4822b11f10a9408b82430c7fc9edbd1a1", size = 316507, upload-time = "2026-07-22T23:32:22.439Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/f3/72611b75f807fc4d640d2d95c39d47d2d14c13179c7016e1e807be18e1b2/gumnut_sdk-0.120.0-py3-none-any.whl", hash = "sha256:054e866ed2e87d2e75777baa3c2760abd06d125df69c719e4e132044b5ca4b27", size = 186990, upload-time = "2026-07-02T17:28:47.865Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/17/1575c9888f2b39ba0582d3159ab9c182d660ab6a563b147aad3e55abac28/gumnut_sdk-0.131.0-py3-none-any.whl", hash = "sha256:379e72b4baf9a7981418803d88054279cbd58ea82e8b017aa653f5d658747964", size = 199754, upload-time = "2026-07-22T23:32:23.734Z" },
 ]
 
 [[package]]
@@ -414,7 +414,7 @@ dev = [
 requires-dist = [
     { name = "cryptography", specifier = ">=46.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.138.1" },
-    { name = "gumnut-sdk", specifier = ">=0.120.0" },
+    { name = "gumnut-sdk", specifier = ">=0.131.0" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "python-socketio", specifier = ">=5.13.0" },


### PR DESCRIPTION
## What
- Forward criterion-less metadata enumeration order to the Gumnut API
- Remove adapter-side in-memory reversal
- Use the typed `order` parameter from `gumnut-sdk` 0.131.0
- Update ordering tests and architecture documentation

## Why
- Immich clients request ascending enumeration during full-library sweeps, and the API can now provide that order directly
- Keeping ordering in the API avoids redundant adapter-side work and preserves cursor order across upstream pages
- Deployment note: the Gumnut API order-query support must be deployed before this adapter change

## Test plan
- [x] `uv run pytest` (1,217 passed)
- [x] `uv run ruff format --check`
- [x] `uv run ruff check`
- [x] `uv run pyright`

Generated by an AI coding agent.
