### PR TITLE
Migrate bulk trash/restore/delete calls to typed SDK methods

### DIFF
--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -343,10 +343,12 @@ Immich's trash flow is implemented end to end. The adapter preserves Immich's pu
 
 `TrashResponseDto.count` is not a count of rows the backend actually transitioned — no backend trash endpoint returns one.
 
-- `POST /api/trash/restore/assets` returns `len(request.ids)`: the upstream restore endpoint answers `204` with no per-row count, and already-live ids are silently skipped backend-side.
+- `POST /api/trash/restore/assets` returns `len(request.ids)`: the upstream restore endpoint answers with an empty acknowledgment body carrying no per-row count, and already-live ids are silently skipped backend-side.
 - `POST /api/trash/restore` and `POST /api/trash/empty` return the count of ids enumerated *before* mutating. A concurrent request that transitions some of those ids between enumeration and the chunked mutation makes the true count slightly smaller.
 
 **Enumerate before mutate.** Both restore-all and empty-trash call `_list_trashed_ids` to collect the full trashed id list before issuing any mutation (`routers/api/trash.py`). This is load-bearing, not incidental: the enumeration walks a cursor-paginated `state="trashed"` listing, and mutating mid-walk shrinks the result set out from under the cursor, making resumption ill-defined. The approximate count above is the price of that ordering.
+
+**The SDK's one-shot `assets.empty_trash` is deliberately unused.** `POST /api/trash/empty` enumerates and then chunks `assets.delete_list` instead. The one-shot method would purge without ever yielding the id list, and the adapter needs that list to emit one `on_asset_delete` per purged id — Immich's wire shape for permanent deletes. Switching to it would silently drop those events and the returned count.
 
 ### Trash-aware read paths
 
@@ -363,7 +365,6 @@ Trash state travels through both client update channels:
 
 ### Remaining limitations
 
-- The trash router issues its restore and bulk-delete calls through `AsyncGumnut.post()` / `.delete()` rather than the typed SDK. The typed helpers now exist (`assets.trash`, `assets.restore`, `assets.delete_list`, `assets.empty_trash`), so this is an unmigrated leftover rather than an SDK gap — the router and its module docstring still describe the helpers as missing.
 - `trashDays` is a shared deploy-time environment-variable contract (`TRASH_RETENTION_DAYS`, documented in `.env.example` and the README), not a value the adapter discovers from the backend at runtime. Adapter and backend must be configured with the same number or the web trash page misreports the retention window.
 - Trash visibility on the search surface is partial. The criterion-less `POST /api/search/metadata` enumeration path honors `withDeleted` (widen to live + trashed) and `trashedAfter` (trashed-only, with the timestamp bound applied client-side). Criterion-bearing metadata searches route to `client.search.search`, which has no trash selector, and `trashedBefore` is treated as a restricting filter that keeps a request off the enumeration path entirely. `GET /api/search/large-assets` is a full stub, so it surfaces nothing at all.
 

--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -346,8 +346,7 @@ Immich's trash flow is implemented end to end. The adapter preserves Immich's pu
 - `POST /api/trash/restore/assets` returns `len(request.ids)`: the upstream restore endpoint answers with an empty acknowledgment body carrying no per-row count, and already-live ids are silently skipped backend-side.
 - `POST /api/trash/restore` and `POST /api/trash/empty` return the count of ids enumerated *before* mutating. A concurrent request that transitions some of those ids between enumeration and the chunked mutation makes the true count slightly smaller.
 
-**Enumerate before mutate.** Both restore-all and empty-trash call `_list_trashed_ids` to collect the full trashed id list before issuing any mutation (`routers/api/trash.py`). This is load-bearing, not incidental: the enumeration walks a cursor-paginated `state="trashed"` listing, and mutating mid-walk shrinks the result set out from under the cursor, making resumption ill-defined. The approximate count above is the price of that ordering.
- The SDK's one-shot `assets.empty_trash` is deliberately unused for the same reason — it purges without yielding the id list (see `empty_trash` in `routers/api/trash.py`).
+**Enumerate before mutate.** Both restore-all and empty-trash call `_list_trashed_ids` to collect the full trashed id list before issuing any mutation (`routers/api/trash.py`). This is load-bearing, not incidental: the enumeration walks a cursor-paginated `state="trashed"` listing, and mutating mid-walk shrinks the result set out from under the cursor, making resumption ill-defined. The approximate count above is the price of that ordering. The SDK's one-shot `assets.empty_trash` is deliberately unused for the same reason, plus one more — it purges without yielding the id list the flow needs for per-id delete events.
 
 ### Trash-aware read paths
 

--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -347,8 +347,7 @@ Immich's trash flow is implemented end to end. The adapter preserves Immich's pu
 - `POST /api/trash/restore` and `POST /api/trash/empty` return the count of ids enumerated *before* mutating. A concurrent request that transitions some of those ids between enumeration and the chunked mutation makes the true count slightly smaller.
 
 **Enumerate before mutate.** Both restore-all and empty-trash call `_list_trashed_ids` to collect the full trashed id list before issuing any mutation (`routers/api/trash.py`). This is load-bearing, not incidental: the enumeration walks a cursor-paginated `state="trashed"` listing, and mutating mid-walk shrinks the result set out from under the cursor, making resumption ill-defined. The approximate count above is the price of that ordering.
-
-**The SDK's one-shot `assets.empty_trash` is deliberately unused.** `POST /api/trash/empty` enumerates and then chunks `assets.delete_list` instead. The one-shot method would purge without ever yielding the id list, and the adapter needs that list to emit one `on_asset_delete` per purged id — Immich's wire shape for permanent deletes. Switching to it would silently drop those events and the returned count.
+ The SDK's one-shot `assets.empty_trash` is deliberately unused for the same reason — it purges without yielding the id list (see `empty_trash` in `routers/api/trash.py`).
 
 ### Trash-aware read paths
 

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -372,7 +372,7 @@ If you write a *new* fan-out helper instead of using `gather_with_concurrency`, 
 
 ### Bulk-ID Endpoints
 
