### PR TITLE
Attribute Sentry user.id at session lookup, not at user resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ The sections below follow that order, with design docs split by their `status:` 
 
 | Topic | Document | Consult when... |
 |-------|----------|-----------------|
-| Adapter architecture | `docs/architecture/adapter-architecture.md` | Overall adapter design, auth and session handling, trash/restore semantics, data translation, pagination, sync protocol, error handling, endpoint status |
+| Adapter architecture | `docs/architecture/adapter-architecture.md` | Overall adapter design, auth and session handling, request observability (Sentry tags and user attribution), trash/restore semantics, data translation, pagination, sync protocol, error handling, endpoint status |
 | Sync stream architecture | `docs/architecture/sync-stream-architecture.md` | Sync stream event processing, FK ordering, event classification, face/album handling, adding new sync type versions |
 | WebSocket implementation | `docs/architecture/websocket-implementation.md` | WebSocket connections, real-time sync, event handling |
 | Session & checkpoint implementation | `docs/architecture/session-checkpoint-implementation.md` | Session management, checkpoint tracking, sync state |

--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -79,7 +79,7 @@ For mobile, OAuth providers that don't support custom URL schemes (e.g., `app.im
 
 - **`interface` tag** — A low-cardinality Sentry tag/span attribute describing the Immich client behind the request: `immich-mobile-ios`, `immich-mobile-android`, or `immich-web`. Classification uses the mobile `deviceType` header first, falls back to `immich-ios` / `immich-android` transfer User-Agents, and treats standard browser User-Agents as web. Unrecognized callers stay unset.
 - **`user_agent.original` span attribute** — The raw `User-Agent` header is attached to the active span following the OpenTelemetry semantic convention. Because it is high-cardinality, it is emitted as a span attribute rather than a tag.
-- **Authenticated user attribution** — When a handler resolves the current user, the adapter sets Sentry `user.id` to the internal `intuser_*` id. No email or other PII is attached, and the dependency is cached per request so attribution happens once.
+- **Authenticated user attribution** — Sentry `user.id` is set to the internal `intuser_*` id; no email or other PII is attached. For session-token clients (Immich web and mobile), `AuthMiddleware` sets it from the session's stored UUID-form id as soon as Redis resolves, so read-heavy routes that never resolve a user DTO (streaming, sync, timeline buckets) are attributed too. `x-api-key` clients (immich-go) carry no session, so they are attributed only when a handler resolves the current user, via the cached `users.me()` response.
 
 ### Session storage (Redis)
 

--- a/routers/middleware/auth_middleware.py
+++ b/routers/middleware/auth_middleware.py
@@ -1,5 +1,7 @@
 import logging
+from uuid import UUID
 
+import sentry_sdk
 from fastapi import Request, Response, status
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
@@ -9,9 +11,37 @@ from routers.utils.gumnut_client import (
     get_refreshed_token,
     init_refresh_token_holder,
 )
+from routers.utils.gumnut_id_conversion import uuid_to_gumnut_user_id
 from services.session_store import get_session_store
 
 logger = logging.getLogger(__name__)
+
+
+def _set_sentry_user(session_user_id: str) -> None:
+    """Attribute the current request to a Gumnut user in Sentry.
+
+    Sessions store the user id in the UUID form Immich clients expect; Sentry
+    wants the `intuser_*` form the Gumnut API tags its own events with. The
+    conversion is a pure shortuuid re-encode, so attribution costs no backend
+    call and reaches routes that never resolve a user DTO — which is most of
+    the read-heavy traffic (streaming, sync, timeline buckets).
+
+    Id only, never email or other PII.
+
+    Non-throwing: a session whose stored user id isn't a UUID is a data problem,
+    not a reason to fail a request that has otherwise authenticated. The caller
+    wraps this in a `try` that turns anything raised into a 500.
+    """
+    try:
+        user_id = uuid_to_gumnut_user_id(UUID(session_user_id))
+    except (ValueError, TypeError):
+        logger.warning(
+            "Session user id is not a UUID; skipping Sentry attribution",
+            extra={"session_user_id": session_user_id},
+        )
+        return
+
+    sentry_sdk.set_user({"id": user_id})
 
 
 class AuthMiddleware(BaseHTTPMiddleware):
@@ -25,8 +55,11 @@ class AuthMiddleware(BaseHTTPMiddleware):
        from cookies (web) or the Authorization header (mobile)
     3. For session tokens, looks up the session in Redis and decrypts the stored
        JWT; for API keys, forwards the key straight through as the credential
