### PR TITLE
Emulate Immich tags for immich-go imports via description append

### DIFF
--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Immich Adapter Architecture"
-last-updated: 2026-07-22
+last-updated: 2026-07-23
 ---
 
 # Immich Adapter Architecture
@@ -418,13 +418,14 @@ The adapter implements a subset of Immich's API surface. Unimplemented endpoints
 | WebSockets | Real-time upload/trash/restore/delete notifications | Socket.IO with room-based messaging |
 | Memories (read) | Search, get-by-id, statistics for OnThisDay memories | Synthesized from per-day asset queries; mutations still stubbed |
 | Map (markers) | `GET /map/markers` and album-scoped `GET /albums/{id}/map-markers` return GPS-tagged assets | Server-side geotag filter via `client.assets.list(bbox=...)`; the album route also passes the album filter; capped at 2000 markers, with a degraded-path scan bound if the coordinate filter is unavailable; reverse-geocode still stubbed |
+| Tags (upsert + assign) | `PUT /api/tags` upserts a tag; `PUT /api/tags/{id}/assets` assigns assets to it | Gumnut has no tag model; emulated by appending the tag to each asset's **description**. Upsert mints a deterministic synthetic id and records `id → value` in Redis (`services/tag_store.py`); assign recovers the value and appends it. Unblocks immich-go's tagged import. The client-side tags UI stays disabled (see below) |
 
 ### Stub implementations
 
 | Area | Why stubbed |
 |------|-------------|
 | Libraries | Gumnut has a different library model |
-| Tags | Not yet implemented in Gumnut |
+| Tags (read / CRUD / bulk) | Gumnut has no tag model. `GET /api/tags`, `POST /api/tags`, `GET`/`PUT`/`DELETE /api/tags/{id}`, `DELETE /api/tags/{id}/assets`, and `PUT /api/tags/assets` stay stubs; only the immich-go import path (upsert + assign, see above) is emulated. The tags sidebar is left disabled — `GET /api/tags` returns `[]`, so surfacing the UI would show a permanently empty, non-functional tag list |
 | Map (reverse-geocode) | `/map/reverse-geocode` is unused by shipped Immich clients; not wired up |
 | Memories (write) | Synthetic memories have no persistence layer; create/update/delete and asset add/remove are no-ops |
 | Asset metadata (custom) | Gumnut doesn't support arbitrary key-value metadata |

--- a/docs/design-docs/immich-adapter-gap-analysis.md
+++ b/docs/design-docs/immich-adapter-gap-analysis.md
@@ -2,7 +2,7 @@
 title: "Immich Adapter Gap Analysis"
 status: active
 created: 2026-04-15
-last-updated: 2026-07-22
+last-updated: 2026-07-23
 ---
 
 # Immich Adapter Gap Analysis
@@ -70,15 +70,15 @@ Immich shared links let users create public URLs to share individual assets or a
 
 Immich tags allow hierarchical labeling of assets (e.g., `vacation/2024/beach`). Tags can be bulk-applied to assets.
 
-**Current behavior**: All 9 endpoints return empty lists or fake single-item responses. Tag operations appear to succeed but nothing persists.
+**Current behavior**: **Partially closed (interim workaround).** The immich-go import path is emulated: `PUT /api/tags` upserts a tag (deterministic synthetic id, recorded `id → value` in Redis via `services/tag_store.py`) and `PUT /api/tags/{id}/assets` "assigns" assets by appending the tag to each asset's **description** (idempotently). This unblocks `immich-go upload from-folder --tag <name>`, which previously panicked when the upsert stub returned `[]`. The remaining 7 endpoints (`GET /api/tags`, `POST /api/tags`, `GET`/`PUT`/`DELETE /api/tags/{id}`, `DELETE /api/tags/{id}/assets`, `PUT /api/tags/assets`) are still stubs, so there is no real tag entity — tags don't round-trip as tags, only as description text.
 
-**User impact**: **Medium** — Power users rely on tags for organization. Most casual users rely on albums instead. The Immich web UI shows the tags sidebar, which is always empty.
+**User impact**: **Medium** — Power users rely on tags for organization. Most casual users rely on albums instead. The Immich web tags sidebar stays intentionally disabled (surfacing it would show a permanently empty list, since `GET /api/tags` returns `[]`); the interim workaround serves only bulk importers.
 
-**Dependency**: **Both** — the Gumnut API needs a tagging model (tag CRUD, asset-tag associations). Adapter work is straightforward translation once the backend exists.
+**Dependency**: **Both** — a real tag feature needs the Gumnut API to model tags (tag CRUD, asset-tag associations). The description-append workaround is adapter-only and does not migrate to real tags automatically when the backend lands.
 
 **Effort**: **L** — Backend needs a new entity type (tags), a many-to-many association with assets, CRUD endpoints, and hierarchical tag support. Adapter translation is M on its own.
 
-**Recommendation**: **Revisit later** — Moderate user value. Consider once Gumnut's data model stabilizes.
+**Recommendation**: **Revisit later** — The interim import workaround is in place; a full tag feature waits on Gumnut's data model. When real tags land, replace the description-append emulation and consider a one-time migration of embedded `#`-tags.
 
 ---
 
