### PR TITLE
Preserve initial assets when creating albums

### DIFF
--- a/docs/guides/importing-with-immich-go.md
+++ b/docs/guides/importing-with-immich-go.md
@@ -1,6 +1,6 @@
 ---
 title: "Importing with immich-go"
-last-updated: 2026-07-22
+last-updated: 2026-07-23
 ---
 
 # Importing with immich-go
@@ -59,8 +59,9 @@ For a `upload from-folder` run, immich-go:
    `/api/assets/bulk-upload-check`.
 3. Uploads each new asset with `POST /api/assets` (multipart `assetData`), sending
    an `x-immich-checksum` header so the server can reject an already-stored file.
-4. Optionally creates albums (`POST /api/albums`) and adds assets to them
-   (`PUT /api/albums/{id}/assets`).
+4. Optionally creates albums with their initial asset membership
+   (`POST /api/albums` with `assetIds`). Other album updates can add assets
+   through `PUT /api/albums/{id}/assets`.
 
 ## Troubleshooting
 

--- a/routers/api/albums.py
+++ b/routers/api/albums.py
@@ -1,9 +1,10 @@
 import logging
+from itertools import batched
 from typing import Annotated, List
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
-from gumnut import AsyncGumnut
+from gumnut import AsyncGumnut, GumnutError
 
 from routers.utils.bulk import (
     BulkChunkError,
@@ -166,17 +167,99 @@ async def create_album(
     current_user: UserResponseDto = Depends(get_current_user),
 ) -> AlbumResponseDto:
     """
-    Create a new album using the Gumnut SDK.
-    Note: albumUsers and assetIds are not supported by the Gumnut SDK.
+    Create a new album and associate any initial assets.
+
+    Album creation and asset association are separate Gumnut API operations.
+    If any association fails, delete the just-created album before surfacing
+    the error so Immich clients never receive a successful partial create.
+    albumUsers remain unsupported.
     """
 
     gumnut_album = await client.albums.create(
         name=request.albumName or "",
         description=request.description,
-        # Note: albumUsers and assetIds are not supported in this adapter
     )
 
-    return convert_gumnut_album_to_immich(gumnut_album, current_user, asset_count=0)
+    asset_count = await _add_initial_assets_to_album(
+        client,
+        gumnut_album.id,
+        request.assetIds or [],
+    )
+
+    return convert_gumnut_album_to_immich(
+        gumnut_album,
+        current_user,
+        asset_count=asset_count,
+    )
+
+
+async def _add_initial_assets_to_album(
+    client: AsyncGumnut,
+    gumnut_album_id: str,
+    asset_uuids: list[UUID],
+) -> int:
+    """Associate initial assets and return the resulting unique membership count."""
+    associated_asset_ids: set[str] = set()
+
+    for asset_uuid_chunk in batched(asset_uuids, GUMNUT_API_MAX_BULK_IDS):
+        gumnut_asset_ids = [
+            uuid_to_gumnut_asset_id(asset_uuid) for asset_uuid in asset_uuid_chunk
+        ]
+        requested_asset_ids = set(gumnut_asset_ids)
+
+        try:
+            response = await client.albums.assets_associations.add(
+                gumnut_album_id,
+                asset_ids=gumnut_asset_ids,
+            )
+        except GumnutError:
+            await _rollback_created_album(client, gumnut_album_id)
+            raise
+
+        added_asset_ids = set(response.added_assets)
+        duplicate_asset_ids = set(response.duplicate_assets)
+        not_found_asset_ids = set(response.not_found_assets)
+
+        if not_found_asset_ids:
+            await _rollback_created_album(client, gumnut_album_id)
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="One or more initial album assets were not found or are not accessible",
+            )
+
+        reported_asset_ids = added_asset_ids | duplicate_asset_ids
+        if reported_asset_ids != requested_asset_ids:
+            logger.error(
+                "Initial album asset association response did not account for every asset",
+                extra={
+                    "album_id": gumnut_album_id,
+                    "requested_count": len(requested_asset_ids),
+                    "reported_count": len(reported_asset_ids),
+                },
+            )
+            await _rollback_created_album(client, gumnut_album_id)
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Upstream did not report membership for every initial album asset",
+            )
+
+        associated_asset_ids.update(requested_asset_ids)
+
+    return len(associated_asset_ids)
+
+
+async def _rollback_created_album(
+    client: AsyncGumnut,
+    gumnut_album_id: str,
+) -> None:
+    """Best-effort cleanup for an album whose initial membership failed."""
+    try:
+        await client.albums.delete(gumnut_album_id)
+    except GumnutError:
+        logger.exception(
+            "Failed to roll back album after initial asset association failure",
+            extra={"album_id": gumnut_album_id},
+        )
 
 
 @router.put("/{id}/assets")