-    4. Stores the resulting credential in request.state for dependency injection
-    5. Handles JWT refresh from backend by updating stored JWT in session
+    4. Attributes the request to the session's user in Sentry (see
+       `_set_sentry_user`); API keys carry no session, so those requests are
+       attributed later, by whichever route resolves the current user
+    5. Stores the resulting credential in request.state for dependency injection
+    6. Handles JWT refresh from backend by updating stored JWT in session
        (session-token clients only; API keys are non-refreshing)
     """
 
@@ -140,6 +173,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 session = await session_store.get_by_id(session_token)
 
                 if session:
+                    # Before `get_jwt()`, so a decryption failure is
+                    # attributable to the user it failed for.
+                    _set_sentry_user(session.user_id)
                     jwt_token = session.get_jwt()
                 else:
                     logger.warning(

--- a/routers/utils/current_user.py
+++ b/routers/utils/current_user.py
@@ -75,11 +75,10 @@ async def get_current_user_admin(
     # Fetch from Gumnut backend (SDK errors bubble to the global GumnutError handler)
     user = await client.users.me()
 
-    # Attribute this request to the Gumnut user in Sentry as early as the
-    # intuser_* id is known, so the active transaction and any error events
-    # group per-user. Set the intuser_* id only, never email/PII — matching how
-    # the Gumnut backend tags its own Sentry events. This dependency is cached
-    # per request, so set_user runs once when the user is first resolved.
+    # Covers `x-api-key` clients, whose credential carries no session, so
+    # AuthMiddleware can't attribute them (see `_set_sentry_user` there) and
+    # this response is the first time their user id is known. Session-token
+    # requests are already attributed; re-setting the same id is harmless.
     sentry_sdk.set_user({"id": user.id})
 
     # Map Gumnut UserResponse to Immich UserAdminResponseDto

--- a/routers/utils/gumnut_id_conversion.py
+++ b/routers/utils/gumnut_id_conversion.py
@@ -99,3 +99,8 @@ def uuid_to_gumnut_face_id(uuid_obj: UUID) -> str:
 def safe_uuid_from_user_id(user_id: str) -> UUID:
     """Convert user ID to UUID."""
     return safe_uuid_from_gumnut_id(user_id, "intuser")
+
+
+def uuid_to_gumnut_user_id(uuid_obj: UUID) -> str:
+    """Convert UUID to user ID."""
+    return uuid_to_gumnut_id(uuid_obj, "intuser")

--- a/tests/unit/middleware/test_auth_middleware.py
+++ b/tests/unit/middleware/test_auth_middleware.py
@@ -15,6 +15,10 @@ from utils.jwt_encryption import JWTEncryptionError
 
 # Test UUIDs for consistent testing
 TEST_SESSION_ID = UUID("550e8400-e29b-41d4-a716-446655440000")
+# The `intuser_*` id is hardcoded rather than computed, so these tests pin the
+# encoding instead of restating the implementation.
+TEST_USER_UUID = "550e8400-e29b-41d4-a716-446655440001"
+TEST_INTUSER_ID = "intuser_H9cNmGXLEc8NWcZzSThA9T"
 TEST_ENCRYPTED_JWT = "gAAAAABh..."  # Mock encrypted JWT
 TEST_JWT = "test.jwt.token"
 
@@ -24,7 +28,7 @@ def create_test_session(session_id: UUID = TEST_SESSION_ID) -> Session:
     now = datetime.now(timezone.utc)
     return Session(
         id=session_id,
-        user_id="user_123",
+        user_id=TEST_USER_UUID,
         library_id="lib_456",
         stored_jwt=TEST_ENCRYPTED_JWT,
         device_type="iOS",
@@ -438,6 +442,33 @@ class TestSessionLookupErrors:
             assert response.status_code == 500
             assert response.json()["message"] == "Internal server error"
 
+    def test_jwt_decryption_error_is_still_attributed(self, app_for_errors):
+        """A failure after the session resolves is still attributed to its user."""
+
+        mock_session_store = AsyncMock()
+        session = create_test_session()
+        session.get_jwt = MagicMock(side_effect=JWTEncryptionError("decryption failed"))
+        mock_session_store.get_by_id.return_value = session
+
+        async def mock_get_session_store():
+            return mock_session_store
+
+        with (
+            patch(
+                "routers.middleware.auth_middleware.get_session_store",
+                mock_get_session_store,
+            ),
+            patch(
+                "routers.middleware.auth_middleware.sentry_sdk.set_user"
+            ) as mock_set_user,
+        ):
+            client = TestClient(app_for_errors)
+            headers = {"Authorization": f"Bearer {TEST_SESSION_ID}"}
+
+            assert client.get("/api/test/protected", headers=headers).status_code == 500
+
+        mock_set_user.assert_called_once_with({"id": TEST_INTUSER_ID})
+
     def test_redis_error_returns_500(self, app_for_errors):
         """Test that Redis errors return 500."""
         mock_session_store = AsyncMock()
@@ -458,3 +489,48 @@ class TestSessionLookupErrors:
 
             assert response.status_code == 500
             assert response.json()["message"] == "Internal server error"
+
+
+class TestSentryUserAttribution:
+    """Sentry `user.id` attribution for authenticated session-token requests.
+
+    The route used here declares no current-user dependency, mirroring the
+    streaming and sync endpoints that make up most adapter traffic.
+    """
+
+    def test_authenticated_request_sets_intuser_id(self, client_with_mocks):
+        """The session's UUID-form user id is restored to its `intuser_*` form."""
+        with patch(
+            "routers.middleware.auth_middleware.sentry_sdk.set_user"
+        ) as mock_set_user:
+            headers = {"Authorization": f"Bearer {TEST_SESSION_ID}"}
+            response = client_with_mocks.get("/api/test/protected", headers=headers)
+
+        assert response.status_code == 200
+        mock_set_user.assert_called_once_with({"id": TEST_INTUSER_ID})
+
+    def test_unauthenticated_request_is_not_attributed(self, client_with_mocks):
+        """Requests with no credential stay in the genuinely-anonymous bucket."""
+        with patch(
+            "routers.middleware.auth_middleware.sentry_sdk.set_user"
+        ) as mock_set_user:
+            response = client_with_mocks.get("/api/test/protected")
+
+        assert response.status_code == 200
+        mock_set_user.assert_not_called()
+
+    def test_malformed_session_user_id_does_not_fail_the_request(
+        self, client_with_mocks, mock_session_store
+    ):
+        """A session whose user id isn't a UUID is logged, not raised."""
+        mock_session_store.get_by_id.return_value.user_id = "not-a-uuid"
+
+        with patch(
+            "routers.middleware.auth_middleware.sentry_sdk.set_user"
+        ) as mock_set_user:
+            headers = {"Authorization": f"Bearer {TEST_SESSION_ID}"}
+            response = client_with_mocks.get("/api/test/protected", headers=headers)
+
+        assert response.status_code == 200
+        assert response.json()["jwt_token"] == TEST_JWT
+        mock_set_user.assert_not_called()