@@ -740,7 +740,7 @@ adapter code.
 | ~~#3a Map markers~~ | — | — | Closed — server-side geotag filter via `client.assets.list(bbox=...)`; 2000-marker cap |
 | #34 Performance (pagination) | L | Both | Scaling requirement |
 | #8 Memories (write path) | S | Both | Read path shipped; only save/hide persistence remains |
-| #2 Tags | L | Both | Power-user organization |
+| #2 Tags | L | Both | Power-user organization — immich-go import path emulated via description-append; full tag entity still needs the backend |
 
 ### Tier 3: Revisit Later (high effort or blocked)
 

--- a/docs/guides/importing-with-immich-go.md
+++ b/docs/guides/importing-with-immich-go.md
@@ -1,6 +1,6 @@
 ---
 title: "Importing with immich-go"
-last-updated: 2026-07-22
+last-updated: 2026-07-23
 ---
 
 # Importing with immich-go
@@ -61,6 +61,27 @@ For a `upload from-folder` run, immich-go:
    an `x-immich-checksum` header so the server can reject an already-stored file.
 4. Optionally creates albums (`POST /api/albums`) and adds assets to them
    (`PUT /api/albums/{id}/assets`).
+5. If `--tag` is passed, upserts each tag (`PUT /api/tags`, reading the returned
+   tag id) and assigns the uploaded assets to it (`PUT /api/tags/{id}/assets`).
+
+## Tags (`--tag`)
+
+The Gumnut API has no tag concept yet, so the adapter emulates tags to keep a
+tagged import working: `PUT /api/tags` returns a stable synthetic tag id, and
+`PUT /api/tags/{id}/assets` **appends the tag to each asset's description** (as a
+`#<tag>` line) rather than storing a real tag. Re-importing the same tag is
+idempotent — the line isn't duplicated. The tag therefore shows up in the
+asset's description in the web/mobile app, not in the (intentionally disabled)
+tags sidebar. This is an interim workaround; when Gumnut gains real tags the
+embedded `#`-lines won't migrate automatically.
+
+```bash
+immich-go upload from-folder \
+  --server http://localhost:3001 \
+  --api-key apikey_your_key_here \
+  --tag Vacation \
+  /path/to/photos
+```
 
 ## Troubleshooting
 
@@ -70,3 +91,6 @@ For a `upload from-folder` run, immich-go:
 - **"invalid semantic version" at connect time**: `.immich-container-tag` must hold
   a semver value (e.g. `v3.0.3`); immich-go parses `/api/server/about`'s `version`
   and aborts if it can't.
+- **`panic: index out of range [0]` on a `--tag` import**: fixed — the tag upsert
+  now returns a non-empty response. If you still hit it, the adapter is running an
+  old revision where `PUT /api/tags` was a stub returning `[]`.

--- a/routers/api/tags.py
+++ b/routers/api/tags.py
@@ -1,24 +1,64 @@
-from fastapi import APIRouter
-from uuid import UUID, uuid4
-from typing import List
 from datetime import datetime, timezone
+from itertools import batched
+from typing import List, cast
+from uuid import UUID, uuid4
 
+from fastapi import APIRouter, Depends, HTTPException, status
+from gumnut import AsyncGumnut
+from gumnut.types.asset_bulk_update_assets_params import Update, UpdateChange
+
+from routers.api.constants import GUMNUT_API_MAX_BULK_IDS
 from routers.immich_models import (
-    TagBulkAssetsResponseDto,
-    TagResponseDto,
-    TagCreateDto,
-    TagUpdateDto,
-    TagBulkAssetsDto,
-    TagUpsertDto,
-    BulkIdsDto,
+    BulkIdErrorReason,
     BulkIdResponseDto,
+    BulkIdsDto,
+    TagBulkAssetsDto,
+    TagBulkAssetsResponseDto,
+    TagCreateDto,
+    TagResponseDto,
+    TagUpdateDto,
+    TagUpsertDto,
 )
+from routers.utils.asset_conversion import ASSET_INCLUDE_METADATA_ONLY
+from routers.utils.current_user import get_current_user_id
+from routers.utils.gumnut_client import get_authenticated_gumnut_client
+from routers.utils.gumnut_id_conversion import uuid_to_gumnut_asset_id
+from services.tag_store import deterministic_tag_id, lookup_tag_value, remember_tag
 
 router = APIRouter(
     prefix="/api/tags",
     tags=["tags"],
     responses={404: {"description": "Not found"}},
 )
