### PR TITLE
Fold camera and place filters into the free-text search query

### DIFF
--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Immich Adapter Architecture"
-last-updated: 2026-07-22
+last-updated: 2026-07-27
 ---
 
 # Immich Adapter Architecture
@@ -200,6 +200,22 @@ requested page. Page N still walks through the preceding N - 1 pages because a
 numeric page cannot encode the Gumnut cursor, but it no longer exhausts the
 remaining library just to compute an exact total. A request carrying a real
 search criterion continues to use `client.search.search`, which mandates one.
+
+**Camera and place filters are folded into the query, not applied as filters.**
+Immich's `make` / `model` / `lensModel` / `city` / `state` / `country` have no
+typed equivalent on the Gumnut API, but all six are indexed in its full-text
+metadata corpus, so `_compose_free_text_query` appends their values to the
+free-text query on both `/search/metadata` and `/search/smart`. Without this a
+filters-only request reaches the API with no criterion and 400s — which is what
+Immich's Explore and Places pages and its asset detail panel all generate.
+
+The cost is that **query terms are OR-ed, not intersected**, and retrieval is
+capped at a fixed candidate count. Adding a term therefore widens the candidate
+pool rather than narrowing it: searching "beach" with `make=Canon` against a
+library of thousands of Canon photos can crowd the beach matches out. Weigh
+that before folding any further Immich filter into the query string — a filter
+that is common in the library degrades the caller's own search term. Exact
+filtering needs a typed parameter on the Gumnut API.
 
 **Endpoints using this pattern:**
 