--- a/tests/unit/utils/test_gumnut_id_conversion.py
+++ b/tests/unit/utils/test_gumnut_id_conversion.py
@@ -18,6 +18,7 @@ from routers.utils.gumnut_id_conversion import (
     safe_uuid_from_face_id,
     uuid_to_gumnut_face_id,
     safe_uuid_from_user_id,
+    uuid_to_gumnut_user_id,
 )
 
 
@@ -155,7 +156,7 @@ class TestConvenienceFunctions:
         test_uuid = uuid4()
 
         # UUID to user ID
-        user_id = uuid_to_gumnut_id(test_uuid, "intuser")
+        user_id = uuid_to_gumnut_user_id(test_uuid)
         assert user_id.startswith("intuser_")
 
         # User ID back to UUID


### PR DESCRIPTION
## What

- Set the Sentry user in `AuthMiddleware` as soon as the Redis session resolves, reconstructing the `intuser_*` id from the session's stored UUID form via a reversible shortuuid re-encode — no backend call, no added latency on the hot path.
- Keep the existing `set_user` call in the `get_current_user_admin` dependency: `x-api-key` clients (immich-go) carry no session, so that response is still the first point their user id is known.
- Add the missing `uuid_to_gumnut_user_id` reverse helper, completing the symmetric pair every other id prefix already has.

## Why

`sentry_sdk.set_user()` had exactly one call site: the `get_current_user*` FastAPI dependency, right after its `users.me()` call. That made `user.id` conditional on a route declaring that dependency — and the busiest routes deliberately don't, because they have no use for a user DTO and the dependency costs a backend round-trip. Their spans landed with no user at all.

Over a representative week that was most adapter traffic — all successful, authenticated, and unattributed:

| transaction | spans | declares `get_current_user*`? |
|---|---|---|
| `/api/assets/{id}/thumbnail` | 750 | no |
| `/api/sync/ack` | 280 | no |
| `/api/jobs/{name}` | 80 | no |
| `/api/sync/stream` | 50 | no |
| `/api/auth/validateToken` | 50 | no |
| `/api/faces` | 30 | no |
| `/api/notifications` | 30 | no |
| `/api/users/me/preferences` | 20 | no |
| `/api/timeline/buckets` | 20 | no |
| `/api/map/markers` | 20 | no |

For contrast, `/api/assets` and `/api/timeline/bucket` (singular) do declare the dependency and were attributed correctly. So per-user traffic counts understated real usage, and `user.id = null` could no longer be read as "unauthenticated" — most nulls were authenticated requests.

Adding the current-user dependency to those routes would have fixed the symptom by putting a `users.me()` round-trip on every thumbnail. Attributing at the session lookup instead fixes all of them at once, for free: the session already stores the user id, and the UUID conversion is lossless in both directions.

Still `user.id` only — no email, name, or IP.

## Test plan

- [x] `uv run pytest` — 1238 passed
- [x] `uv run ruff format` / `uv run ruff check` / `uv run pyright` — clean
- [x] New tests pin the positive case (session-token request on a route with no current-user dependency → exact `intuser_*` id), both negative cases (no credential → not attributed; non-UUID stored id → not attributed, request still succeeds), and the ordering guarantee (attribution happens before JWT decryption, so a decryption failure is still attributable)
- [ ] After deploy, confirm `span.op:http.server transaction:"/api/assets/{id}/thumbnail"` grouped by `user.id` returns real `intuser_*` rows

Generated by an AI coding agent.