--- a/routers/api/albums.py
+++ b/routers/api/albums.py
@@ -170,8 +170,9 @@ async def create_album(
     Create a new album and associate any initial assets.
 
     Album creation and asset association are separate Gumnut API operations.
-    If any association fails, delete the just-created album before surfacing
-    the error so Immich clients never receive a successful partial create.
+    If any association fails, attempt a best-effort delete of the just-created
+    album before surfacing the error so Immich clients never receive a
+    successful partial create.
     albumUsers remain unsupported.
     """
 

--- a/tests/unit/api/test_albums.py
+++ b/tests/unit/api/test_albums.py
@@ -490,13 +490,14 @@ class TestCreateAlbum:
 
     @pytest.mark.anyio
     async def test_create_album_success(self, sample_gumnut_album, mock_current_user):
-        """Test successful album creation."""
+        """An empty initial asset list creates an empty album."""
         # Setup - create mock client
         mock_client = Mock()
         # Update the sample to have the name we want to test
         sample_gumnut_album.name = "New Album"
         sample_gumnut_album.description = "New Description"
         mock_client.albums.create = AsyncMock(return_value=sample_gumnut_album)
+        mock_client.albums.assets_associations.add = AsyncMock()
 
         request = CreateAlbumDto(albumName="New Album", description="New Description")
 
@@ -509,13 +510,96 @@ class TestCreateAlbum:
         # Now result is a real AlbumResponseDto, so use attribute access
         assert hasattr(result, "albumName")
         assert result.albumName == "New Album"
+        assert result.assetCount == 0
         mock_client.albums.create.assert_called_once_with(
             name="New Album", description="New Description"
         )
+        mock_client.albums.assets_associations.add.assert_not_awaited()
 
     @pytest.mark.anyio
-    async def test_create_album_propagates_sdk_error(self, mock_current_user):
-        """SDK errors bubble up; the global GumnutError handler maps them."""
+    async def test_create_album_with_single_asset(
+        self, sample_gumnut_album, mock_current_user
+    ):
+        """A supplied asset is associated and reflected in the create response."""
+        asset_uuid = uuid4()
+        gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
+        mock_client = Mock()
+        mock_client.albums.create = AsyncMock(return_value=sample_gumnut_album)
+        mock_client.albums.assets_associations.add = AsyncMock(
+            return_value=_add_response(added=[gumnut_asset_id])
+        )
+
+        result = await create_album(
+            CreateAlbumDto(albumName="Single", assetIds=[asset_uuid]),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert result.assetCount == 1
+        mock_client.albums.assets_associations.add.assert_awaited_once_with(
+            sample_gumnut_album.id,
+            asset_ids=[gumnut_asset_id],
+        )
+
+    @pytest.mark.anyio
+    async def test_create_album_with_multiple_assets(
+        self, sample_gumnut_album, mock_current_user
+    ):
+        """Multiple initial assets are associated and counted."""
+        asset_uuids = [uuid4(), uuid4()]
+        gumnut_asset_ids = [
+            uuid_to_gumnut_asset_id(asset_uuid) for asset_uuid in asset_uuids
+        ]
+        mock_client = Mock()
+        mock_client.albums.create = AsyncMock(return_value=sample_gumnut_album)
+        mock_client.albums.assets_associations.add = AsyncMock(
+            return_value=_add_response(added=gumnut_asset_ids)
+        )
+
+        result = await create_album(
+            CreateAlbumDto(albumName="Multiple", assetIds=asset_uuids),
+            client=mock_client,
+            current_user=mock_current_user,
+        )
+
+        assert result.assetCount == 2
+        mock_client.albums.assets_associations.add.assert_awaited_once_with(
+            sample_gumnut_album.id,
+            asset_ids=gumnut_asset_ids,
+        )
+
+    @pytest.mark.anyio
+    async def test_create_album_rolls_back_partial_asset_failure(
+        self, sample_gumnut_album, mock_current_user
+    ):
+        """A response-reported missing asset fails and removes the partial album."""
+        added_uuid = uuid4()
+        missing_uuid = uuid4()
+        added_id = uuid_to_gumnut_asset_id(added_uuid)
+        missing_id = uuid_to_gumnut_asset_id(missing_uuid)
+        mock_client = Mock()
+        mock_client.albums.create = AsyncMock(return_value=sample_gumnut_album)
+        mock_client.albums.assets_associations.add = AsyncMock(
+            return_value=_add_response(added=[added_id], not_found=[missing_id])
+        )
+        mock_client.albums.delete = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await create_album(
+                CreateAlbumDto(
+                    albumName="Partial",
+                    assetIds=[added_uuid, missing_uuid],
+                ),
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+        assert exc_info.value.status_code == 404
+        mock_client.albums.delete.assert_awaited_once_with(sample_gumnut_album.id)
+
+    @pytest.mark.anyio
+    async def test_create_album_propagates_creation_sdk_error(self, mock_current_user):
+        """Album creation SDK errors bubble to the global handler."""
         from gumnut import APIStatusError
 
         mock_client = Mock()
@@ -523,12 +607,39 @@ class TestCreateAlbum:
             side_effect=make_sdk_status_error(500, "boom")
         )
 
-        request = CreateAlbumDto(albumName="Test Album")
+        with pytest.raises(APIStatusError):
+            await create_album(
+                CreateAlbumDto(albumName="Test Album"),
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+    @pytest.mark.anyio
+    async def test_create_album_rolls_back_association_sdk_error(
+        self, mock_current_user
+    ):
+        """Association SDK errors roll back and bubble to the global handler."""
+        from gumnut import APIStatusError
+
+        mock_client = Mock()
+        sample_album = Mock(
+            id=uuid_to_gumnut_album_id(uuid4()),
+            name="Test Album",
+            description=None,
+        )
+        mock_client.albums.create = AsyncMock(return_value=sample_album)
+        mock_client.albums.assets_associations.add = AsyncMock(
+            side_effect=make_sdk_status_error(500, "boom")
+        )
+        mock_client.albums.delete = AsyncMock()
+
+        request = CreateAlbumDto(albumName="Test Album", assetIds=[uuid4()])
 
         with pytest.raises(APIStatusError):
             await create_album(
                 request, client=mock_client, current_user=mock_current_user
             )
+        mock_client.albums.delete.assert_awaited_once_with(sample_album.id)
 
 
 class TestAddAssetsToAlbum:

--- a/tests/unit/api/test_albums.py
+++ b/tests/unit/api/test_albums.py
@@ -6,8 +6,8 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi import HTTPException
-from unittest.mock import AsyncMock, Mock
-from gumnut import NotFoundError
+from unittest.mock import AsyncMock, Mock, call
+from gumnut import APIStatusError, NotFoundError
 from gumnut.types.albums import AssetsAssociationAddResponse
 from uuid import uuid4
 
@@ -545,15 +545,18 @@ class TestCreateAlbum:
     async def test_create_album_with_multiple_assets(
         self, sample_gumnut_album, mock_current_user
     ):
-        """Multiple initial assets are associated and counted."""
-        asset_uuids = [uuid4(), uuid4()]
+        """Initial assets are chunked at the upstream limit and all counted."""
+        asset_uuids = [uuid4() for _ in range(GUMNUT_API_MAX_BULK_IDS + 1)]
         gumnut_asset_ids = [
             uuid_to_gumnut_asset_id(asset_uuid) for asset_uuid in asset_uuids
         ]
         mock_client = Mock()
         mock_client.albums.create = AsyncMock(return_value=sample_gumnut_album)
         mock_client.albums.assets_associations.add = AsyncMock(
-            return_value=_add_response(added=gumnut_asset_ids)
+            side_effect=[
+                _add_response(added=gumnut_asset_ids[:GUMNUT_API_MAX_BULK_IDS]),
+                _add_response(added=gumnut_asset_ids[GUMNUT_API_MAX_BULK_IDS:]),
+            ]
         )
 
         result = await create_album(
@@ -562,25 +565,58 @@ class TestCreateAlbum:
             current_user=mock_current_user,
         )
 
-        assert result.assetCount == 2
-        mock_client.albums.assets_associations.add.assert_awaited_once_with(
-            sample_gumnut_album.id,
-            asset_ids=gumnut_asset_ids,
+        assert result.assetCount == len(asset_uuids)
+        assert mock_client.albums.assets_associations.add.await_args_list == [
+            call(
+                sample_gumnut_album.id,
+                asset_ids=gumnut_asset_ids[:GUMNUT_API_MAX_BULK_IDS],
+            ),
+            call(
+                sample_gumnut_album.id,
+                asset_ids=gumnut_asset_ids[GUMNUT_API_MAX_BULK_IDS:],
+            ),
+        ]
+
+    @pytest.mark.anyio
+    async def test_create_album_rolls_back_incomplete_asset_response(
+        self, sample_gumnut_album, mock_current_user
+    ):
+        """An unaccounted-for asset fails with 502 and removes the partial album."""
+        asset_uuids = [uuid4(), uuid4()]
+        reported_id = uuid_to_gumnut_asset_id(asset_uuids[0])
+        mock_client = Mock()
+        mock_client.albums.create = AsyncMock(return_value=sample_gumnut_album)
+        mock_client.albums.assets_associations.add = AsyncMock(
+            return_value=_add_response(added=[reported_id])
         )
+        mock_client.albums.delete = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await create_album(
+                CreateAlbumDto(albumName="Incomplete", assetIds=asset_uuids),
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+        assert exc_info.value.status_code == 502
+        mock_client.albums.delete.assert_awaited_once_with(sample_gumnut_album.id)
 
     @pytest.mark.anyio
     async def test_create_album_rolls_back_partial_asset_failure(
         self, sample_gumnut_album, mock_current_user
     ):
-        """A response-reported missing asset fails and removes the partial album."""
-        added_uuid = uuid4()
-        missing_uuid = uuid4()
-        added_id = uuid_to_gumnut_asset_id(added_uuid)
-        missing_id = uuid_to_gumnut_asset_id(missing_uuid)
+        """A later-chunk missing asset fails and removes the partial album."""
+        asset_uuids = [uuid4() for _ in range(GUMNUT_API_MAX_BULK_IDS + 1)]
+        gumnut_asset_ids = [
+            uuid_to_gumnut_asset_id(asset_uuid) for asset_uuid in asset_uuids
+        ]
         mock_client = Mock()
         mock_client.albums.create = AsyncMock(return_value=sample_gumnut_album)
         mock_client.albums.assets_associations.add = AsyncMock(
-            return_value=_add_response(added=[added_id], not_found=[missing_id])
+            side_effect=[
+                _add_response(added=gumnut_asset_ids[:GUMNUT_API_MAX_BULK_IDS]),
+                _add_response(not_found=gumnut_asset_ids[GUMNUT_API_MAX_BULK_IDS:]),
+            ]
         )
         mock_client.albums.delete = AsyncMock()
 
@@ -588,8 +624,34 @@ class TestCreateAlbum:
             await create_album(
                 CreateAlbumDto(
                     albumName="Partial",
-                    assetIds=[added_uuid, missing_uuid],
+                    assetIds=asset_uuids,
                 ),
+                client=mock_client,
+                current_user=mock_current_user,
+            )
+
+        assert exc_info.value.status_code == 404
+        mock_client.albums.delete.assert_awaited_once_with(sample_gumnut_album.id)
+
+    @pytest.mark.anyio
+    async def test_create_album_preserves_error_when_rollback_fails(
+        self, sample_gumnut_album, mock_current_user
+    ):
+        """A cleanup failure does not mask the original association error."""
+        missing_uuid = uuid4()
+        missing_id = uuid_to_gumnut_asset_id(missing_uuid)
+        mock_client = Mock()
+        mock_client.albums.create = AsyncMock(return_value=sample_gumnut_album)
+        mock_client.albums.assets_associations.add = AsyncMock(
+            return_value=_add_response(not_found=[missing_id])
+        )
+        mock_client.albums.delete = AsyncMock(
+            side_effect=make_sdk_status_error(500, "cleanup failed")
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await create_album(
+                CreateAlbumDto(albumName="Rollback", assetIds=[missing_uuid]),
                 client=mock_client,
                 current_user=mock_current_user,
             )
@@ -600,8 +662,6 @@ class TestCreateAlbum:
     @pytest.mark.anyio
     async def test_create_album_propagates_creation_sdk_error(self, mock_current_user):
         """Album creation SDK errors bubble to the global handler."""
-        from gumnut import APIStatusError
-
         mock_client = Mock()
         mock_client.albums.create = AsyncMock(
             side_effect=make_sdk_status_error(500, "boom")
@@ -619,8 +679,6 @@ class TestCreateAlbum:
         self, mock_current_user
     ):
         """Association SDK errors roll back and bubble to the global handler."""
-        from gumnut import APIStatusError
-
         mock_client = Mock()
         sample_album = Mock(
             id=uuid_to_gumnut_album_id(uuid4()),
@@ -819,13 +877,13 @@ class TestAddAssetsToAlbum:
         assert (
             mock_client.albums.assets_associations.add.call_count == expected_call_count
         )
-        for idx, call in enumerate(
+        for idx, add_call in enumerate(
             mock_client.albums.assets_associations.add.call_args_list
         ):
             expected_chunk = gumnut_ids[
                 idx * GUMNUT_API_MAX_BULK_IDS : (idx + 1) * GUMNUT_API_MAX_BULK_IDS
             ]
-            assert call.kwargs["asset_ids"] == expected_chunk
+            assert add_call.kwargs["asset_ids"] == expected_chunk
 
     @pytest.mark.anyio
     async def test_add_assets_duplicate_in_later_chunk_surfaces_in_response(
@@ -1169,13 +1227,13 @@ class TestRemoveAssetFromAlbum:
             mock_client.albums.assets_associations.remove.call_count
             == expected_call_count
         )
-        for idx, call in enumerate(
+        for idx, remove_call in enumerate(
             mock_client.albums.assets_associations.remove.call_args_list
         ):
             expected_chunk = gumnut_ids[
                 idx * GUMNUT_API_MAX_BULK_IDS : (idx + 1) * GUMNUT_API_MAX_BULK_IDS
             ]
-            assert call.kwargs["asset_ids"] == expected_chunk
+            assert remove_call.kwargs["asset_ids"] == expected_chunk
 
     @pytest.mark.anyio
     async def test_remove_assets_empty_request(self, sample_uuid):


### PR DESCRIPTION
## What
- Associate `assetIds` supplied during album creation in bounded upstream chunks
- Return the resulting unique membership count and roll back failed partial creates
- Add focused regression coverage and update the immich-go import guide

## Why
- immich-go sends folder-album membership in the create request and treats a successful response as complete, so dropping those IDs creates empty albums while reporting success
- Failed or incomplete association responses must not be exposed as successful partial album creation

## Test plan
- [x] `.venv/bin/pytest` (1,225 passed)
- [x] `.venv/bin/pytest tests/unit/api/test_albums.py -k create_album` (8 passed)
- [x] `.venv/bin/ruff format --check`
- [x] `.venv/bin/ruff check`
- [x] `.venv/bin/pyright routers/api/albums.py tests/unit/api/test_albums.py`
- [ ] After deployment, run an immich-go `--folder-as-album=FOLDER` import and confirm each album contains the expected assets

Generated by an AI coding agent.