-For Gumnut API endpoints that accept bulk IDs (e.g., `POST /api/assets/trash`, `POST /api/assets/restore`, bulk `DELETE /api/assets`, and list filters with `ids=...`), chunk the request at `GUMNUT_API_MAX_BULK_IDS`. The constant in `routers/api/constants.py` is the source of truth for the current API cap:
+For Gumnut API endpoints that accept bulk IDs (e.g., `assets.trash`, `assets.restore`, `assets.delete_list`, and list filters with `ids=...`), chunk the request at `GUMNUT_API_MAX_BULK_IDS`. The SDK enforces the cap but does not chunk for you, so the loop is the caller's job. The constant in `routers/api/constants.py` is the source of truth for the current API cap:
 
 ```python
 from itertools import batched
@@ -380,7 +380,7 @@ from routers.api.constants import GUMNUT_API_MAX_BULK_IDS
 
 for chunk in batched(asset_uuids, GUMNUT_API_MAX_BULK_IDS):
     gumnut_ids = [uuid_to_gumnut_asset_id(uid) for uid in chunk]
-    await client.post("/api/assets/trash", body={"ids": gumnut_ids}, cast_to=type(None))
+    await client.assets.trash(ids=gumnut_ids)
 ```
 
 Backend bulk endpoints are idempotent on already-transitioned rows (e.g., `trash_assets` skips already-trashed ids; `restore_assets` skips already-live ids). **Don't add per-id 404 / NotFoundError swallowing for these flows** — let bulk failures (validation, transport, 5xx) propagate to the global `GumnutError` handler. The per-id-loop-with-NotFoundError pattern shown above under *Gumnut SDK Errors* applies to single-asset endpoints (e.g., `client.assets.delete(asset_id)`), not to the bulk variants.
@@ -395,14 +395,15 @@ Pin the no-swallow contract with a `test_*_propagates_sdk_error` test per bulk f
 
 Pin the chunking math with exact-boundary tests at `total = GUMNUT_API_MAX_BULK_IDS` (one chunk, no split) and `total = GUMNUT_API_MAX_BULK_IDS + 1` (two chunks, second is a single element) — these catch off-by-one regressions a future hand-rolled `if len(ids) > N` split would introduce. See the parametrized cases in `tests/unit/utils/test_bulk.py::test_splits_oversized_input_into_ordered_chunks` and `tests/unit/api/test_albums.py::test_*_chunks_large_request`.
 
-When the SDK doesn't yet expose a typed method for a backend endpoint (Stainless regenerates on a delay after each backend release), call the raw HTTP layer directly via `AsyncGumnut.post()` / `.delete()` with `cast_to=type(None)` for 204-returning endpoints:
+**Prefer typed SDK methods; the raw client is a stopgap.** When the SDK doesn't yet expose a typed method for a backend endpoint (Stainless regenerates on a delay after each backend release), call the raw HTTP layer directly via `AsyncGumnut.post()` / `.delete()` with `cast_to=type(None)` for endpoints that return no useful body:
 
 ```python
-await client.post("/api/assets/trash", body={"ids": gumnut_ids}, cast_to=type(None))
-await client.delete("/api/assets", body={"ids": gumnut_ids}, cast_to=type(None))
+await client.post("/api/some-new-endpoint", body={"ids": gumnut_ids}, cast_to=type(None))
 ```
 
 `AsyncGumnut` extends `AsyncAPIClient`, whose `.post()` / `.delete()` methods are public, route through the same JWT auth, retry, and response-hook plumbing as the typed methods, and surface the same `GumnutError` hierarchy. Don't import from `gumnut._types` — `cast_to=type(None)` works without it.
+
+Treat every such call site as temporary. The gap it works around closes silently on the next SDK bump, and nothing fails to tell you — a raw call keeps working indefinitely, so the workaround outlives its cause and its comment turns into a false claim that discourages the cleanup. When you touch a raw call site, or bump `gumnut-sdk`, check whether the typed method has landed and migrate if so. Don't write the reason as "the SDK doesn't have this *yet*" in a docstring that no one will revisit; if a comment must explain the raw call, point at what to re-check rather than asserting a fact about the SDK that expires.
 
 ### WebSocket Emission
 

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -112,6 +112,8 @@ A regen can add newly-required fields to (or retype) the generated DTOs, breakin
 
 The SDK is auto-generated (Stainless), so a version bump can add **newly-required** fields to response models (e.g. `FaceResponse.source` arrived in 0.116). Tests construct these models directly as fixtures, so a bump can break suites unrelated to the endpoint you're touching. Run the **full** `uv run pytest` after a bump (not just the changed endpoint's tests), and when a required field is added, `grep` the tests for `<Model>(` to fix every direct construction.
 
+A bump can also *close* gaps silently: grep for raw `client.post(` / `client.delete(` call sites and migrate any whose typed method has now landed (see the raw-client note under *Bulk-ID Endpoints*). Nothing fails to prompt this — a raw call keeps working forever.
+
 ### Implementing New Endpoints
 
 1. **Generate models**: Use `generate_immich_models.py` to create up-to-date Pydantic models (see [development tools](development-tools.md))

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -372,7 +372,7 @@ If you write a *new* fan-out helper instead of using `gather_with_concurrency`, 
 
 ### Bulk-ID Endpoints
 