+
+
+# The Gumnut API has no tag concept. immich-go's tagged import (`upload
+# from-folder --tag <name>`) upserts the tag via `PUT /api/tags`, reads the
+# returned tag id, then assigns the imported assets via
+# `PUT /api/tags/{id}/assets`. The adapter emulates tags by appending the tag to
+# each asset's description: upsert mints a deterministic id and records
+# `id -> value` (see services/tag_store.py), and assignment recovers the value
+# and appends it. The remaining tag endpoints stay informational stubs — they
+# are not on immich-go's import path, and the client-side tags UI is
+# deliberately left disabled (see routers/api/users.py preferences and
+# routers/api/server.py server features) because `GET /api/tags` is still a stub.
+
+
+def _append_tag_to_description(description: str | None, tag_value: str) -> str:
+    """Append ``tag_value`` to a description as its own ``#``-prefixed line.
+
+    Idempotent: if the exact tag line is already present the description is
+    returned unchanged, so re-imports don't duplicate the tag. A tag value can
+    contain spaces and ``/`` (hierarchical paths) but never a newline, so
+    line-equality is an exact, collision-free membership test.
+    """
+    tag_line = f"#{tag_value}"
+    existing = description or ""
+    if tag_line in existing.split("\n"):
+        return existing
+    if existing:
+        return f"{existing}\n{tag_line}"
+    return tag_line
 
 
 @router.get("")
@@ -48,12 +88,42 @@ async def create_tag(request: TagCreateDto) -> TagResponseDto:
 
 
 @router.put("")
-async def upsert_tags(request: TagUpsertDto) -> List[TagResponseDto]:
+async def upsert_tags(
+    request: TagUpsertDto,
+    current_user_id: UUID = Depends(get_current_user_id),
+) -> List[TagResponseDto]:
+    """Upsert tags (create or resolve each requested name).
+
+    The Gumnut API has no tags, so the adapter emulates them (see the module
+    comment). Each requested name is mapped to a deterministic synthetic id —
+    idempotent across repeated upserts and identical across workers — and the
+    ``id -> value`` mapping is recorded in Redis so a later
+    ``PUT /api/tags/{id}/assets`` can recover the value and append it to each
+    asset's description.
+
+    Returns one ``TagResponseDto`` per requested name, in the same order:
+    immich-go reads the upserted tag back positionally, and matches on the
+    echoed ``value``, so names are echoed verbatim (``value`` = full path,
+    ``name`` = leaf segment).
     """
-    Upsert tags.
-    This is a stub implementation that returns an empty list.
-    """
-    return []
+    user_id = str(current_user_id)
+    now = datetime.now(tz=timezone.utc)
+    responses: List[TagResponseDto] = []
+    for value in request.tags:
+        tag_id = deterministic_tag_id(user_id, value)
+        await remember_tag(user_id, tag_id, value)
+        responses.append(
+            TagResponseDto(
+                id=tag_id,
+                name=value.rsplit("/", 1)[-1],
+                value=value,
+                color=None,
+                parentId=None,
+                createdAt=now,
+                updatedAt=now,
+            )
+        )
+    return responses
 
 
 @router.get("/{id}")
@@ -100,12 +170,79 @@ async def delete_tag(id: UUID):
 
 
 @router.put("/{id}/assets")
-async def tag_assets(id: UUID, request: BulkIdsDto) -> List[BulkIdResponseDto]:
+async def tag_assets(
+    id: UUID,
+    request: BulkIdsDto,
+    client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
+    current_user_id: UUID = Depends(get_current_user_id),
+) -> List[BulkIdResponseDto]:
+    """Assign assets to a tag by appending the tag to each asset's description.
+
+    The Gumnut API has no tags, so "assignment" means appending the tag value —
+    recovered from the id minted at upsert time — as a line to each asset's
+    description. Reads the requested assets' current descriptions
+    (``state="all"`` so trashed assets aren't silently dropped), appends the tag
+    idempotently, and writes changed descriptions back via
+    ``bulk_update_assets``. Calls are chunked by ``GUMNUT_API_MAX_BULK_IDS``.
+
+    Returns one ``BulkIdResponseDto`` per requested id: ``success=True`` for
+    assets that were updated (or already carried the tag), and
+    ``success=False`` / ``not_found`` for ids the user's scoped read didn't
+    return (inaccessible or nonexistent). An unknown tag id — one never recorded
+    at upsert time — is a ``400``, matching Immich's tag-not-found behavior.
     """
-    Bulk assign assets to tag.
-    This is a stub implementation that returns an empty list.
-    """
-    return []
+    user_id = str(current_user_id)
+    tag_value = await lookup_tag_value(user_id, id)
+    if tag_value is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Tag not found",
+        )
+
+    if not request.ids:
+        return []
+
+    accessible: set[UUID] = set()
+    for chunk in batched(request.ids, GUMNUT_API_MAX_BULK_IDS):
+        gumnut_ids = [uuid_to_gumnut_asset_id(uid) for uid in chunk]
+        page = await client.assets.list(
+            state="all",
+            ids=gumnut_ids,
+            limit=len(gumnut_ids),
+            include=ASSET_INCLUDE_METADATA_ONLY,
+        )
+        current_desc_by_id: dict[str, str | None] = {
+            asset.id: (asset.metadata.description if asset.metadata else None)
+            for asset in page.data
+        }
+
+        updates: list[Update] = []
+        for uid, gid in zip(chunk, gumnut_ids):
+            if gid not in current_desc_by_id:
+                continue  # inaccessible / nonexistent → not_found below
+            accessible.add(uid)
+            existing = current_desc_by_id[gid]
+            new_desc = _append_tag_to_description(existing, tag_value)
+            if new_desc != (existing or ""):
+                updates.append(
+                    {
+                        "id": gid,
+                        "change": cast(UpdateChange, {"description": new_desc}),
+                    }
+                )
+
+        if updates:
+            await client.assets.bulk_update_assets(updates=updates)
+
+    return [
+        BulkIdResponseDto(
+            id=uid,
+            success=uid in accessible,
+            error=None if uid in accessible else BulkIdErrorReason.not_found,
+            errorMessage=None if uid in accessible else "Asset not found",
+        )
+        for uid in request.ids
+    ]
 
 
 @router.delete("/{id}/assets")