@@ -412,7 +428,7 @@ The adapter implements a subset of Immich's API surface. Unimplemented endpoints
 | People | CRUD, list with pagination/sort/filter, thumbnails, statistics, merge | |
 | Faces | List, create, delete, reassign | Create draws a user-specified box on an asset and links it to a person (Immich's "create a face on-the-fly" flow) |
 | Timeline | Time buckets (monthly), bucket contents | Date-range filtering with timezone handling, including `isTrashed=true` |
-| Search | Smart search, metadata search, person search, statistics, random sampling, explore (cities + recents) | Places, cities, suggestions, and large-assets are stubs |
+| Search | Smart search, metadata search, person search, statistics, random sampling, explore (cities + recents) | Camera/place filters are folded into the query, not filtered on (see above); places, cities, suggestions, and large-assets are stubs |
 | Sync | Stream, ack | Two-phase ordering, checkpoint management |
 | Auth | OAuth login/callback, logout, session management | Clerk OAuth via the Gumnut API |
 | WebSockets | Real-time upload/trash/restore/delete notifications | Socket.IO with room-based messaging |

--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -273,6 +273,46 @@ _ENUMERATION_HONORABLE_FIELDS = frozenset(
 )
 
 
+# Immich exposes these as typed filters; the Gumnut API has no equivalent
+# parameter for any of them. All six are indexed in its full-text metadata
+# corpus, so folding their values into the free-text query is what makes them
+# count for anything. Order is stable so a given request always produces the
+# same query string, which keeps tests and cached results deterministic.
+_FREE_TEXT_FILTER_FIELDS = ("make", "model", "lensModel", "city", "state", "country")
+
+
+def _compose_free_text_query(
+    text: str | None, request: MetadataSearchDto | SmartSearchDto
+) -> str | None:
+    """Fold Immich's camera and place filters into the free-text query.
+
+    **These become ranking signals, not filters.** Immich's UI presents make /
+    model / lens / city / state / country as hard filters, and a caller who
+    picks "Canon" reasonably expects only Canon assets. What they get is a
+    search where "Canon" contributes to relevance, so lower-ranked non-Canon
+    assets still appear. That is a deliberate approximation, and the reason it
+    is worth making is that the alternative is worse in both directions: a
+    request carrying only these fields currently reaches the Gumnut API with no
+    criterion at all and fails with a 400, and one that also carries free text
+    silently drops them.
+
+    Exact filtering needs a typed parameter on the Gumnut API; until that
+    exists, this is the closest honest approximation.
+
+    Returns ``None`` when nothing is populated, preserving the existing
+    no-criterion behavior for callers that supply neither text nor filters.
+    """
+    values = (
+        text,
+        *(getattr(request, field, None) for field in _FREE_TEXT_FILTER_FIELDS),
+    )
+    # Immich web sends "" for a cleared filter box rather than omitting the
+    # key, so blank and whitespace-only values must drop out rather than
+    # contribute a stray separator.
+    terms = [stripped for value in values if value and (stripped := value.strip())]
+    return " ".join(terms) or None
+
+
 def _is_criterion_less_enumeration(request: MetadataSearchDto) -> bool:
     """True when a metadata search is a filter-less asset-listing walk.
 
@@ -408,7 +448,12 @@ async def search_assets(
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
     current_user: UserResponseDto = Depends(get_current_user),
 ) -> SearchResponseDto:
-    """Search for assets by metadata filters."""
+    """Search for assets by metadata filters.
+
+    Camera and place filters (make / model / lens / city / state / country) are
+    folded into the free-text query rather than applied as filters — see
+    `_compose_free_text_query` for what that costs.
+    """
     if _is_criterion_less_enumeration(request):
         return await _list_asset_page(request, client, current_user)
 
@@ -417,7 +462,7 @@ async def search_assets(
         person_ids = [uuid_to_gumnut_person_id(pid) for pid in request.personIds]
 
     search_kwargs: dict[str, Any] = {
-        "query": request.description,
+        "query": _compose_free_text_query(request.description, request),
         # These map to the Gumnut API's local_datetime bounds by deliberate
         # translation, not identity, and web sends them in the keepLocalTime
         # wire format so its offset is fictitious (both: see code practices,
@@ -467,8 +512,15 @@ async def search_smart(
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
     current_user: UserResponseDto = Depends(get_current_user),
 ) -> SearchResponseDto:
-    """Smart search for assets."""
-    search_kwargs: dict[str, Any] = {"query": request.query, "include": ASSET_INCLUDE}
+    """Smart search for assets.
+
+    Camera and place filters are folded into the query alongside the caller's
+    text — see `_compose_free_text_query` for what that costs.
+    """
+    search_kwargs: dict[str, Any] = {
+        "query": _compose_free_text_query(request.query, request),
+        "include": ASSET_INCLUDE,
+    }
     if request.size is not None:
         # Clamp at the Gumnut API per-page ceiling. The Immich client default
         # is 1000; without this, the Gumnut API 422s.

--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -273,11 +273,9 @@ _ENUMERATION_HONORABLE_FIELDS = frozenset(
 )
 
 
-# Immich exposes these as typed filters; the Gumnut API has no equivalent
-# parameter for any of them. All six are indexed in its full-text metadata
-# corpus, so folding their values into the free-text query is what makes them
-# count for anything. Order is stable so a given request always produces the
-# same query string, which keeps tests and cached results deterministic.
+# The Gumnut API has no typed parameter for any of these, but all six are
+# indexed in its full-text metadata corpus — which is the only reason folding
+# them into the query accomplishes anything at all.
 _FREE_TEXT_FILTER_FIELDS = ("make", "model", "lensModel", "city", "state", "country")
 
 
@@ -286,29 +284,44 @@ def _compose_free_text_query(
 ) -> str | None:
     """Fold Immich's camera and place filters into the free-text query.
 
-    **These become ranking signals, not filters.** Immich's UI presents make /
-    model / lens / city / state / country as hard filters, and a caller who
-    picks "Canon" reasonably expects only Canon assets. What they get is a
-    search where "Canon" contributes to relevance, so lower-ranked non-Canon
-    assets still appear. That is a deliberate approximation, and the reason it
-    is worth making is that the alternative is worse in both directions: a
-    request carrying only these fields currently reaches the Gumnut API with no
-    criterion at all and fails with a 400, and one that also carries free text
-    silently drops them.
+    **These become ranking signals, not filters**, and the two request shapes
+    pay for that differently.
+
+    *Filters only, no text.* A strict win. Immich's Explore and Places pages
+    and its asset detail panel all link to searches carrying only these fields;
+    every one of them reaches the Gumnut API with no criterion at all and fails
+    with a 400 today. Folding turns each into a working search.
+
+    *Filters plus text.* A real trade, and it can lose correct matches rather
+    than merely admit wrong ones. The terms are OR-ed against the caller's
+    text, not intersected with it, and retrieval is capped at a fixed candidate
+    count — so searching "beach" with `make=Canon` against a library of
+    thousands of Canon photos and a handful of beach photos lets the camera
+    term crowd the beach matches down or out. Before this fold that request
+    searched "beach" cleanly and ignored the camera filter. Shipping it anyway
+    is a deliberate call: the filters-only shape is the one clients actually
+    generate, since the search modal's camera and location pickers are
+    unusable against this adapter (they populate from `/search/suggestions`,
+    which is a stub).
+
+    The same fold can also change the *question*: `originalFileName`, `ocr`,
+    and `originalPath` are not read here or anywhere, so a filename search
+    combined with a camera filter now returns plausible-looking camera results
+    instead of failing visibly.
 
     Exact filtering needs a typed parameter on the Gumnut API; until that
-    exists, this is the closest honest approximation.
+    exists, this is the closest approximation available.
 
     Returns ``None`` when nothing is populated, preserving the existing
     no-criterion behavior for callers that supply neither text nor filters.
     """
-    values = (
-        text,
-        *(getattr(request, field, None) for field in _FREE_TEXT_FILTER_FIELDS),
-    )
-    # Immich web sends "" for a cleared filter box rather than omitting the
-    # key, so blank and whitespace-only values must drop out rather than
-    # contribute a stray separator.
+    # No getattr default: both DTOs declare all six fields, and these models are
+    # generated from Immich's OpenAPI spec. A rename on a version bump should
+    # fail loudly here rather than silently stop forwarding the term.
+    values = (text, *(getattr(request, field) for field in _FREE_TEXT_FILTER_FIELDS))
+    # Blank and whitespace-only values drop out rather than contribute a stray
+    # separator. Immich web itself maps a cleared box to null, but immich-go,
+    # scripts, and hand-built `?query={…}` URLs can all carry blanks.
     terms = [stripped for value in values if value and (stripped := value.strip())]
     return " ".join(terms) or None
 

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -1838,7 +1838,11 @@ class TestCameraAndPlaceFilters:
     async def test_blank_and_whitespace_only_values_are_ignored(
         self, mock_current_user
     ):
-        """Immich web sends "" for a cleared filter box, not omitting the key."""
+        """Blanks must drop out rather than contribute a stray separator.
+
+        Immich web itself maps a cleared box to null, but immich-go, scripts,
+        and hand-built `?query={…}` URLs can all carry blanks.
+        """
         client = self._mock_client()
         request = MetadataSearchDto(description="  beach  ", make="", city="   ")
 

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -1724,3 +1724,174 @@ class TestSearchRandom:
                 client=mock_client,
                 current_user=mock_current_user,
             )
+
+
+class TestCameraAndPlaceFilters:
+    """Immich's camera/place filters folded into the free-text query.
+
+    The Gumnut API has no typed parameter for make / model / lens / city /
+    state / country, but its full-text metadata corpus indexes all six. These
+    pin the approximation: the terms reach the query, and — importantly — the
+    two failure modes they replace stay fixed.
+    """
+
+    @staticmethod
+    def _mock_client():
+        search_response = Mock()
+        search_response.data = []
+        client = Mock()
+        client.search.search = AsyncMock(return_value=search_response)
+        return client
+
+    def _query_for(self, client) -> str | None:
+        return client.search.search.call_args.kwargs["query"]
+
+    @pytest.mark.anyio
+    async def test_camera_only_search_reaches_the_api_with_a_query(
+        self, mock_current_user
+    ):
+        """Previously a 400: no criterion reached the Gumnut API at all.
+
+        A camera-only request is not a criterion-less enumeration, so it takes
+        the search path — where every argument used to be None.
+        """
+        client = self._mock_client()
+        request = MetadataSearchDto(make="Canon")
+
+        await search_assets(
+            request=request, client=client, current_user=mock_current_user
+        )
+
+        assert self._query_for(client) == "Canon"
+
+    @pytest.mark.anyio
+    async def test_place_only_search_reaches_the_api_with_a_query(
+        self, mock_current_user
+    ):
+        client = self._mock_client()
+        request = MetadataSearchDto(city="Paris", country="France")
+
+        await search_assets(
+            request=request, client=client, current_user=mock_current_user
+        )
+
+        assert self._query_for(client) == "Paris France"
+
+    @pytest.mark.anyio
+    async def test_filters_are_appended_to_caller_text_not_replacing_it(
+        self, mock_current_user
+    ):
+        """Previously the filters were silently dropped and only text searched."""
+        client = self._mock_client()
+        request = MetadataSearchDto(description="beach", make="Canon", city="Paris")
+
+        await search_assets(
+            request=request, client=client, current_user=mock_current_user
+        )
+
+        assert self._query_for(client) == "beach Canon Paris"
+
+    @pytest.mark.anyio
+    async def test_all_six_fields_are_folded_in_declared_order(self, mock_current_user):
+        """Every field in _FREE_TEXT_FILTER_FIELDS must actually be read.
+
+        Asserting the whole string in order means dropping one — or reordering
+        the tuple — fails here rather than silently narrowing what the adapter
+        forwards.
+        """
+        client = self._mock_client()
+        request = MetadataSearchDto(
+            make="Canon",
+            model="EOS 5D",
+            lensModel="EF 24-70mm",
+            city="Paris",
+            state="Ile-de-France",
+            country="France",
+        )
+
+        await search_assets(
+            request=request, client=client, current_user=mock_current_user
+        )
+
+        assert self._query_for(client) == (
+            "Canon EOS 5D EF 24-70mm Paris Ile-de-France France"
+        )
+
+    @pytest.mark.anyio
+    async def test_query_stays_none_when_nothing_is_populated(self, mock_current_user):
+        """A request with only non-text criteria must not gain an empty query.
+
+        Sending "" instead of None would turn "no text criterion" into a
+        full-text search for nothing, which the Gumnut API treats differently.
+        """
+        client = self._mock_client()
+        person_id = uuid4()
+        request = MetadataSearchDto(personIds=[person_id])
+
+        await search_assets(
+            request=request, client=client, current_user=mock_current_user
+        )
+
+        assert self._query_for(client) is None
+
+    @pytest.mark.anyio
+    async def test_blank_and_whitespace_only_values_are_ignored(
+        self, mock_current_user
+    ):
+        """Immich web sends "" for a cleared filter box, not omitting the key."""
+        client = self._mock_client()
+        request = MetadataSearchDto(description="  beach  ", make="", city="   ")
+
+        await search_assets(
+            request=request, client=client, current_user=mock_current_user
+        )
+
+        assert self._query_for(client) == "beach"
+
+    @pytest.mark.anyio
+    async def test_smart_search_folds_filters_alongside_its_query(
+        self, mock_current_user
+    ):
+        client = self._mock_client()
+        request = SmartSearchDto(query="sunset", make="Nikon", country="Japan")
+
+        await search_smart(
+            request=request, client=client, current_user=mock_current_user
+        )
+
+        assert self._query_for(client) == "sunset Nikon Japan"
+
+    @pytest.mark.anyio
+    async def test_smart_search_camera_only_reaches_the_api_with_a_query(
+        self, mock_current_user
+    ):
+        """SmartSearchDto.query is optional, so this was a 400 too."""
+        client = self._mock_client()
+        request = SmartSearchDto(make="Nikon")
+
+        await search_smart(
+            request=request, client=client, current_user=mock_current_user
+        )
+
+        assert self._query_for(client) == "Nikon"
+
+    @pytest.mark.anyio
+    async def test_camera_filter_does_not_become_a_criterion_less_enumeration(
+        self, mock_current_user
+    ):
+        """A camera-only request must keep taking the search path.
+
+        If these fields were ever added to _ENUMERATION_HONORABLE_FIELDS, this
+        request would be treated as an unfiltered library walk and return
+        everything — the failure mode that gate exists to prevent.
+        """
+        client = self._mock_client()
+        client.assets.list = Mock()
+        request = MetadataSearchDto(make="Canon")
+
+        await search_assets(
+            request=request, client=client, current_user=mock_current_user
+        )
+
+        client.search.search.assert_called_once()
+        client.assets.list.assert_not_called()


### PR DESCRIPTION
## What

- Adds `_compose_free_text_query`, which appends any populated `make` / `model` / `lensModel` / `city` / `state` / `country` to the free-text query, and wires it into both `POST /api/search/metadata` and `POST /api/search/smart`.
- Documents the translation and its cost in `docs/architecture/adapter-architecture.md`.

## Why

Both `MetadataSearchDto` and `SmartSearchDto` carry those six fields, all optional, and the adapter read **none** of them. That failed in two directions:

| Immich request | Before |
|---|---|
| `make="Canon"` alone | **HTTP 400** — not a criterion-less enumeration, so it took the search path with every argument `None`, and the Gumnut API requires a criterion. `SmartSearchDto.query` is optional too, so a camera-only smart search failed the same way. |
| `description="beach"` + `make="Canon"` | Returned beach photos; `Canon` silently dropped. |

The filters-only row is the one clients actually hit: Immich's Explore page, Places page, and asset detail panel all link to searches carrying only these fields. Every one of them is broken today and works after this change. (The search modal's camera and location pickers are a separate matter — they populate from `/search/suggestions`, which is a stub, so they have no options to pick.)

Folding works because the Gumnut API indexes all six fields in its full-text metadata corpus, so the terms reach the sparse retrieval stage.

## What it costs

**These become ranking signals, not filters**, and the two request shapes pay differently. Both endpoint docstrings and the architecture doc say so explicitly, because a future reader should not mistake this for real filtering.

- *Filters only* — a strict win. A 400 becomes a working search.
- *Filters plus text* — a real trade that can lose correct matches, not merely admit wrong ones. Terms are OR-ed against the caller's text rather than intersected with it, and retrieval is capped at a fixed candidate count, so searching "beach" with `make=Canon` against a library of thousands of Canon photos can crowd the beach matches out. Before this change that request searched "beach" cleanly and ignored the filter.

Shipping the unconditional fold anyway is a deliberate call, taken with the filters-only shape being the one clients generate. Exact filtering needs a typed parameter on the Gumnut API; this is a stopgap until that exists.

One further honesty note recorded in the docstring: `originalFileName`, `ocr`, and `originalPath` are read nowhere, so a filename search combined with a camera filter now returns plausible camera results instead of failing visibly.

## Deliberately unchanged

`_is_criterion_less_enumeration`. These stay restricting fields, so immich-go's enumeration path is unaffected — a camera-only search simply now reaches a query that works. A test pins it, since moving them into the honorable set would turn a filtered search into an unfiltered library walk.

## Test plan

- [x] 9 new tests: camera-only and place-only reach the API with a query (the former 400s on `main`); filters append to caller text rather than replace it; all six fields folded, asserted as one ordered string so dropping or reordering one fails; `None` preserved when nothing is populated, so "no text criterion" doesn't become a search for `""`; blank and whitespace-only values dropped; smart search covered for both shapes; and a regression guard that a camera-only request still takes the search path rather than the enumeration walk
- [x] `uv run ruff format` · `uv run ruff check` · `uv run pyright` (0 errors) · `uv run pytest` (1234 passed)

Generated by an AI coding agent.