### PR TITLE
Avoid exact totals in asset enumeration

### DIFF
--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -169,11 +169,8 @@ Mobile reads only the `people` array. A third-party client assuming upstream's `
 | `GET /api/albums` | `client.albums.list(limit=GUMNUT_API_MAX_PAGE_SIZE)` | Convert all to list, no pagination exposed |
 | `GET /api/albums/statistics` | `client.albums.list(limit=GUMNUT_API_MAX_PAGE_SIZE)` | Count total albums from the full set |
 | `GET /api/assets/statistics` | `client.assets.list(limit=GUMNUT_API_MAX_PAGE_SIZE)` | Count total/images/videos from full set |
-| `POST /api/search/metadata` (criterion-less) | `client.assets.list(state=…, limit=GUMNUT_API_MAX_PAGE_SIZE)` + requested `order` query | Full-library enumeration (immich-go's asset sweep): load in the requested native order → apply any `trashedAfter` lower bound → slice `page`/`size` → real `total` + `nextPage`. A request carrying a real criterion instead uses `client.search.search` (which mandates one). |
 
 **Performance implications:** Memory usage scales with total entity count, not page size. For a library with 10,000 people, every `GET /api/people` request loads all 10,000 into memory. This is acceptable for current Gumnut library sizes but will need optimization (e.g., server-side sorting support in the Gumnut API) as libraries grow.
-
-The criterion-less `POST /api/search/metadata` enumeration is a heavier case of this pattern: unlike the fetch-once endpoints above (each loaded once per client action), a client *pages through* it. immich-go requests `size:1000` (clamped to 200) and follows `nextPage` to the end, so the full library is re-loaded and re-converted on every page — cost scales with `library_size × page_count` for one bulk sweep. It's bounded and one-time (a library import), and the Gumnut API's cursor-only listing offers no stateless offset to page against, so load-all is the pragmatic choice today; cursor-based paging or a short-lived per-sweep cache is the optimization path if bulk-import cost against the Gumnut API becomes a concern.
 
 ### Pattern 2: Server-side cursor pagination
 
@@ -189,10 +186,26 @@ Both support optional time-bound filters (e.g., `local_datetime_before`, `create
 2. Check `response.has_more` for next page
 3. Advance the cursor (last entity ID or returned cursor token) for subsequent pages
 
+**Criterion-less `POST /api/search/metadata`.** immich-go exposes numeric page
+requests while the Gumnut API exposes asset cursors. The adapter bridges them
+without an exact count: it walks the cursor listing from the beginning until the
+requested page, collects that page plus one matching lookahead asset, and stops.
+The lookahead determines numeric-string `nextPage`; `count` and deprecated
+`total` both contain the returned page length, matching Immich's current search
+response. A real `trashedAfter` lower bound is applied before page positions are
+counted.
+
+This translation is stateless, with memory bounded to one SDK page plus the
+requested page. Page N still walks through the preceding N - 1 pages because a
+numeric page cannot encode the Gumnut cursor, but it no longer exhausts the
+remaining library just to compute an exact total. A request carrying a real
+search criterion continues to use `client.search.search`, which mandates one.
+
 **Endpoints using this pattern:**
 
 | Endpoint | SDK call | Cursor + filters |
 |----------|----------|-----------------|
+| `POST /api/search/metadata` (criterion-less) | `client.assets.list(state=…, order=…)` | Rewalk to numeric page, apply `trashedAfter`, collect one lookahead asset |
 | `GET /api/timeline/buckets` | `client.assets.counts(group_by="month")` | `starting_after_id` cursor, `local_datetime_before` filter, paginate until `has_more=false` |
 | Sync stream (internal) | `client.events.get(...)` | `after_cursor` opaque cursor, `created_at_lt` time bound |
 

--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -251,7 +251,7 @@ async def search_asset_statistics(
 # Fields on MetadataSearchDto that a plain asset listing can honor (or that
 # don't restrict the result set), so their presence does NOT disqualify a
 # request from the criterion-less enumeration path: pagination, response-shape
-# hints, sort order, and the visibility/trash selectors `_list_all_assets`
+# hints, sort order, and the visibility/trash selectors `_list_asset_page`
 # translates. Every *other* field is a restricting filter. Framing this as an
 # allow-list (rather than enumerating the restricting fields) fails safe:
 # MetadataSearchDto is generated from Immich's OpenAPI spec and regenerated on
@@ -274,7 +274,7 @@ _ENUMERATION_HONORABLE_FIELDS = frozenset(
 
 
 def _is_criterion_less_enumeration(request: MetadataSearchDto) -> bool:
-    """True when a metadata search is a filter-less full-library enumeration.
+    """True when a metadata search is a filter-less asset-listing walk.
 
     immich-go lists every server asset with a criterion-less
     `POST /api/search/metadata` — its body carries only pagination plus
@@ -283,7 +283,7 @@ def _is_criterion_less_enumeration(request: MetadataSearchDto) -> bool:
     request, but the Gumnut API's `search.search` mandates a criterion and 400s
     on an empty one, aborting immich-go before it uploads anything. So route a
     criterion-less enumeration to a plain asset listing instead
-    (`_list_all_assets`).
+    (`_list_asset_page`).
 
     A request is criterion-less only when every populated field is
     enumeration-honorable (see `_ENUMERATION_HONORABLE_FIELDS`). Any restricting
@@ -308,17 +308,16 @@ def _is_criterion_less_enumeration(request: MetadataSearchDto) -> bool:
     return True
 
 
-async def _list_all_assets(
+async def _list_asset_page(
     request: MetadataSearchDto,
     client: AsyncGumnut,
     current_user: UserResponseDto,
 ) -> SearchResponseDto:
-    """Serve a criterion-less metadata search as a plain, paginated asset listing.
+    """Serve one numeric Immich page from the cursor-paginated asset listing.
 
-    Follows the adapter's load-all + client-side pagination pattern (as in
-    `/api/assets/statistics`): the Gumnut API's asset listing is cursor-based
-    with no total, while Immich clients page by offset and read `total` /
-    `nextPage`, so the full set is loaded once and sliced here.
+    Immich no longer requires an exact search total. Walk only far enough to
+    reach the requested page plus one matching lookahead asset, which determines
+    whether another numeric page exists.
     """
     # Every Gumnut asset converts to `timeline` visibility (hardcoded in
     # `convert_gumnut_asset_to_immich`), so a non-timeline query matches nothing.
@@ -336,11 +335,9 @@ async def _list_all_assets(
             ),
         )
 
-    # `withDeleted` widens to live+trashed; immich-go's trashed pass instead
-    # sends `trashedAfter` (a min date meaning "all trashed ever"). The Gumnut
-    # API has no trash-date filter, so `trashedAfter`'s value isn't honored —
-    # its presence just selects the trashed set, which is exactly immich-go's
-    # all-trashed intent.
+    # `withDeleted` widens to live+trashed. A `trashedAfter` request selects the
+    # trashed listing; because the Gumnut API has no trash-date filter, the loop
+    # below applies its timestamp bound before counting page positions.
     if request.withDeleted:
         state = "all"
     elif request.trashedAfter is not None:
@@ -348,32 +345,6 @@ async def _list_all_assets(
     else:
         state = "live"
 
-    all_assets = [
-        asset
-        async for asset in client.assets.list(
-            state=state,
-            limit=GUMNUT_API_MAX_PAGE_SIZE,
-            include=ASSET_INCLUDE,
-            order=request.order.value,
-        )
-    ]
-
-    # Honor a `trashedAfter` lower bound. The Gumnut API can't filter the trashed
-    # set by trash time, so drop assets trashed before the requested instant
-    # here. immich-go sends the min sentinel ("all trashed ever"), for which this
-    # keeps everything; a real bound (e.g. "deleted since last week") is honored
-    # rather than silently widened to the whole trash. Live assets (`trashed_at`
-    # is None) are always kept — the bound only restricts trashed ones — so this
-    # is correct for both `state="trashed"` and the `withDeleted` `state="all"`
-    # case (live + trash), which can also carry `trashedAfter`.
-    if request.trashedAfter is not None:
-        all_assets = [
-            asset
-            for asset in all_assets
-            if asset.trashed_at is None or asset.trashed_at >= request.trashedAfter
-        ]
-
-    total = len(all_assets)
     # Clamp at the Gumnut API per-page ceiling. The Immich client default is
     # 1000; the adapter pages the client through the library at 200 per page.
     size = (
@@ -383,20 +354,41 @@ async def _list_all_assets(
     )
     page = int(request.page) if request.page is not None else 1
     start = (page - 1) * size
-    # Convert only the requested page, not the whole library, so the heavy Immich
-    # DTOs are built for at most `size` assets even when the library is large.
-    # The listing itself is still fully loaded — offset paging over the Gumnut
-    # API's cursor listing needs the full ordered set for `total` and slicing
-    # (native offset/total support is tracked as a follow-up).
+
+    page_assets: list[AssetResponse] = []
+    matching_index = 0
+    async for asset in client.assets.list(
+        state=state,
+        limit=GUMNUT_API_MAX_PAGE_SIZE,
+        include=ASSET_INCLUDE,
+        order=request.order.value,
+    ):
+        # The Gumnut API cannot express a trash-time lower bound. Apply it before
+        # counting positions so numeric pages contain only matching assets. Live
+        # assets remain eligible when `withDeleted` selects live + trash.
+        if (
+            request.trashedAfter is not None
+            and asset.trashed_at is not None
+            and asset.trashed_at < request.trashedAfter
+        ):
+            continue
+
+        if matching_index >= start:
+            page_assets.append(asset)
+            if len(page_assets) > size:
+                break
+        matching_index += 1
+
+    has_more = len(page_assets) > size
+    page_assets = page_assets[:size]
     page_items = [
-        convert_gumnut_asset_to_immich(asset, current_user)
-        for asset in all_assets[start : start + size]
+        convert_gumnut_asset_to_immich(asset, current_user) for asset in page_assets
     ]
 
     # `nextPage` is a JSON string (immich-go decodes it as `nextPage,string`);
     # `None` — never "" — on the last page keeps the mobile client's
     # `nextPage?.toInt()` from throwing (see `test_response_next_page_is_none`).
-    next_page = str(page + 1) if start + size < total else None
+    next_page = str(page + 1) if has_more else None
 
     return SearchResponseDto(
         albums=SearchAlbumResponseDto(count=0, facets=[], items=[], total=0),
@@ -405,7 +397,7 @@ async def _list_all_assets(
             facets=[],
             items=page_items,
             nextPage=next_page,
-            total=total,
+            total=len(page_items),
         ),
     )
 
@@ -418,7 +410,7 @@ async def search_assets(
 ) -> SearchResponseDto:
     """Search for assets by metadata filters."""
     if _is_criterion_less_enumeration(request):
-        return await _list_all_assets(request, client, current_user)
+        return await _list_asset_page(request, client, current_user)
 
     person_ids = None
     if request.personIds:

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -622,9 +622,7 @@ class TestSearchMetadataEnumeration:
     async def test_paginates_with_string_next_page(
         self, mock_sync_cursor_page, mock_current_user
     ):
-        """total counts the full set; nextPage is a string until the last page,
-        then None — the throwaway eval patch returned nextPage=None always and
-        so truncated any library larger than one page."""
+        """Page length supplies deprecated total; nextPage drives traversal."""
         now = datetime(2024, 6, 1, tzinfo=timezone.utc)
         assets = [_make_search_asset(now) for _ in range(5)]
 
@@ -640,23 +638,52 @@ class TestSearchMetadataEnumeration:
 
         page1 = await _search(1)
         assert page1.assets.count == 2
-        assert page1.assets.total == 5
+        assert page1.assets.total == 2
         assert page1.assets.nextPage == "2"
 
         page2 = await _search(2)
         assert page2.assets.count == 2
+        assert page2.assets.total == 2
         assert page2.assets.nextPage == "3"
 
         page3 = await _search(3)
         assert page3.assets.count == 1
+        assert page3.assets.total == 1
         assert page3.assets.nextPage is None
+
+    @pytest.mark.anyio
+    async def test_stops_after_requested_page_lookahead(self, mock_current_user):
+        """Cursor iteration stops after one asset beyond the requested page."""
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        assets = [_make_search_asset(now) for _ in range(10)]
+        consumed: list[str] = []
+
+        async def asset_stream():
+            for asset in assets:
+                consumed.append(asset.id)
+                yield asset
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(return_value=asset_stream())
+
+        result = await search_assets(
+            request=MetadataSearchDto(size=2, page=2),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert consumed == [asset.id for asset in assets[:5]]
+        assert [item.id for item in result.assets.items] == [
+            safe_uuid_from_asset_id(asset.id) for asset in assets[2:4]
+        ]
+        assert result.assets.total == 2
+        assert result.assets.nextPage == "3"
 
     @pytest.mark.anyio
     async def test_exact_full_final_page_has_no_next_page(
         self, mock_sync_cursor_page, mock_current_user
     ):
-        """When total is an exact multiple of size, the last full page ends the
-        walk — nextPage is None (the `start + size < total` boundary, not `<=`)."""
+        """A full final page has no nextPage when no lookahead asset exists."""
         now = datetime(2024, 6, 1, tzinfo=timezone.utc)
         assets = [_make_search_asset(now) for _ in range(4)]
 
@@ -670,7 +697,7 @@ class TestSearchMetadataEnumeration:
         )
 
         assert result.assets.count == 2
-        assert result.assets.total == 4
+        assert result.assets.total == 2
         assert result.assets.nextPage is None
 
     @pytest.mark.anyio
@@ -692,7 +719,7 @@ class TestSearchMetadataEnumeration:
         )
 
         assert result.assets.count == 0
-        assert result.assets.total == 3
+        assert result.assets.total == 0
         assert result.assets.nextPage is None
 
     @pytest.mark.anyio
@@ -731,7 +758,7 @@ class TestSearchMetadataEnumeration:
         )
 
         assert result.assets.count == 200
-        assert result.assets.total == 201
+        assert result.assets.total == 200
         assert result.assets.nextPage == "2"
 
     @pytest.mark.anyio
@@ -788,6 +815,44 @@ class TestSearchMetadataEnumeration:
         assert result.assets.count == 1
         assert result.assets.total == 1
         assert result.assets.items[0].id == safe_uuid_from_asset_id(recent.id)
+
+    @pytest.mark.anyio
+    async def test_trashed_after_filters_before_page_positions(
+        self, mock_sync_cursor_page, mock_current_user
+    ):
+        """Filtered-out trash does not consume a numeric page position."""
+        now = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        old_1 = _make_search_asset(now)
+        old_1.trashed_at = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        recent_1 = _make_search_asset(now)
+        recent_1.trashed_at = datetime(2024, 6, 20, tzinfo=timezone.utc)
+        old_2 = _make_search_asset(now)
+        old_2.trashed_at = datetime(2024, 6, 2, tzinfo=timezone.utc)
+        recent_2 = _make_search_asset(now)
+        recent_2.trashed_at = datetime(2024, 6, 21, tzinfo=timezone.utc)
+        recent_3 = _make_search_asset(now)
+        recent_3.trashed_at = datetime(2024, 6, 22, tzinfo=timezone.utc)
+
+        mock_client = Mock()
+        mock_client.assets.list = Mock(
+            return_value=mock_sync_cursor_page(
+                [old_1, recent_1, old_2, recent_2, recent_3]
+            )
+        )
+
+        result = await search_assets(
+            request=MetadataSearchDto(
+                size=1,
+                page=2,
+                trashedAfter=datetime(2024, 6, 10, tzinfo=timezone.utc),
+            ),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert result.assets.total == 1
+        assert result.assets.items[0].id == safe_uuid_from_asset_id(recent_2.id)
+        assert result.assets.nextPage == "3"
 
     @pytest.mark.anyio
     async def test_with_deleted_reads_all_state(


### PR DESCRIPTION
## What

- Stop criterion-less metadata listing after the requested numeric page plus one matching lookahead asset.
- Derive `nextPage` from the lookahead and return the page length for both `count` and deprecated `total`.
- Preserve state, ordering, visibility, and `trashedAfter` behavior while documenting the bounded cursor translation.

## Why

- Current Immich search responses use the current page length for `total`, and clients traverse with `nextPage`.
- Computing an exact total forced every numeric page request to exhaust and materialize the remaining asset listing unnecessarily.

## Test plan

- `uv run pytest` (1,219 passed)
- `uv run ruff format --check`
- `uv run ruff check`
- `uv run pyright`

Generated by an AI coding agent.