--- a/routers/api/tags.py
+++ b/routers/api/tags.py
@@ -39,9 +39,9 @@ router = APIRouter(
 # each asset's description: upsert mints a deterministic id and records
 # `id -> value` (see services/tag_store.py), and assignment recovers the value
 # and appends it. The remaining tag endpoints stay informational stubs — they
-# are not on immich-go's import path, and the client-side tags UI is
-# deliberately left disabled (see routers/api/users.py preferences and
-# routers/api/server.py server features) because `GET /api/tags` is still a stub.
+# are not on immich-go's import path, and the client-side tags sidebar is
+# deliberately left disabled (see the `tags` preference in routers/api/users.py)
+# because `GET /api/tags` is still a stub.
 
 
 def _append_tag_to_description(description: str | None, tag_value: str) -> str:
@@ -109,7 +109,12 @@ async def upsert_tags(
     user_id = str(current_user_id)
     now = datetime.now(tz=timezone.utc)
     responses: List[TagResponseDto] = []
-    for value in request.tags:
+    for raw_value in request.tags:
+        # A tag is stored as a single description line, so newlines would break
+        # both the append and its idempotency check. immich-go can't send one
+        # (tags come from CLI args / folder names), but sanitize at this input
+        # boundary so the "one line per tag" invariant holds for any client.
+        value = raw_value.replace("\r", " ").replace("\n", " ")
         tag_id = deterministic_tag_id(user_id, value)
         await remember_tag(user_id, tag_id, value)
         responses.append(
@@ -190,6 +195,11 @@ async def tag_assets(
     ``success=False`` / ``not_found`` for ids the user's scoped read didn't
     return (inaccessible or nonexistent). An unknown tag id — one never recorded
     at upsert time — is a ``400``, matching Immich's tag-not-found behavior.
+
+    The per-asset read-then-write has a small race window (like
+    ``assets.update_assets``): a concurrent description edit between the read and
+    the write can be clobbered. immich-go applies tags sequentially, so this is
+    not a concern on the import path.
     """
     user_id = str(current_user_id)
     tag_value = await lookup_tag_value(user_id, id)

--- a/services/tag_store.py
+++ b/services/tag_store.py
@@ -1,0 +1,58 @@
+"""Redis-backed store mapping synthetic tag IDs to their tag values.
+
+The Gumnut API has no tag concept. To keep Immich clients working — notably
+immich-go, which upserts a tag and then assigns assets to it by ID — the adapter
+emulates tags: ``PUT /api/tags`` mints a deterministic synthetic ID per tag and
+records the ``ID -> value`` mapping here, and ``PUT /api/tags/{id}/assets`` later
+recovers the value to append it to each asset's description.
+
+The mapping has to survive between those two requests and across worker
+processes, so it lives in Redis (already a hard dependency for sessions and
+checkpoints) rather than in process memory.
+"""
+
+from uuid import UUID, uuid5
+
+from utils.redis_client import get_redis_client
+
+# Fixed namespace for deriving synthetic tag IDs from (user, value). Chosen once
+# at random; never change it — every previously-minted tag ID is derived from it,
+# so a change would orphan tags mid-import.
+_TAG_ID_NAMESPACE = UUID("6f3d8c2a-9b4e-4f1a-8c7d-2e1b0a9f8d6c")
+
+# A tag mapping only needs to outlive a single import run (an upsert immediately
+# followed by assignment), but a generous TTL keeps re-runs and slow imports
+# working while ensuring keys eventually expire.
+TAG_TTL_SECONDS = 7 * 24 * 60 * 60  # 7 days
+
+
+def deterministic_tag_id(user_id: str, value: str) -> UUID:
+    """Return a stable synthetic tag ID for a ``(user, tag value)`` pair.
+
+    Deterministic so repeated upserts of the same tag return the same ID
+    (idempotency) and every worker computes the same ID without coordination.
+    Scoped by ``user_id`` so the same tag name for different users never
+    collides.
+    """
+    return uuid5(_TAG_ID_NAMESPACE, f"{user_id}:{value}")
+
+
+def _tag_key(user_id: str, tag_id: UUID) -> str:
+    return f"immich_adapter:tag:{user_id}:{tag_id}"
+
+
+async def remember_tag(user_id: str, tag_id: UUID, value: str) -> None:
+    """Record ``tag_id -> value`` for this user, with a TTL."""
+    client = await get_redis_client()
+    await client.set(_tag_key(user_id, tag_id), value, ex=TAG_TTL_SECONDS)
+
+
+async def lookup_tag_value(user_id: str, tag_id: UUID) -> str | None:
+    """Return the tag value recorded for ``tag_id``, or ``None`` if unknown."""
+    client = await get_redis_client()
+    value = await client.get(_tag_key(user_id, tag_id))
+    # The client is configured with decode_responses=True, so values come back
+    # as ``str``; the decode guard just narrows the broad redis-py return type.
+    if isinstance(value, bytes):
+        return value.decode()
+    return value

--- a/tests/unit/api/test_tags.py
+++ b/tests/unit/api/test_tags.py
@@ -1,0 +1,270 @@
+"""Tests for tags.py endpoints.
+
+The Gumnut API has no tags; the adapter emulates them so Immich clients (notably
+immich-go's tagged import) don't fail. `PUT /api/tags` mints a deterministic
+synthetic id per requested name and records `id -> value`; `PUT
+/api/tags/{id}/assets` recovers the value and appends it to each asset's
+description. These tests exercise create, idempotent upsert, assignment,
+idempotent re-assignment, inaccessible assets, unknown tag id, and malformed
+requests.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from routers.api.tags import (
+    _append_tag_to_description,
+    tag_assets,
+    upsert_tags,
+)
+from routers.immich_models import BulkIdErrorReason, BulkIdsDto, TagUpsertDto
+from routers.utils.gumnut_id_conversion import uuid_to_gumnut_asset_id
+from services.tag_store import deterministic_tag_id
+
+
+def _mock_asset(uid: UUID, description: str | None) -> Mock:
+    """Build a mock Gumnut asset carrying only what tag_assets reads."""
+    asset = Mock()
+    asset.id = uuid_to_gumnut_asset_id(uid)
+    asset.metadata = Mock(description=description)
+    return asset
+
+
+def _mock_read(assets_by_uuid: dict[UUID, str | None]) -> AsyncMock:
+    """Mock `client.assets.list` returning the given description per asset."""
+    from tests.conftest import MockSyncCursorPage
+
+    page = MockSyncCursorPage(
+        [_mock_asset(uid, desc) for uid, desc in assets_by_uuid.items()]
+    )
+    return AsyncMock(return_value=page)
+
+
+def _change_by_id(mock_call: AsyncMock) -> dict[str, Any]:
+    """Map gumnut id → change from a single bulk_update_assets call."""
+    mock_call.assert_awaited_once()
+    call = mock_call.await_args
+    assert call is not None
+    return {item["id"]: item["change"] for item in call.kwargs["updates"]}
+
+
+class TestAppendTagToDescription:
+    """The idempotent description-append helper."""
+
+    def test_appends_to_empty_description(self):
+        assert _append_tag_to_description(None, "Vacation") == "#Vacation"
+        assert _append_tag_to_description("", "Vacation") == "#Vacation"
+
+    def test_appends_as_new_line_to_existing(self):
+        assert (
+            _append_tag_to_description("A sunset", "Vacation") == "A sunset\n#Vacation"
+        )
+
+    def test_idempotent_when_already_present(self):
+        existing = "A sunset\n#Vacation"
+        assert _append_tag_to_description(existing, "Vacation") == existing
+
+    def test_hierarchical_value_with_spaces_is_preserved(self):
+        assert (
+            _append_tag_to_description(None, "My Trips/Summer 2026")
+            == "#My Trips/Summer 2026"
+        )
+
+    def test_distinct_tags_both_appended(self):
+        desc = _append_tag_to_description(None, "Trees")
+        desc = _append_tag_to_description(desc, "TreesTall")
+        assert desc == "#Trees\n#TreesTall"
+        # Re-adding the prefix tag stays idempotent (line-equality, not substring).
+        assert _append_tag_to_description(desc, "Trees") == desc
+
+
+class TestDeterministicTagId:
+    """Synthetic tag ids are stable and user-scoped."""
+
+    def test_same_inputs_same_id(self):
+        assert deterministic_tag_id("user-1", "Vacation") == deterministic_tag_id(
+            "user-1", "Vacation"
+        )
+
+    def test_different_user_different_id(self):
+        assert deterministic_tag_id("user-1", "Vacation") != deterministic_tag_id(
+            "user-2", "Vacation"
+        )
+
+    def test_different_value_different_id(self):
+        assert deterministic_tag_id("user-1", "Vacation") != deterministic_tag_id(
+            "user-1", "Work"
+        )
+
+
+class TestUpsertTags:
+    """PUT /api/tags."""
+
+    @pytest.mark.anyio
+    async def test_creates_tag_returns_nonempty(self):
+        user_id = uuid4()
+        request = TagUpsertDto(tags=["Vacation"])
+        with patch("routers.api.tags.remember_tag", new=AsyncMock()) as mock_remember:
+            result = await upsert_tags(request, current_user_id=user_id)
+
+        assert len(result) == 1
+        tag = result[0]
+        assert tag.name == "Vacation"
+        assert tag.value == "Vacation"
+        assert tag.id == deterministic_tag_id(str(user_id), "Vacation")
+        mock_remember.assert_awaited_once_with(str(user_id), tag.id, "Vacation")
+
+    @pytest.mark.anyio
+    async def test_repeated_upsert_is_idempotent(self):
+        user_id = uuid4()
+        request = TagUpsertDto(tags=["Vacation"])
+        with patch("routers.api.tags.remember_tag", new=AsyncMock()):
+            first = await upsert_tags(request, current_user_id=user_id)
+            second = await upsert_tags(request, current_user_id=user_id)
+
+        assert first[0].id == second[0].id
+
+    @pytest.mark.anyio
+    async def test_hierarchical_name_and_order_preserved(self):
+        user_id = uuid4()
+        request = TagUpsertDto(tags=["Nature/Trees", "Vacation"])
+        with patch("routers.api.tags.remember_tag", new=AsyncMock()):
+            result = await upsert_tags(request, current_user_id=user_id)
+
+        assert [t.value for t in result] == ["Nature/Trees", "Vacation"]
+        # value is the full path; name is the leaf segment.
+        assert result[0].name == "Trees"
+        assert result[1].name == "Vacation"
+
+
+class TestTagAssets:
+    """PUT /api/tags/{id}/assets."""
+
+    @pytest.mark.anyio
+    async def test_appends_tag_to_asset_descriptions(self):
+        user_id = uuid4()
+        tag_id = uuid4()
+        a1, a2 = uuid4(), uuid4()
+        mock_client = Mock()
+        mock_client.assets.list = _mock_read({a1: "Sunset", a2: None})
+        mock_client.assets.bulk_update_assets = AsyncMock(return_value=None)
+        request = BulkIdsDto(ids=[a1, a2])
+
+        with patch(
+            "routers.api.tags.lookup_tag_value",
+            new=AsyncMock(return_value="Vacation"),
+        ):
+            result = await tag_assets(
+                tag_id, request, client=mock_client, current_user_id=user_id
+            )
+
+        assert [(r.id, r.success) for r in result] == [(a1, True), (a2, True)]
+        changes = _change_by_id(mock_client.assets.bulk_update_assets)
+        assert changes[uuid_to_gumnut_asset_id(a1)] == {
+            "description": "Sunset\n#Vacation"
+        }
+        assert changes[uuid_to_gumnut_asset_id(a2)] == {"description": "#Vacation"}
+
+    @pytest.mark.anyio
+    async def test_reassign_is_idempotent_no_write(self):
+        user_id = uuid4()
+        tag_id = uuid4()
+        a1 = uuid4()
+        mock_client = Mock()
+        mock_client.assets.list = _mock_read({a1: "Sunset\n#Vacation"})
+        mock_client.assets.bulk_update_assets = AsyncMock(return_value=None)
+        request = BulkIdsDto(ids=[a1])
+
+        with patch(
+            "routers.api.tags.lookup_tag_value",
+            new=AsyncMock(return_value="Vacation"),
+        ):
+            result = await tag_assets(
+                tag_id, request, client=mock_client, current_user_id=user_id
+            )
+
+        assert [(r.id, r.success) for r in result] == [(a1, True)]
+        # Already tagged → success, but nothing written.
+        mock_client.assets.bulk_update_assets.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_inaccessible_assets_marked_not_found(self):
+        user_id = uuid4()
+        tag_id = uuid4()
+        accessible, inaccessible = uuid4(), uuid4()
+        mock_client = Mock()
+        # The scoped read returns only the accessible asset.
+        mock_client.assets.list = _mock_read({accessible: None})
+        mock_client.assets.bulk_update_assets = AsyncMock(return_value=None)
+        request = BulkIdsDto(ids=[accessible, inaccessible])
+
+        with patch(
+            "routers.api.tags.lookup_tag_value",
+            new=AsyncMock(return_value="Vacation"),
+        ):
+            result = await tag_assets(
+                tag_id, request, client=mock_client, current_user_id=user_id
+            )
+
+        by_id = {r.id: r for r in result}
+        assert by_id[accessible].success is True
+        assert by_id[inaccessible].success is False
+        assert by_id[inaccessible].error == BulkIdErrorReason.not_found
+        # Only the accessible asset is written.
+        changes = _change_by_id(mock_client.assets.bulk_update_assets)
+        assert list(changes) == [uuid_to_gumnut_asset_id(accessible)]
+
+    @pytest.mark.anyio
+    async def test_unknown_tag_id_is_400(self):
+        user_id = uuid4()
+        tag_id = uuid4()
+        mock_client = Mock()
+        mock_client.assets.list = AsyncMock()
+        request = BulkIdsDto(ids=[uuid4()])
+
+        with patch(
+            "routers.api.tags.lookup_tag_value", new=AsyncMock(return_value=None)
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await tag_assets(
+                    tag_id, request, client=mock_client, current_user_id=user_id
+                )
+
+        assert exc_info.value.status_code == 400
+        mock_client.assets.list.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_empty_ids_returns_empty(self):
+        user_id = uuid4()
+        tag_id = uuid4()
+        mock_client = Mock()
+        mock_client.assets.list = AsyncMock()
+        request = BulkIdsDto(ids=[])
+
+        with patch(
+            "routers.api.tags.lookup_tag_value",
+            new=AsyncMock(return_value="Vacation"),
+        ):
+            result = await tag_assets(
+                tag_id, request, client=mock_client, current_user_id=user_id
+            )
+
+        assert result == []
+        mock_client.assets.list.assert_not_awaited()
+
+
+class TestMalformedRequests:
+    """Malformed bodies are rejected at the DTO layer (FastAPI → 422)."""
+
+    def test_upsert_requires_tags(self):
+        with pytest.raises(ValidationError):
+            TagUpsertDto.model_validate({})
+
+    def test_assign_rejects_non_uuid_ids(self):
+        with pytest.raises(ValidationError):
+            BulkIdsDto.model_validate({"ids": ["not-a-uuid"]})

--- a/tests/unit/api/test_tags.py
+++ b/tests/unit/api/test_tags.py
@@ -24,7 +24,12 @@ from routers.api.tags import (
 )
 from routers.immich_models import BulkIdErrorReason, BulkIdsDto, TagUpsertDto
 from routers.utils.gumnut_id_conversion import uuid_to_gumnut_asset_id
-from services.tag_store import deterministic_tag_id
+from services.tag_store import (
+    TAG_TTL_SECONDS,
+    deterministic_tag_id,
+    lookup_tag_value,
+    remember_tag,
+)
 
 
 def _mock_asset(uid: UUID, description: str | None) -> Mock:
@@ -141,6 +146,22 @@ class TestUpsertTags:
         assert result[0].name == "Trees"
         assert result[1].name == "Vacation"
 
+    @pytest.mark.anyio
+    async def test_newlines_in_value_are_sanitized(self):
+        """A tag is stored as one description line, so newlines are stripped at
+        the input boundary to keep the append idempotent."""
+        user_id = uuid4()
+        request = TagUpsertDto(tags=["Bad\nTag\r\nName"])
+        with patch("routers.api.tags.remember_tag", new=AsyncMock()) as mock_remember:
+            result = await upsert_tags(request, current_user_id=user_id)
+
+        assert "\n" not in result[0].value
+        assert "\r" not in result[0].value
+        # The sanitized value is what gets recorded for later assignment.
+        mock_remember.assert_awaited_once_with(
+            str(user_id), result[0].id, result[0].value
+        )
+
 
 class TestTagAssets:
     """PUT /api/tags/{id}/assets."""
@@ -256,6 +277,133 @@ class TestTagAssets:
 
         assert result == []
         mock_client.assets.list.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_asset_with_null_metadata_is_tagged(self):
+        """An asset whose metadata object is absent gets the tag as its whole
+        description (the `asset.metadata is None` branch)."""
+        user_id = uuid4()
+        tag_id = uuid4()
+        a1 = uuid4()
+        from tests.conftest import MockSyncCursorPage
+
+        asset = Mock()
+        asset.id = uuid_to_gumnut_asset_id(a1)
+        asset.metadata = None
+        mock_client = Mock()
+        mock_client.assets.list = AsyncMock(return_value=MockSyncCursorPage([asset]))
+        mock_client.assets.bulk_update_assets = AsyncMock(return_value=None)
+        request = BulkIdsDto(ids=[a1])
+
+        with patch(
+            "routers.api.tags.lookup_tag_value",
+            new=AsyncMock(return_value="Vacation"),
+        ):
+            result = await tag_assets(
+                tag_id, request, client=mock_client, current_user_id=user_id
+            )
+
+        assert [(r.id, r.success) for r in result] == [(a1, True)]
+        changes = _change_by_id(mock_client.assets.bulk_update_assets)
+        assert changes[uuid_to_gumnut_asset_id(a1)] == {"description": "#Vacation"}
+
+    @pytest.mark.anyio
+    async def test_multiple_chunks_accumulate_across_batches(self):
+        """Ids spanning more than one chunk each get read + written, and the
+        per-id results accumulate across the batched loop."""
+        from tests.conftest import MockSyncCursorPage
+
+        user_id = uuid4()
+        tag_id = uuid4()
+        a1, a2, a3 = uuid4(), uuid4(), uuid4()
+        mock_client = Mock()
+        # One asset per chunk (a3 is inaccessible: its chunk read returns empty).
+        mock_client.assets.list = AsyncMock(
+            side_effect=[
+                MockSyncCursorPage([_mock_asset(a1, "One")]),
+                MockSyncCursorPage([_mock_asset(a2, None)]),
+                MockSyncCursorPage([]),
+            ]
+        )
+        mock_client.assets.bulk_update_assets = AsyncMock(return_value=None)
+        request = BulkIdsDto(ids=[a1, a2, a3])
+
+        with (
+            patch("routers.api.tags.GUMNUT_API_MAX_BULK_IDS", 1),
+            patch(
+                "routers.api.tags.lookup_tag_value",
+                new=AsyncMock(return_value="Vacation"),
+            ),
+        ):
+            result = await tag_assets(
+                tag_id, request, client=mock_client, current_user_id=user_id
+            )
+
+        # Order preserved across chunks; a3 inaccessible → not_found.
+        assert [(r.id, r.success) for r in result] == [
+            (a1, True),
+            (a2, True),
+            (a3, False),
+        ]
+        assert result[2].error == BulkIdErrorReason.not_found
+        # One read per chunk; one write per chunk that had an accessible asset.
+        assert mock_client.assets.list.await_count == 3
+        assert mock_client.assets.bulk_update_assets.await_count == 2
+
+
+class TestTagStore:
+    """The Redis-backed id -> value store (services/tag_store.py)."""
+
+    @pytest.mark.anyio
+    async def test_remember_tag_sets_scoped_key_with_ttl(self):
+        tag_id = deterministic_tag_id("user-1", "Vacation")
+        redis = Mock()
+        redis.set = AsyncMock(return_value=None)
+        with patch(
+            "services.tag_store.get_redis_client",
+            new=AsyncMock(return_value=redis),
+        ):
+            await remember_tag("user-1", tag_id, "Vacation")
+
+        redis.set.assert_awaited_once_with(
+            f"immich_adapter:tag:user-1:{tag_id}", "Vacation", ex=TAG_TTL_SECONDS
+        )
+
+    @pytest.mark.anyio
+    async def test_lookup_tag_value_round_trips(self):
+        tag_id = deterministic_tag_id("user-1", "Vacation")
+        redis = Mock()
+        redis.get = AsyncMock(return_value="Vacation")
+        with patch(
+            "services.tag_store.get_redis_client",
+            new=AsyncMock(return_value=redis),
+        ):
+            value = await lookup_tag_value("user-1", tag_id)
+
+        assert value == "Vacation"
+        redis.get.assert_awaited_once_with(f"immich_adapter:tag:user-1:{tag_id}")
+
+    @pytest.mark.anyio
+    async def test_lookup_tag_value_missing_returns_none(self):
+        redis = Mock()
+        redis.get = AsyncMock(return_value=None)
+        with patch(
+            "services.tag_store.get_redis_client",
+            new=AsyncMock(return_value=redis),
+        ):
+            assert await lookup_tag_value("user-1", uuid4()) is None
+
+    @pytest.mark.anyio
+    async def test_lookup_tag_value_decodes_bytes(self):
+        """decode_responses is on in production, but narrow the broad redis
+        return type by decoding a bytes value defensively."""
+        redis = Mock()
+        redis.get = AsyncMock(return_value=b"Vacation")
+        with patch(
+            "services.tag_store.get_redis_client",
+            new=AsyncMock(return_value=redis),
+        ):
+            assert await lookup_tag_value("user-1", uuid4()) == "Vacation"
 
 
 class TestMalformedRequests:


### PR DESCRIPTION
## What
- Implement `PUT /api/tags` (upsert) and `PUT /api/tags/{id}/assets` (assign), replacing stubs that returned `[]`. Since the Gumnut API has no tag model, tags are **emulated**: upsert mints a deterministic `uuid5` id per name and records `id → value` in Redis (new `services/tag_store.py`, 7-day TTL); assign recovers the value and appends it to each asset's **description** as an idempotent `#<value>` line via chunked `bulk_update_assets`.
- Return one `TagResponseDto` per requested name (in order); return per-id `BulkIdResponseDto` on assign (`not_found` for inaccessible ids, `400` for an unknown tag id). Newlines are sanitized out of tag values so each tag stays one description line.
- Remaining tag endpoints stay stubs and the client-side tags sidebar stays disabled (`GET /api/tags` still returns `[]`, so surfacing it would show a permanently empty list).
- Update the implementation-status docs (adapter architecture, gap analysis) and the immich-go import guide; add `tests/unit/api/test_tags.py`.

## Why
`immich-go upload from-folder --tag <name>` stores assets, then reads the upserted tag at response index 0 and calls the assign endpoint. The old upsert stub returned `[]`, so immich-go panicked (`index out of range [0]`) *after* assets were already stored. This unblocks tagged bulk imports without waiting on a real backend tag model. It is an interim workaround — embedded `#`-tags won't auto-migrate when real tags land.

## Test plan
- [x] `uv run pytest` (full suite, 1244 passed) — new `test_tags.py` covers create, idempotent upsert, ordering/hierarchy, newline sanitization, assignment, idempotent re-assign, null-metadata, multi-chunk accumulation, inaccessible → `not_found`, unknown tag → 400, empty ids, malformed → 422, and the `tag_store` key scheme/TTL/bytes-decode.
- [x] `uv run ruff format` / `uv run ruff check` / `uv run pyright` clean.
- [ ] Manual: a fresh `immich-go upload from-folder --tag <name>` import exits 0 and the imported asset's description shows `#<name>`.

Generated by an AI coding agent.