-For Gumnut API endpoints that accept bulk IDs (e.g., `assets.trash`, `assets.restore`, `assets.delete_list`, and list filters with `ids=...`), chunk the request at `GUMNUT_API_MAX_BULK_IDS`. The SDK enforces the cap but does not chunk for you, so the loop is the caller's job. The constant in `routers/api/constants.py` is the source of truth for the current API cap:
+For Gumnut API endpoints that accept bulk IDs (e.g., `assets.trash`, `assets.restore`, `assets.delete_list`, and list filters with `ids=...`), chunk the request at `GUMNUT_API_MAX_BULK_IDS`. The Gumnut API rejects over-cap requests with a 422, and neither the API nor the SDK chunks for you, so the loop is the caller's job. The constant in `routers/api/constants.py` is the source of truth for the current API cap:
 
 ```python
 from itertools import batched
@@ -403,7 +403,7 @@ await client.post("/api/some-new-endpoint", body={"ids": gumnut_ids}, cast_to=ty
 
 `AsyncGumnut` extends `AsyncAPIClient`, whose `.post()` / `.delete()` methods are public, route through the same JWT auth, retry, and response-hook plumbing as the typed methods, and surface the same `GumnutError` hierarchy. Don't import from `gumnut._types` — `cast_to=type(None)` works without it.
 
-Treat every such call site as temporary. The gap it works around closes silently on the next SDK bump, and nothing fails to tell you — a raw call keeps working indefinitely, so the workaround outlives its cause and its comment turns into a false claim that discourages the cleanup. When you touch a raw call site, or bump `gumnut-sdk`, check whether the typed method has landed and migrate if so. Don't write the reason as "the SDK doesn't have this *yet*" in a docstring that no one will revisit; if a comment must explain the raw call, point at what to re-check rather than asserting a fact about the SDK that expires.
+The gap a raw call works around closes silently on the next SDK bump — nothing fails to tell you. So: (1) when you touch a raw call site or bump `gumnut-sdk`, check whether the typed method has landed and migrate if so; (2) if a comment must explain the raw call, point at what to re-check rather than asserting the SDK lacks the method — that claim expires.
 
 ### WebSocket Emission
 

--- a/routers/api/albums.py
+++ b/routers/api/albums.py
@@ -388,7 +388,8 @@ async def remove_asset_from_album(
 
     gumnut_album_id = uuid_to_gumnut_album_id(id)
 
-    # Upstream silently skips missing assets and 204s on success.
+    # Upstream silently skips missing assets and returns an empty
+    # acknowledgment body on success.
     errors_by_uuid: dict[UUID, BulkIdErrorReason] = {}
     async for outcome in chunked_per_item_bulk(
         request.ids,

--- a/routers/api/assets.py
+++ b/routers/api/assets.py
@@ -972,12 +972,12 @@ async def delete_assets(
     """
     Delete multiple assets, branching on the Immich `force` flag.
 
-    - ``force=True`` permanently deletes via the backend's bulk
-      ``DELETE /api/assets`` endpoint. Emits one ``on_asset_delete`` per id —
-      Immich's wire shape is single-id-per-event for permanent deletes.
+    - ``force=True`` permanently deletes via the SDK's bulk
+      ``assets.delete_list``. Emits one ``on_asset_delete`` per id — Immich's
+      wire shape is single-id-per-event for permanent deletes.
     - ``force=False`` or absent (Immich's native default) soft-deletes via the
-      backend's ``POST /api/assets/trash`` endpoint. Emits a single batched
-      ``on_asset_trash`` event per chunk carrying the full id array.
+      SDK's bulk ``assets.trash``. Emits a single batched ``on_asset_trash``
+      event per chunk carrying the full id array.
 
     The backend bulk endpoints are idempotent — already-trashed or already-purged
     rows are skipped without erroring — so the previous per-id 404 swallowing
@@ -1003,11 +1003,7 @@ async def _bulk_permanent_delete(
     """Bulk hard-delete; emits one on_asset_delete per id."""
     for chunk in batched(asset_uuids, GUMNUT_API_MAX_BULK_IDS):
         gumnut_ids = [uuid_to_gumnut_asset_id(uid) for uid in chunk]
-        await client.delete(
-            "/api/assets",
-            body={"ids": gumnut_ids},
-            cast_to=type(None),
-        )
+        await client.assets.delete_list(ids=gumnut_ids)
         await emit_user_event_per_id(
             WebSocketEvent.ASSET_DELETE,
             user_id,
@@ -1023,11 +1019,7 @@ async def _bulk_trash(
     """Bulk soft-delete; emits one batched on_asset_trash per chunk."""
     for chunk in batched(asset_uuids, GUMNUT_API_MAX_BULK_IDS):
         gumnut_ids = [uuid_to_gumnut_asset_id(uid) for uid in chunk]
-        await client.post(
-            "/api/assets/trash",
-            body={"ids": gumnut_ids},
-            cast_to=type(None),
-        )
+        await client.assets.trash(ids=gumnut_ids)
         chunk_uuid_strs = [str(uid) for uid in chunk]
         await emit_user_event(
             WebSocketEvent.ASSET_TRASH,

--- a/routers/api/trash.py
+++ b/routers/api/trash.py
@@ -1,15 +1,21 @@
 """Trash router — restore-by-ids, restore-all, and empty-trash flows.
 
-Backed by the Gumnut API trash primitives:
+Backed by the Gumnut API trash primitives, reached through the SDK's typed
+asset methods:
 
-- ``POST /api/assets/restore`` — bulk restore by ids (idempotent on already-live).
-- ``DELETE /api/assets`` (bulk body) — bulk permanent delete by ids.
-- ``GET /api/assets?state=trashed`` — paginated trashed listing for the
+- ``assets.restore`` — bulk restore by ids (idempotent on already-live).
+- ``assets.delete_list`` — bulk permanent delete by ids.
+- ``assets.list(state="trashed")`` — paginated trashed listing for the
   restore-all and empty-trash flows.
 
-The SDK does not expose typed methods for these endpoints yet, so calls go
-through ``AsyncGumnut.post`` / ``.delete`` directly. Errors propagate to the
-global ``GumnutError`` handler.
+Each bulk method caps a single request at ``GUMNUT_API_MAX_BULK_IDS`` ids, so
+the flows below chunk their id lists. Errors propagate to the global
+``GumnutError`` handler.
+
+The SDK's one-shot ``assets.empty_trash`` is deliberately unused: the
+empty-trash flow needs the enumerated id list to emit per-id delete events,
+and enumerating up front is load-bearing for cursor stability (see
+``_list_trashed_ids``).
 """
 
 from itertools import batched
@@ -50,22 +56,18 @@ async def empty_trash(
 ) -> TrashResponseDto:
     """Permanently delete every trashed asset belonging to the caller.
 
-    Enumerates the caller's trashed ids, then issues bulk
-    ``DELETE /api/assets`` calls in chunks. Emits one ``on_asset_delete`` per
-    purged id, matching Immich's wire shape (single-id-per-event for permanent
-    deletes). The returned count reflects the upfront enumerated id list;
-    between enumeration and the chunked deletes a concurrent request could
-    transition some ids, so the count can diverge slightly from rows actually
-    purged in this call. The bulk DELETE is idempotent on already-purged ids.
+    Enumerates the caller's trashed ids, then issues bulk ``assets.delete_list``
+    calls in chunks. Emits one ``on_asset_delete`` per purged id, matching
+    Immich's wire shape (single-id-per-event for permanent deletes). The
+    returned count reflects the upfront enumerated id list; between enumeration
+    and the chunked deletes a concurrent request could transition some ids, so
+    the count can diverge slightly from rows actually purged in this call. The
+    bulk delete is idempotent on already-purged ids.
     """
     user_id = str(current_user_id)
     trashed_gumnut_ids = await _list_trashed_ids(client)
     for chunk in batched(trashed_gumnut_ids, GUMNUT_API_MAX_BULK_IDS):
-        await client.delete(
-            "/api/assets",
-            body={"ids": list(chunk)},
-            cast_to=type(None),
-        )
+        await client.assets.delete_list(ids=list(chunk))
         await emit_user_event_per_id(
             WebSocketEvent.ASSET_DELETE,
             user_id,
@@ -81,22 +83,18 @@ async def restore_trash(
 ) -> TrashResponseDto:
     """Restore every trashed asset belonging to the caller.
 
-    Enumerates the caller's trashed ids, then issues bulk
-    ``POST /api/assets/restore`` calls in chunks. Emits a single batched
-    ``on_asset_restore`` event per chunk carrying the chunk's id array. The
-    returned count reflects the upfront enumerated id list; concurrent
-    transitions between enumeration and the chunked restores can make it
-    diverge slightly from rows actually restored in this call. The backend's
-    restore endpoint is idempotent on already-live ids.
+    Enumerates the caller's trashed ids, then issues bulk ``assets.restore``
+    calls in chunks. Emits a single batched ``on_asset_restore`` event per
+    chunk carrying the chunk's id array. The returned count reflects the
+    upfront enumerated id list; concurrent transitions between enumeration and
+    the chunked restores can make it diverge slightly from rows actually
+    restored in this call. The backend's restore endpoint is idempotent on
+    already-live ids.
     """
     user_id = str(current_user_id)
     trashed_gumnut_ids = await _list_trashed_ids(client)
     for chunk in batched(trashed_gumnut_ids, GUMNUT_API_MAX_BULK_IDS):
-        await client.post(
-            "/api/assets/restore",
-            body={"ids": list(chunk)},
-            cast_to=type(None),
-        )
+        await client.assets.restore(ids=list(chunk))
         chunk_uuid_strs = [str(safe_uuid_from_asset_id(gid)) for gid in chunk]
         await emit_user_event(
             WebSocketEvent.ASSET_RESTORE,
@@ -114,12 +112,12 @@ async def restore_assets(
 ) -> TrashResponseDto:
     """Restore the caller's trashed assets identified by the given ids.
 
-    Issues bulk ``POST /api/assets/restore`` calls in chunks of
+    Issues bulk ``assets.restore`` calls in chunks of
     ``GUMNUT_API_MAX_BULK_IDS``. Emits one batched ``on_asset_restore`` event
     per chunk. Already-live ids are silently skipped on the backend; the
     returned count therefore reflects the request size, not the number of
-    rows that actually transitioned (the backend's restore endpoint returns
-    204 with no count).
+    rows that actually transitioned (the backend's restore endpoint answers
+    with an empty acknowledgment body carrying no count).
     """
     if not request.ids:
         return TrashResponseDto(count=0)
@@ -127,11 +125,7 @@ async def restore_assets(
     user_id = str(current_user_id)
     for chunk in batched(request.ids, GUMNUT_API_MAX_BULK_IDS):
         gumnut_ids = [uuid_to_gumnut_asset_id(uid) for uid in chunk]
-        await client.post(
-            "/api/assets/restore",
-            body={"ids": gumnut_ids},
-            cast_to=type(None),
-        )
+        await client.assets.restore(ids=gumnut_ids)
         chunk_uuid_strs = [str(uid) for uid in chunk]
         await emit_user_event(
             WebSocketEvent.ASSET_RESTORE,

--- a/routers/api/trash.py
+++ b/routers/api/trash.py
@@ -8,9 +8,9 @@ asset methods:
 - ``assets.list(state="trashed")`` — paginated trashed listing for the
   restore-all and empty-trash flows.
 
-Each bulk method caps a single request at ``GUMNUT_API_MAX_BULK_IDS`` ids, so
-the flows below chunk their id lists. Errors propagate to the global
-``GumnutError`` handler.
+The Gumnut API caps a single bulk request at ``GUMNUT_API_MAX_BULK_IDS`` ids
+(422 over cap), so the flows below chunk their id lists. Errors propagate to
+the global ``GumnutError`` handler.
 
 The SDK's one-shot ``assets.empty_trash`` is deliberately unused: the
 empty-trash flow needs the enumerated id list to emit per-id delete events,

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -2316,17 +2316,16 @@ class TestDeleteAssets:
     """Test the delete_assets endpoint.
 
     The handler branches on ``force``: ``True`` → bulk hard-delete via
-    ``client.delete("/api/assets", body=...)`` with one ``on_asset_delete``
-    per id. ``False``/absent → bulk soft-delete via
-    ``client.post("/api/assets/trash", body=...)`` with one batched
-    ``on_asset_trash`` per chunk.
+    ``client.assets.delete_list(ids=...)`` with one ``on_asset_delete`` per id.
+    ``False``/absent → bulk soft-delete via ``client.assets.trash(ids=...)``
+    with one batched ``on_asset_trash`` per chunk.
     """
 
     @pytest.mark.anyio
     async def test_delete_assets_force_false_calls_trash_endpoint(self):
-        """force=False routes to POST /api/assets/trash with the full id list."""
+        """force=False routes to the bulk trash method with the full id list."""
         mock_client = Mock()
-        mock_client.post = AsyncMock(return_value=None)
+        mock_client.assets.trash = AsyncMock(return_value=None)
 
         asset_ids = [uuid4(), uuid4()]
         request = AssetBulkDeleteDto(ids=asset_ids, force=False)
@@ -2338,18 +2337,18 @@ class TestDeleteAssets:
             )
 
         assert result.status_code == 204
-        mock_client.post.assert_awaited_once()
-        call = mock_client.post.await_args
-        assert call.args[0] == "/api/assets/trash"
-        body = call.kwargs["body"]
-        assert set(body["ids"]) == {uuid_to_gumnut_asset_id(uid) for uid in asset_ids}
+        mock_client.assets.trash.assert_awaited_once()
+        call = mock_client.assets.trash.await_args_list[0]
+        assert set(call.kwargs["ids"]) == {
+            uuid_to_gumnut_asset_id(uid) for uid in asset_ids
+        }
 
     @pytest.mark.anyio
     async def test_delete_assets_force_absent_treated_as_soft_delete(self):
         """force omitted (Immich's native default) routes to trash, not hard-delete."""
         mock_client = Mock()
-        mock_client.post = AsyncMock(return_value=None)
-        mock_client.delete = AsyncMock(return_value=None)
+        mock_client.assets.trash = AsyncMock(return_value=None)
+        mock_client.assets.delete_list = AsyncMock(return_value=None)
 
         asset_ids = [uuid4()]
         request = AssetBulkDeleteDto(ids=asset_ids)
@@ -2361,14 +2360,14 @@ class TestDeleteAssets:
             )
 
         assert result.status_code == 204
-        mock_client.post.assert_awaited_once()
-        mock_client.delete.assert_not_awaited()
+        mock_client.assets.trash.assert_awaited_once()
+        mock_client.assets.delete_list.assert_not_awaited()
 
     @pytest.mark.anyio
     async def test_delete_assets_force_true_calls_bulk_delete_endpoint(self):
-        """force=True routes to bulk DELETE /api/assets."""
+        """force=True routes to the bulk permanent-delete method."""
         mock_client = Mock()
-        mock_client.delete = AsyncMock(return_value=None)
+        mock_client.assets.delete_list = AsyncMock(return_value=None)
 
         asset_ids = [uuid4(), uuid4()]
         request = AssetBulkDeleteDto(ids=asset_ids, force=True)
@@ -2380,17 +2379,17 @@ class TestDeleteAssets:
             )
 
         assert result.status_code == 204
-        mock_client.delete.assert_awaited_once()
-        call = mock_client.delete.await_args
-        assert call.args[0] == "/api/assets"
-        body = call.kwargs["body"]
-        assert set(body["ids"]) == {uuid_to_gumnut_asset_id(uid) for uid in asset_ids}
+        mock_client.assets.delete_list.assert_awaited_once()
+        call = mock_client.assets.delete_list.await_args_list[0]
+        assert set(call.kwargs["ids"]) == {
+            uuid_to_gumnut_asset_id(uid) for uid in asset_ids
+        }
 
     @pytest.mark.anyio
     async def test_delete_assets_force_false_emits_single_batched_trash_event(self):
         """A single bulk soft-delete fires one on_asset_trash with the full id array."""
         mock_client = Mock()
-        mock_client.post = AsyncMock(return_value=None)
+        mock_client.assets.trash = AsyncMock(return_value=None)
 
         asset_ids = [uuid4(), uuid4(), uuid4()]
         request = AssetBulkDeleteDto(ids=asset_ids, force=False)
@@ -2413,7 +2412,7 @@ class TestDeleteAssets:
     async def test_delete_assets_force_true_emits_one_delete_event_per_id(self):
         """A bulk hard-delete fires one on_asset_delete per id (single-id wire shape)."""
         mock_client = Mock()
-        mock_client.delete = AsyncMock(return_value=None)
+        mock_client.assets.delete_list = AsyncMock(return_value=None)
 
         asset_ids = [uuid4(), uuid4(), uuid4()]
         request = AssetBulkDeleteDto(ids=asset_ids, force=True)
@@ -2440,7 +2439,7 @@ class TestDeleteAssets:
     async def test_delete_assets_chunks_when_over_cap(self):
         """Request larger than the per-call cap is split into chunks."""
         mock_client = Mock()
-        mock_client.post = AsyncMock(return_value=None)
+        mock_client.assets.trash = AsyncMock(return_value=None)
 
         asset_ids = [uuid4() for _ in range(GUMNUT_API_MAX_BULK_IDS + 50)]
         request = AssetBulkDeleteDto(ids=asset_ids, force=False)
@@ -2454,9 +2453,9 @@ class TestDeleteAssets:
             )
 
         assert result.status_code == 204
-        assert mock_client.post.await_count == 2
+        assert mock_client.assets.trash.await_count == 2
         chunk_sizes = [
-            len(call.kwargs["body"]["ids"]) for call in mock_client.post.await_args_list
+            len(call.kwargs["ids"]) for call in mock_client.assets.trash.await_args_list
         ]
         assert chunk_sizes == [GUMNUT_API_MAX_BULK_IDS, 50]
         # One batched on_asset_trash per chunk.
@@ -2466,7 +2465,7 @@ class TestDeleteAssets:
     async def test_delete_assets_force_true_chunks_and_emits_per_id(self):
         """force=True over the cap chunks bulk DELETE and emits one event per id."""
         mock_client = Mock()
-        mock_client.delete = AsyncMock(return_value=None)
+        mock_client.assets.delete_list = AsyncMock(return_value=None)
 
         asset_ids = [uuid4() for _ in range(GUMNUT_API_MAX_BULK_IDS + 50)]
         request = AssetBulkDeleteDto(ids=asset_ids, force=True)
@@ -2483,10 +2482,10 @@ class TestDeleteAssets:
             )
 
         assert result.status_code == 204
-        assert mock_client.delete.await_count == 2
+        assert mock_client.assets.delete_list.await_count == 2
         chunk_sizes = [
-            len(call.kwargs["body"]["ids"])
-            for call in mock_client.delete.await_args_list
+            len(call.kwargs["ids"])
+            for call in mock_client.assets.delete_list.await_args_list
         ]
         assert chunk_sizes == [GUMNUT_API_MAX_BULK_IDS, 50]
         assert mock_emit.await_count == len(asset_ids)
@@ -2495,7 +2494,7 @@ class TestDeleteAssets:
     async def test_delete_assets_websocket_error_does_not_fail_deletion(self):
         """WebSocket emission errors must not fail the deletion."""
         mock_client = Mock()
-        mock_client.post = AsyncMock(return_value=None)
+        mock_client.assets.trash = AsyncMock(return_value=None)
 
         request = AssetBulkDeleteDto(ids=[uuid4()], force=False)
         current_user_id = uuid4()
@@ -2517,8 +2516,8 @@ class TestDeleteAssets:
     async def test_delete_assets_empty_id_list_is_noop(self):
         """An empty ids list returns 204 without calling the backend."""
         mock_client = Mock()
-        mock_client.post = AsyncMock(return_value=None)
-        mock_client.delete = AsyncMock(return_value=None)
+        mock_client.assets.trash = AsyncMock(return_value=None)
+        mock_client.assets.delete_list = AsyncMock(return_value=None)
 
         request = AssetBulkDeleteDto(ids=[], force=False)
 
@@ -2528,22 +2527,24 @@ class TestDeleteAssets:
             )
 
         assert result.status_code == 204
-        mock_client.post.assert_not_awaited()
-        mock_client.delete.assert_not_awaited()
+        mock_client.assets.trash.assert_not_awaited()
+        mock_client.assets.delete_list.assert_not_awaited()
 
     @pytest.mark.anyio
     async def test_delete_assets_force_false_propagates_sdk_error(self):
         """SDK errors on bulk-trash bubble to the global GumnutError handler.
 
-        Pins the no-swallow contract: a future refactor that wraps client.post
-        in try/except (e.g. to ignore per-id 404s the way the legacy per-id
-        loop did) must break this test.
+        Pins the no-swallow contract: a future refactor that wraps the bulk
+        trash call in try/except (e.g. to ignore per-id 404s the way the legacy
+        per-id loop did) must break this test.
         """
         from gumnut import APIStatusError
         from tests.conftest import make_sdk_status_error
 
         mock_client = Mock()
-        mock_client.post = AsyncMock(side_effect=make_sdk_status_error(500, "boom"))
+        mock_client.assets.trash = AsyncMock(
+            side_effect=make_sdk_status_error(500, "boom")
+        )
 
         request = AssetBulkDeleteDto(ids=[uuid4()], force=False)
 
@@ -2560,7 +2561,9 @@ class TestDeleteAssets:
         from tests.conftest import make_sdk_status_error
 
         mock_client = Mock()
-        mock_client.delete = AsyncMock(side_effect=make_sdk_status_error(500, "boom"))
+        mock_client.assets.delete_list = AsyncMock(
+            side_effect=make_sdk_status_error(500, "boom")
+        )
 
         request = AssetBulkDeleteDto(ids=[uuid4()], force=True)
 

--- a/tests/unit/api/test_assets.py
+++ b/tests/unit/api/test_assets.py
@@ -2463,7 +2463,7 @@ class TestDeleteAssets:
 
     @pytest.mark.anyio
     async def test_delete_assets_force_true_chunks_and_emits_per_id(self):
-        """force=True over the cap chunks bulk DELETE and emits one event per id."""
+        """force=True over the cap chunks the permanent-delete call, one event per id."""
         mock_client = Mock()
         mock_client.assets.delete_list = AsyncMock(return_value=None)
 

--- a/tests/unit/api/test_trash.py
+++ b/tests/unit/api/test_trash.py
@@ -1,7 +1,7 @@
 """Tests for the trash router (restore-by-ids, restore-all, empty-trash).
 
-The router calls the Gumnut API trash primitives directly through the
-``AsyncGumnut`` client (``client.post``, ``client.delete``,
+The router reaches the Gumnut API trash primitives through the SDK's typed
+asset methods (``client.assets.restore``, ``client.assets.delete_list``,
 ``client.assets.list(state="trashed")``). Tests mock those entry points and
 assert on the bulk call shapes, WebSocket event shapes, and returned counts.
 """
@@ -36,7 +36,7 @@ class TestRestoreAssets:
     @pytest.mark.anyio
     async def test_empty_id_list_returns_zero_without_calling_backend(self):
         mock_client = Mock()
-        mock_client.post = AsyncMock(return_value=None)
+        mock_client.assets.restore = AsyncMock(return_value=None)
 
         with patch("routers.api.trash.emit_user_event", new_callable=AsyncMock):
             result = await restore_assets(
@@ -44,12 +44,12 @@ class TestRestoreAssets:
             )
 
         assert result.count == 0
-        mock_client.post.assert_not_awaited()
+        mock_client.assets.restore.assert_not_awaited()
 
     @pytest.mark.anyio
     async def test_calls_backend_restore_with_gumnut_ids(self):
         mock_client = Mock()
-        mock_client.post = AsyncMock(return_value=None)
+        mock_client.assets.restore = AsyncMock(return_value=None)
 
         asset_ids = [uuid4(), uuid4()]
         request = BulkIdsDto(ids=asset_ids)
@@ -60,16 +60,16 @@ class TestRestoreAssets:
             )
 
         assert result.count == 2
-        mock_client.post.assert_awaited_once()
-        call = mock_client.post.await_args
-        assert call.args[0] == "/api/assets/restore"
-        body = call.kwargs["body"]
-        assert set(body["ids"]) == {uuid_to_gumnut_asset_id(uid) for uid in asset_ids}
+        mock_client.assets.restore.assert_awaited_once()
+        call = mock_client.assets.restore.await_args_list[0]
+        assert set(call.kwargs["ids"]) == {
+            uuid_to_gumnut_asset_id(uid) for uid in asset_ids
+        }
 
     @pytest.mark.anyio
     async def test_emits_single_batched_restore_event_per_chunk(self):
         mock_client = Mock()
-        mock_client.post = AsyncMock(return_value=None)
+        mock_client.assets.restore = AsyncMock(return_value=None)
 
         asset_ids = [uuid4(), uuid4(), uuid4()]
         request = BulkIdsDto(ids=asset_ids)
@@ -91,7 +91,7 @@ class TestRestoreAssets:
     @pytest.mark.anyio
     async def test_chunks_when_over_cap(self):
         mock_client = Mock()
-        mock_client.post = AsyncMock(return_value=None)
+        mock_client.assets.restore = AsyncMock(return_value=None)
 
         asset_ids = [uuid4() for _ in range(GUMNUT_API_MAX_BULK_IDS + 50)]
         request = BulkIdsDto(ids=asset_ids)
@@ -104,9 +104,10 @@ class TestRestoreAssets:
             )
 
         assert result.count == len(asset_ids)
-        assert mock_client.post.await_count == 2
+        assert mock_client.assets.restore.await_count == 2
         chunk_sizes = [
-            len(call.kwargs["body"]["ids"]) for call in mock_client.post.await_args_list
+            len(call.kwargs["ids"])
+            for call in mock_client.assets.restore.await_args_list
         ]
         assert chunk_sizes == [GUMNUT_API_MAX_BULK_IDS, 50]
         # One batched on_asset_restore event per chunk.
@@ -115,7 +116,7 @@ class TestRestoreAssets:
     @pytest.mark.anyio
     async def test_websocket_error_does_not_fail_restore(self):
         mock_client = Mock()
-        mock_client.post = AsyncMock(return_value=None)
+        mock_client.assets.restore = AsyncMock(return_value=None)
 
         request = BulkIdsDto(ids=[uuid4()])
 
@@ -143,7 +144,9 @@ class TestRestoreAssets:
         from tests.conftest import make_sdk_status_error
 
         mock_client = Mock()
-        mock_client.post = AsyncMock(side_effect=make_sdk_status_error(500, "boom"))
+        mock_client.assets.restore = AsyncMock(
+            side_effect=make_sdk_status_error(500, "boom")
+        )
 
         request = BulkIdsDto(ids=[uuid4()])
 
@@ -160,14 +163,14 @@ class TestRestoreTrash:
     @pytest.mark.anyio
     async def test_no_trashed_assets_returns_zero(self):
         mock_client = Mock()
-        mock_client.post = AsyncMock(return_value=None)
+        mock_client.assets.restore = AsyncMock(return_value=None)
         mock_client.assets.list = Mock(return_value=MockSyncCursorPage([]))
 
         with patch("routers.api.trash.emit_user_event", new_callable=AsyncMock):
             result = await restore_trash(client=mock_client, current_user_id=uuid4())
 
         assert result.count == 0
-        mock_client.post.assert_not_awaited()
+        mock_client.assets.restore.assert_not_awaited()
         mock_client.assets.list.assert_called_once_with(
             state="trashed", limit=GUMNUT_API_MAX_PAGE_SIZE
         )
@@ -175,7 +178,7 @@ class TestRestoreTrash:
     @pytest.mark.anyio
     async def test_restores_enumerated_ids_and_emits_per_chunk_event(self):
         mock_client = Mock()
-        mock_client.post = AsyncMock(return_value=None)
+        mock_client.assets.restore = AsyncMock(return_value=None)
 
         gumnut_ids = [uuid_to_gumnut_asset_id(uuid4()) for _ in range(3)]
         trashed_assets = [_make_trashed_asset_mock(gid) for gid in gumnut_ids]
@@ -190,10 +193,9 @@ class TestRestoreTrash:
             )
 
         assert result.count == 3
-        mock_client.post.assert_awaited_once()
-        call = mock_client.post.await_args
-        assert call.args[0] == "/api/assets/restore"
-        assert set(call.kwargs["body"]["ids"]) == set(gumnut_ids)
+        mock_client.assets.restore.assert_awaited_once()
+        call = mock_client.assets.restore.await_args_list[0]
+        assert set(call.kwargs["ids"]) == set(gumnut_ids)
 
         # One batched on_asset_restore event with the chunk's UUID strings.
         assert mock_emit.await_count == 1
@@ -206,7 +208,7 @@ class TestRestoreTrash:
     async def test_websocket_error_does_not_fail_restore_trash(self):
         """SocketIOError from emit must not fail the restore-all flow."""
         mock_client = Mock()
-        mock_client.post = AsyncMock(return_value=None)
+        mock_client.assets.restore = AsyncMock(return_value=None)
 
         gumnut_ids = [uuid_to_gumnut_asset_id(uuid4()) for _ in range(2)]
         trashed_assets = [_make_trashed_asset_mock(gid) for gid in gumnut_ids]
@@ -224,7 +226,7 @@ class TestRestoreTrash:
     @pytest.mark.anyio
     async def test_chunks_large_trash_lists(self):
         mock_client = Mock()
-        mock_client.post = AsyncMock(return_value=None)
+        mock_client.assets.restore = AsyncMock(return_value=None)
 
         total = GUMNUT_API_MAX_BULK_IDS * 2 + 50
         gumnut_ids = [uuid_to_gumnut_asset_id(uuid4()) for _ in range(total)]
@@ -237,9 +239,10 @@ class TestRestoreTrash:
             result = await restore_trash(client=mock_client, current_user_id=uuid4())
 
         assert result.count == total
-        assert mock_client.post.await_count == 3
+        assert mock_client.assets.restore.await_count == 3
         chunk_sizes = [
-            len(call.kwargs["body"]["ids"]) for call in mock_client.post.await_args_list
+            len(call.kwargs["ids"])
+            for call in mock_client.assets.restore.await_args_list
         ]
         assert chunk_sizes == [
             GUMNUT_API_MAX_BULK_IDS,
@@ -255,7 +258,9 @@ class TestRestoreTrash:
         from tests.conftest import make_sdk_status_error
 
         mock_client = Mock()
-        mock_client.post = AsyncMock(side_effect=make_sdk_status_error(500, "boom"))
+        mock_client.assets.restore = AsyncMock(
+            side_effect=make_sdk_status_error(500, "boom")
+        )
 
         gumnut_ids = [uuid_to_gumnut_asset_id(uuid4())]
         trashed_assets = [_make_trashed_asset_mock(gid) for gid in gumnut_ids]
@@ -272,19 +277,19 @@ class TestEmptyTrash:
     @pytest.mark.anyio
     async def test_no_trashed_assets_returns_zero(self):
         mock_client = Mock()
-        mock_client.delete = AsyncMock(return_value=None)
+        mock_client.assets.delete_list = AsyncMock(return_value=None)
         mock_client.assets.list = Mock(return_value=MockSyncCursorPage([]))
 
         with patch("routers.api.trash.emit_user_event", new_callable=AsyncMock):
             result = await empty_trash(client=mock_client, current_user_id=uuid4())
 
         assert result.count == 0
-        mock_client.delete.assert_not_awaited()
+        mock_client.assets.delete_list.assert_not_awaited()
 
     @pytest.mark.anyio
     async def test_purges_enumerated_ids_and_emits_per_id_delete_event(self):
         mock_client = Mock()
-        mock_client.delete = AsyncMock(return_value=None)
+        mock_client.assets.delete_list = AsyncMock(return_value=None)
 
         gumnut_ids = [uuid_to_gumnut_asset_id(uuid4()) for _ in range(3)]
         trashed_assets = [_make_trashed_asset_mock(gid) for gid in gumnut_ids]
@@ -302,10 +307,9 @@ class TestEmptyTrash:
             )
 
         assert result.count == 3
-        mock_client.delete.assert_awaited_once()
-        call = mock_client.delete.await_args
-        assert call.args[0] == "/api/assets"
-        assert set(call.kwargs["body"]["ids"]) == set(gumnut_ids)
+        mock_client.assets.delete_list.assert_awaited_once()
+        call = mock_client.assets.delete_list.await_args_list[0]
+        assert set(call.kwargs["ids"]) == set(gumnut_ids)
 
         # One on_asset_delete per id (Immich's wire shape for permanent deletes).
         assert mock_emit.await_count == 3
@@ -319,7 +323,7 @@ class TestEmptyTrash:
     @pytest.mark.anyio
     async def test_chunks_large_trash_lists(self):
         mock_client = Mock()
-        mock_client.delete = AsyncMock(return_value=None)
+        mock_client.assets.delete_list = AsyncMock(return_value=None)
 
         total = GUMNUT_API_MAX_BULK_IDS * 2 + 50
         gumnut_ids = [uuid_to_gumnut_asset_id(uuid4()) for _ in range(total)]
@@ -330,10 +334,10 @@ class TestEmptyTrash:
             result = await empty_trash(client=mock_client, current_user_id=uuid4())
 
         assert result.count == total
-        assert mock_client.delete.await_count == 3
+        assert mock_client.assets.delete_list.await_count == 3
         chunk_sizes = [
-            len(call.kwargs["body"]["ids"])
-            for call in mock_client.delete.await_args_list
+            len(call.kwargs["ids"])
+            for call in mock_client.assets.delete_list.await_args_list
         ]
         assert chunk_sizes == [
             GUMNUT_API_MAX_BULK_IDS,
@@ -345,7 +349,7 @@ class TestEmptyTrash:
     async def test_websocket_error_does_not_fail_empty_trash(self):
         """SocketIOError from emit must not fail the empty-trash flow."""
         mock_client = Mock()
-        mock_client.delete = AsyncMock(return_value=None)
+        mock_client.assets.delete_list = AsyncMock(return_value=None)
 
         gumnut_ids = [uuid_to_gumnut_asset_id(uuid4()) for _ in range(2)]
         trashed_assets = [_make_trashed_asset_mock(gid) for gid in gumnut_ids]
@@ -367,7 +371,9 @@ class TestEmptyTrash:
         from tests.conftest import make_sdk_status_error
 
         mock_client = Mock()
-        mock_client.delete = AsyncMock(side_effect=make_sdk_status_error(500, "boom"))
+        mock_client.assets.delete_list = AsyncMock(
+            side_effect=make_sdk_status_error(500, "boom")
+        )
 
         gumnut_ids = [uuid_to_gumnut_asset_id(uuid4())]
         trashed_assets = [_make_trashed_asset_mock(gid) for gid in gumnut_ids]


### PR DESCRIPTION
## What

- Replaces the five raw `AsyncGumnut.post()` / `.delete()` bulk call sites with the SDK's typed `assets.trash` / `assets.restore` / `assets.delete_list` — three in `routers/api/trash.py`, two in `routers/api/assets.py` (`_bulk_permanent_delete`, `_bulk_trash`).
- Rewrites the trash module docstring, which claimed the SDK exposed no typed methods for these endpoints.
- Corrects a second stale claim that rode along with the first: the upstream restore endpoint returns an empty acknowledgment body, not `204`.
- Updates the architecture and code-practices docs accordingly.

## Why

The trash router's docstring justified the raw calls with "the SDK does not expose typed methods for these endpoints yet." That was true when the router was written and stopped being true several SDK releases ago — `assets.trash`, `assets.restore`, and `assets.delete_list` are all on the async resource in the pinned version.

This is the failure mode worth naming: nothing breaks when such a gap closes. The raw call keeps working forever, so the workaround outlives its cause and its comment quietly becomes a false claim — one that actively discourages the cleanup, since a reader who trusts it concludes the raw calls are load-bearing. The migration also buys request models and type-checker coverage on the payloads.

`docs/references/code-practices.md` keeps its raw-client guidance, since the SDK genuinely does lag backend releases, but its examples are no longer live call sites, and the SDK-bump section now says to grep for raw calls whose typed method has since landed.

**Wire behavior is unchanged**: same URLs, same `{"ids": [...]}` bodies, same error hierarchy and retry config. `library_id` stays omitted from the query. The Gumnut API caps a bulk request at 200 ids and neither it nor the SDK chunks, so the `GUMNUT_API_MAX_BULK_IDS` loops are untouched.

Two behaviors were deliberately preserved and are now documented rather than incidental:

- **`assets.empty_trash` is not used.** The one-shot method would purge without ever yielding the id list, which `POST /api/trash/empty` needs to emit one `on_asset_delete` per purged id — Immich's wire shape for permanent deletes.
- **Enumerate before mutate.** `_list_trashed_ids` still runs before any mutation, so the `state="trashed"` pagination cursor stays stable while the result set shrinks.

On the `204` correction: the conclusion built on it — that returned counts are approximate — is unaffected, since the response body carries no per-row count either way. Only the stated reason was wrong. The same stale claim turned up in the remove-from-album comment and was swept.

## Test plan

- [x] `uv run ruff format` / `uv run ruff check` clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest` — 1234 passed
- [x] Typed-method URLs, body shapes, and omitted `library_id` verified against the pinned SDK
- [x] Empty-acknowledgment-body behavior verified against the backend endpoints
- [ ] Exercise trash → restore and trash → empty from the Immich web client against a live backend

Generated by an AI coding agent.