### PR TITLE
Fix four documentation-linter false positives that can block CI on valid markdown

### DIFF
--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -335,17 +335,6 @@ def blank_noncontent(
     return "\n".join(_blank_scan(text, blank_spans, drop_comments)[0])
 
 
-def has_unterminated_comment(text: str) -> bool:
-    """Whether the doc opens an HTML comment it never closes.
-
-    Per CommonMark an unterminated `<!--` block "continues until the end of the
-    document", so everything after it renders as nothing — and therefore drops out of
-    every check. That is spec-correct but silent, so it is reported: an unclosed comment
-    is almost always an authoring slip, and it hides content from readers too.
-    """
-    return _blank_scan(text, True, False)[1]
-
-
 def _blank_scan(
     text: str, blank_spans: bool, drop_comments: bool
 ) -> tuple[list[str], bool]:
@@ -1147,13 +1136,33 @@ def parse_link_destination(line: str, i: int) -> tuple[str, int] | None:
     return None
 
 
+def scan_links(text: str) -> tuple[list[tuple[int, str]], bool]:
+    """One scan, two answers: (links worth resolving, unterminated comment found).
+
+    Both come from the same state machine, so the caller takes them together rather than
+    scanning every doc twice.
+
+    The unterminated-comment flag is worth reporting rather than tolerating: per
+    CommonMark an unclosed `<!--` block "continues until the end of the document", so
+    everything after it renders as nothing and drops out of every check. That is
+    spec-correct but silent, and an unclosed comment is almost always an authoring slip
+    that hides content from readers too.
+    """
+    lines, unterminated = _blank_scan(text, True, False)
+    return list(_iter_links_in("\n".join(lines))), unterminated
+
+
 def iter_links(text: str):
-    """Yield (line_number, target) for inline links worth resolving.
+    """Yield (line_number, target) for inline links worth resolving."""
+    return iter(scan_links(text)[0])
+
+
+def _iter_links_in(body: str):
+    """Links in already-blanked text.
 
     The label is discarded — comparing a link's label to its target is a separate
     check, deliberately out of scope here.
     """
-    body = blank_noncontent(text)
     for lineno, line in enumerate(body.split("\n"), 1):
         pos = 0
         while True:
@@ -1174,10 +1183,11 @@ def check_links_and_anchors(repo: Repo, enabled: frozenset[str]) -> list[Violati
     violations: list[Violation] = []
     for rel in repo.docs:
         text = repo.text(rel)
+        links, unterminated_comment = scan_links(text)
         if (
             "links" in enabled
             and not repo.config.ignored(rel, "links")
-            and has_unterminated_comment(text)
+            and unterminated_comment
         ):
             # Reported rather than tolerated: everything after the marker renders as
             # nothing and so drops silently out of every check below.
@@ -1189,7 +1199,7 @@ def check_links_and_anchors(repo: Repo, enabled: frozenset[str]) -> list[Violati
                     "`<!--` renders as nothing and is skipped by every check",
                 )
             )
-        for lineno, target in iter_links(text):
+        for lineno, target in links:
             if EXTERNAL_RE.match(target):
                 continue
             path_part, _, frag = target.partition("#")

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -283,12 +283,10 @@ FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})(.*)$")
 HEADING_RE = re.compile(r"^ {0,3}(#{1,6})\s+(.*?)\s*#*\s*$")
 # A complete HTML comment, possibly spanning lines. Only complete ones: blanking from an
 # unterminated `<!--` would silently swallow the rest of the file.
-HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 # A code span is delimited by a *run* of backticks and closed by a run of the same
 # length. Matching only single backticks left a ``double-backtick`` span unblanked,
 # so a link written inside one as an example was parsed as a real link and reported
 # broken — a false positive on correct content.
-CODESPAN_RE = re.compile(r"(`+)(?:(?!\1)[^\n])*?\1")
 # Only the `[label](` prefix is matched here. The destination is scanned, not matched:
 # a regex cannot balance arbitrary nesting, and each fixed-depth attempt left a real
 # form unparsed — `foo_(bar).md` truncated at the first `)` (a *false* break on a file
@@ -312,7 +310,9 @@ TABLE_ROW_RE = re.compile(r"^\|(.+)\|\s*$")
 MAP_HEADING_RE = re.compile(r"^Documentation Map$")
 
 
-def blank_noncontent(text: str, *, blank_spans: bool = True) -> str:
+def blank_noncontent(
+    text: str, *, blank_spans: bool = True, drop_comments: bool = False
+) -> str:
     """Blank fenced blocks, HTML comments, and optionally inline code spans.
 
     **One pass, because these three contexts nest and no ordering of separate passes is
@@ -332,7 +332,7 @@ def blank_noncontent(text: str, *, blank_spans: bool = True) -> str:
     (`## Setup <!-- old -->`) slugs from `Setup` as it renders. Filling would leave the
     comment's width behind as hyphens, since GitHub does not collapse whitespace runs.
     """
-    return "\n".join(_blank_scan(text, blank_spans)[0])
+    return "\n".join(_blank_scan(text, blank_spans, drop_comments)[0])
 
 
 def has_unterminated_comment(text: str) -> bool:
@@ -343,10 +343,12 @@ def has_unterminated_comment(text: str) -> bool:
     every check. That is spec-correct but silent, so it is reported: an unclosed comment
     is almost always an authoring slip, and it hides content from readers too.
     """
-    return _blank_scan(text, True)[1]
+    return _blank_scan(text, True, False)[1]
 
 
-def _blank_scan(text: str, blank_spans: bool) -> tuple[list[str], bool]:
+def _blank_scan(
+    text: str, blank_spans: bool, drop_comments: bool
+) -> tuple[list[str], bool]:
     """The scan itself. Returns (blanked lines, ended inside an open comment).
 
     Three states persist across lines, each for a reason CommonMark dictates:
@@ -366,13 +368,17 @@ def _blank_scan(text: str, blank_spans: bool) -> tuple[list[str], bool]:
     fence: str | None = None
     in_comment = False
     span: str | None = None
+    prev_blank = True
+    in_indented_code = False
     for line in text.split("\n"):
         if in_comment:
             end = line.find("-->")
             if end == -1:
                 out.append("")
                 continue
-            scanned, span, in_comment = _scan_inline(line[end + 3 :], blank_spans, None)
+            scanned, span, in_comment = _scan_inline(
+                line[end + 3 :], blank_spans, drop_comments, None
+            )
             out.append(" " * (end + 3) + scanned)
             continue
         match = FENCE_RE.match(line)
@@ -394,9 +400,22 @@ def _blank_scan(text: str, blank_spans: bool) -> tuple[list[str], bool]:
             continue
         if not line.strip():
             span = None
+            prev_blank = True
             out.append(line)
             continue
-        scanned, span, in_comment = _scan_inline(line, blank_spans, span)
+        # An indented code block (four spaces, opening after a blank line) is code, so a
+        # literal `<!--` in it opened no comment. Bounded by the blank line because
+        # indented code cannot interrupt a paragraph — without that, a four-space list
+        # continuation would be blanked and its real links lost.
+        if (prev_blank or in_indented_code) and line.startswith("    "):
+            in_indented_code = True
+            prev_blank = False
+            span = None
+            out.append("")
+            continue
+        in_indented_code = False
+        prev_blank = False
+        scanned, span, in_comment = _scan_inline(line, blank_spans, drop_comments, span)
         out.append(scanned)
     return out, in_comment
 
@@ -423,7 +442,7 @@ def _find_closing_run(line: str, run: str, start: int) -> int:
 
 
 def _scan_inline(
-    line: str, blank_spans: bool, span: str | None
+    line: str, blank_spans: bool, drop_comments: bool, span: str | None
 ) -> tuple[str, str | None, bool]:
     """Blank code spans and comments in one line.
 
@@ -465,6 +484,12 @@ def _scan_inline(
             close = line.find("-->", i + 4)
             if close == -1:
                 return "".join(out) + " " * (n - i), None, True
+            # Spaces, not removal: a comment is a token boundary. Concatenating what
+            # surrounds it invented syntax that does not render — `[x]<!--c-->(./y)`
+            # became a link, and `<!--c--> ## H` became a heading. Callers that need the
+            # heading *text* pass drop_comments and get the comment elided instead.
+            if not drop_comments:
+                out.append(" " * (close + 3 - i))
             i = close + 3
             continue
         out.append(char)
@@ -499,7 +524,14 @@ def collect_anchors(text: str) -> set[str]:
     """Every fragment a `#...` link in this file could target."""
     # Comments blanked for both scans below: a commented-out `<a id>` *or* heading
     # renders nothing, so neither defines a fragment.
+    # Two renderings of the same text, same line count, used for different questions.
+    # `body` has comments as spaces, which answers *is this line a heading* — a leading
+    # comment pushes the `#` run past the three-space bound, and CommonMark agrees that
+    # is no heading. `texts` has them elided, which answers *what is the heading text* —
+    # spaces there would land in the slug as hyphens, since GitHub does not collapse
+    # whitespace runs.
     body = blank_noncontent(text, blank_spans=False)
+    texts = blank_noncontent(text, blank_spans=False, drop_comments=True).split("\n")
     anchors: set[str] = set()
     # Code spans are blanked for the *tag* scan only: an `<a id="fake">` shown as an
     # inline-code example renders no anchor, so counting it let `[x](#fake)` pass. The
@@ -518,11 +550,12 @@ def collect_anchors(text: str) -> set[str]:
     # and never `foo-1-1`, so a valid link to it was reported broken. Slugs are ids, so
     # they cannot repeat — dedupe against the whole set.
     used: set[str] = set()
-    for line in body.split("\n"):
+    for lineno, line in enumerate(body.split("\n")):
         m = HEADING_RE.match(line)
         if not m:
             continue
-        base = slugify_heading(m.group(2))
+        elided = HEADING_RE.match(texts[lineno]) if lineno < len(texts) else None
+        base = slugify_heading((elided or m).group(2))
         if not base:
             continue
         slug, n = base, 0

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -312,42 +312,6 @@ TABLE_ROW_RE = re.compile(r"^\|(.+)\|\s*$")
 MAP_HEADING_RE = re.compile(r"^Documentation Map$")
 
 
-def blank_fenced_blocks(text: str) -> str:
-    """Replace fenced-code lines with empty ones, preserving line numbering.
-
-    Documentation about markdown syntax lives in fenced blocks; treating those
-    examples as real links is the main source of false positives.
-
-    The opening run is tracked rather than toggled on every fence-shaped line. A
-    block opened with ```` contains ``` lines as *content* — toggling on those
-    turned blanking off mid-block and exposed the rest to the link parser, so an
-    example link inside a longer fence was reported as a real broken link. A tilde
-    fence likewise cannot close a backtick one.
-    """
-    out: list[str] = []
-    fence: str | None = None
-    for line in text.split("\n"):
-        match = FENCE_RE.match(line)
-        if match:
-            run, rest = match.group(1), match.group(2)
-            if fence is None:
-                fence = run
-            elif (
-                run[0] == fence[0]
-                and len(run) >= len(fence)
-                # A closing fence carries no info string, so a same-length
-                # language-tagged line inside the block is content, not the closer.
-                and not rest.strip()
-            ):
-                fence = None
-            # Otherwise a shorter, differently-marked, or tagged run inside a block:
-            # content, blanked like the rest of it.
-            out.append("")
-            continue
-        out.append("" if fence is not None else line)
-    return "\n".join(out)
-
-
 def blank_noncontent(text: str, *, blank_spans: bool = True) -> str:
     """Blank fenced blocks, HTML comments, and optionally inline code spans.
 
@@ -383,20 +347,33 @@ def has_unterminated_comment(text: str) -> bool:
 
 
 def _blank_scan(text: str, blank_spans: bool) -> tuple[list[str], bool]:
-    """The scan itself. Returns (blanked lines, ended inside an open comment)."""
+    """The scan itself. Returns (blanked lines, ended inside an open comment).
+
+    Three states persist across lines, each for a reason CommonMark dictates:
+
+    * **fence** — a fenced block runs until a matching closing fence.
+    * **comment** — an HTML comment block runs to `-->`, across blank lines.
+    * **code span** — a span may contain line endings, but only within a paragraph, so
+      a blank line ends the paragraph and an unclosed span was literal text after all.
+      Fences are block constructs parsed before inlines, so a fence line also ends it.
+
+    Carrying none of these was a real defect rather than a nicety: a span opened on one
+    line and closed on the next left a `<!--` inside it looking like a live comment
+    opener, which both reported a spurious unterminated-comment error and swallowed the
+    links after the span.
+    """
     out: list[str] = []
     fence: str | None = None
     in_comment = False
+    span: str | None = None
     for line in text.split("\n"):
         if in_comment:
             end = line.find("-->")
             if end == -1:
                 out.append("")
                 continue
-            rest, in_comment = line[end + 3 :], False
-            scanned, opened = _scan_inline(rest, blank_spans)
-            out.append(scanned)
-            in_comment = opened
+            scanned, span, in_comment = _scan_inline(line[end + 3 :], blank_spans, None)
+            out.append(" " * (end + 3) + scanned)
             continue
         match = FENCE_RE.match(line)
         if fence is not None:
@@ -408,37 +385,78 @@ def _blank_scan(text: str, blank_spans: bool) -> tuple[list[str], bool]:
             ):
                 fence = None
             out.append("")
+            span = None
             continue
         if match:
             fence = match.group(1)
             out.append("")
+            span = None
             continue
-        scanned, in_comment = _scan_inline(line, blank_spans)
+        if not line.strip():
+            span = None
+            out.append(line)
+            continue
+        scanned, span, in_comment = _scan_inline(line, blank_spans, span)
         out.append(scanned)
     return out, in_comment
 
 
-def _scan_inline(line: str, blank_spans: bool) -> tuple[str, bool]:
-    """Blank code spans and comments in one line. Returns (line, comment left open)."""
+def _find_closing_run(line: str, run: str, start: int) -> int:
+    """Index of a backtick run of *exactly* `len(run)`, at or after `start`.
+
+    Both sides are checked. Looking only at the character after the candidate accepted
+    a suffix of a longer run — in `` `foo`` x` `` the double run cannot close a single
+    backtick span, but the second of its two backticks passed the one-sided test, so the
+    span was closed early and the code content after it was scanned as live markdown.
+    """
+    width, n = len(run), len(line)
+    i = start
+    while True:
+        at = line.find(run, i)
+        if at == -1:
+            return -1
+        if (at == 0 or line[at - 1] != "`") and (
+            at + width >= n or line[at + width] != "`"
+        ):
+            return at
+        i = at + 1
+
+
+def _scan_inline(
+    line: str, blank_spans: bool, span: str | None
+) -> tuple[str, str | None, bool]:
+    """Blank code spans and comments in one line.
+
+    Returns (line, code-span run still open, comment left open).
+    """
     out: list[str] = []
     i, n = 0, len(line)
+    if span is not None:
+        close = _find_closing_run(line, span, 0)
+        if close == -1:
+            return ("x" * n if blank_spans else line), span, False
+        end = close + len(span)
+        out.append("x" * end if blank_spans else line[:end])
+        i = end
     while i < n:
-        if line[i] == "`":
+        char = line[i]
+        # A backslash escape makes the next punctuation character literal, so `\<!--`
+        # opens no comment and ``\` `` opens no span. Both were being read as markup,
+        # each swallowing the live links after it.
+        if char == "\\" and i + 1 < n and not line[i + 1].isalnum():
+            out.append(line[i : i + 2])
+            i += 2
+            continue
+        if char == "`":
             j = i
             while j < n and line[j] == "`":
                 j += 1
             run = line[i:j]
-            close = line.find(run, j)
-            # A closing run must be exactly this long, not part of a longer one.
-            while (
-                close != -1 and close + len(run) < n and line[close + len(run)] == "`"
-            ):
-                close = line.find(run, close + 1)
+            close = _find_closing_run(line, run, j)
             if close == -1:
-                # Unterminated: not a span, so the backticks are literal text.
-                out.append(run)
-                i = j
-                continue
+                # Unclosed on this line: it may continue into the next one.
+                out.append("x" * (n - i) if blank_spans else line[i:])
+                return "".join(out), run, False
             end = close + len(run)
             out.append("x" * (end - i) if blank_spans else line[i:end])
             i = end
@@ -446,22 +464,12 @@ def _scan_inline(line: str, blank_spans: bool) -> tuple[str, bool]:
         if line.startswith("<!--", i):
             close = line.find("-->", i + 4)
             if close == -1:
-                return "".join(out), True
+                return "".join(out) + " " * (n - i), None, True
             i = close + 3
             continue
-        out.append(line[i])
+        out.append(char)
         i += 1
-    return "".join(out), False
-
-
-def blank_code_spans(text: str) -> str:
-    """Neutralize inline code spans, preserving offsets and line numbering.
-
-    Same-length filler means a link *inside* a span stops parsing (its brackets
-    are gone) while a link with a backticked *label* still parses with its target
-    intact: [`foo.md`](foo.md) -> [xxxxxxxxx](foo.md).
-    """
-    return CODESPAN_RE.sub(lambda m: "x" * len(m.group(0)), text)
+    return "".join(out), None, False
 
 
 def slugify_heading(heading: str) -> str:
@@ -1248,7 +1256,7 @@ def find_map_files(repo: Repo) -> list[str]:
     """
     out: list[str] = []
     for rel in repo.docs:
-        for line in blank_fenced_blocks(repo.text(rel)).split("\n"):
+        for line in blank_noncontent(repo.text(rel), blank_spans=False).split("\n"):
             m = HEADING_RE.match(line)
             if m and is_map_heading(m.group(2)):
                 out.append(rel)
@@ -1309,7 +1317,7 @@ def parse_map_rows(repo: Repo, map_rel: str) -> list[MapRow]:
     map_level = 0
     section = ""
     for lineno, line in enumerate(
-        blank_fenced_blocks(repo.text(map_rel)).split("\n"), 1
+        blank_noncontent(repo.text(map_rel), blank_spans=False).split("\n"), 1
     ):
         m = HEADING_RE.match(line)
         if m:

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -393,6 +393,14 @@ def _blank_scan(
             # Paragraph break: a tentative span ends here, unmatched and so literal.
             out.append(line)
             continue
+        if HEADING_RE.match(line):
+            # A heading is its own block, so inline constructs cannot span it. Grouped
+            # with the following line, an unmatched backtick in each paired up and
+            # blanked the live link between them.
+            flush()
+            chunk.append(line)
+            flush()
+            continue
         chunk.append(line)
     flush()
     return out, in_comment

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -351,36 +351,33 @@ def _blank_scan(
 ) -> tuple[list[str], bool]:
     """The scan itself. Returns (blanked lines, ended inside an open comment).
 
-    Three states persist across lines, each for a reason CommonMark dictates:
+    Fenced blocks are line-oriented, so they are handled per line. Everything else is
+    scanned a **paragraph at a time**, because a code span may contain line endings but
+    cannot cross a paragraph break. Scanning the whole paragraph means a closing run is
+    searched for across it, so an *unmatched* run needs no special case — no closer is
+    found, it is literal text, and scanning simply continues past it. Carrying a
+    tentative span line by line instead blanked the rest of the paragraph permanently,
+    silently dropping every link after a stray backtick.
 
-    * **fence** — a fenced block runs until a matching closing fence.
-    * **comment** — an HTML comment block runs to `-->`, across blank lines.
-    * **code span** — a span may contain line endings, but only within a paragraph, so
-      a blank line ends the paragraph and an unclosed span was literal text after all.
-      Fences are block constructs parsed before inlines, so a fence line also ends it.
-
-    Carrying none of these was a real defect rather than a nicety: a span opened on one
-    line and closed on the next left a `<!--` inside it looking like a live comment
-    opener, which both reported a spurious unterminated-comment error and swallowed the
-    links after the span.
+    Comment state is the one thing that persists across paragraphs: an HTML comment
+    block runs to `-->` regardless of blank lines.
     """
     out: list[str] = []
     fence: str | None = None
     in_comment = False
-    span: str | None = None
-    prev_blank = True
-    in_indented_code = False
+    chunk: list[str] = []
+
+    def flush() -> None:
+        nonlocal chunk, in_comment
+        if not chunk:
+            return
+        scanned, in_comment = _scan_chunk(
+            "\n".join(chunk), blank_spans, drop_comments, in_comment
+        )
+        out.extend(scanned.split("\n"))
+        chunk = []
+
     for line in text.split("\n"):
-        if in_comment:
-            end = line.find("-->")
-            if end == -1:
-                out.append("")
-                continue
-            scanned, span, in_comment = _scan_inline(
-                line[end + 3 :], blank_spans, drop_comments, None
-            )
-            out.append(" " * (end + 3) + scanned)
-            continue
         match = FENCE_RE.match(line)
         if fence is not None:
             if (
@@ -391,36 +388,28 @@ def _blank_scan(
             ):
                 fence = None
             out.append("")
-            span = None
             continue
-        if match:
-            fence = match.group(1)
-            out.append("")
-            span = None
-            continue
-        if not line.strip():
-            span = None
-            prev_blank = True
+        if match or not line.strip():
+            # Flush first: comment state is only settled by scanning the buffered
+            # paragraph, and a fence-shaped line *inside* an open comment is comment
+            # content, not a fence.
+            flush()
+            if in_comment:
+                chunk.append(line)
+                continue
+            if match:
+                fence = match.group(1)
+                out.append("")
+                continue
+            # Paragraph break: a tentative span ends here, unmatched and so literal.
             out.append(line)
             continue
-        # An indented code block (four spaces, opening after a blank line) is code, so a
-        # literal `<!--` in it opened no comment. Bounded by the blank line because
-        # indented code cannot interrupt a paragraph — without that, a four-space list
-        # continuation would be blanked and its real links lost.
-        if (prev_blank or in_indented_code) and line.startswith("    "):
-            in_indented_code = True
-            prev_blank = False
-            span = None
-            out.append("")
-            continue
-        in_indented_code = False
-        prev_blank = False
-        scanned, span, in_comment = _scan_inline(line, blank_spans, drop_comments, span)
-        out.append(scanned)
+        chunk.append(line)
+    flush()
     return out, in_comment
 
 
-def _find_closing_run(line: str, run: str, start: int) -> int:
+def _find_closing_run(text: str, run: str, start: int) -> int:
     """Index of a backtick run of *exactly* `len(run)`, at or after `start`.
 
     Both sides are checked. Looking only at the character after the candidate accepted
@@ -428,73 +417,86 @@ def _find_closing_run(line: str, run: str, start: int) -> int:
     backtick span, but the second of its two backticks passed the one-sided test, so the
     span was closed early and the code content after it was scanned as live markdown.
     """
-    width, n = len(run), len(line)
+    width, n = len(run), len(text)
     i = start
     while True:
-        at = line.find(run, i)
+        at = text.find(run, i)
         if at == -1:
             return -1
-        if (at == 0 or line[at - 1] != "`") and (
-            at + width >= n or line[at + width] != "`"
+        if (at == 0 or text[at - 1] != "`") and (
+            at + width >= n or text[at + width] != "`"
         ):
             return at
         i = at + 1
 
 
-def _scan_inline(
-    line: str, blank_spans: bool, drop_comments: bool, span: str | None
-) -> tuple[str, str | None, bool]:
-    """Blank code spans and comments in one line.
+def _blank_keeping_newlines(text: str, char: str) -> str:
+    """Same-length filler that leaves line breaks alone, so line numbers survive."""
+    return "".join("\n" if c == "\n" else char for c in text)
 
-    Returns (line, code-span run still open, comment left open).
+
+def _scan_chunk(
+    text: str, blank_spans: bool, drop_comments: bool, in_comment: bool
+) -> tuple[str, bool]:
+    """Blank code spans and HTML comments across one paragraph.
+
+    Returns (blanked text, comment left open).
     """
     out: list[str] = []
-    i, n = 0, len(line)
-    if span is not None:
-        close = _find_closing_run(line, span, 0)
-        if close == -1:
-            return ("x" * n if blank_spans else line), span, False
-        end = close + len(span)
-        out.append("x" * end if blank_spans else line[:end])
-        i = end
+    i, n = 0, len(text)
     while i < n:
-        char = line[i]
+        if in_comment:
+            close = text.find("-->", i)
+            if close == -1:
+                out.append(_blank_keeping_newlines(text[i:], " "))
+                return "".join(out), True
+            out.append(_blank_keeping_newlines(text[i : close + 3], " "))
+            i = close + 3
+            in_comment = False
+            continue
+        char = text[i]
         # A backslash escape makes the next punctuation character literal, so `\<!--`
-        # opens no comment and ``\` `` opens no span. Both were being read as markup,
-        # each swallowing the live links after it.
-        if char == "\\" and i + 1 < n and not line[i + 1].isalnum():
-            out.append(line[i : i + 2])
+        # opens no comment and ``\` `` opens no span.
+        if char == "\\" and i + 1 < n and not text[i + 1].isalnum():
+            out.append(text[i : i + 2])
             i += 2
             continue
         if char == "`":
             j = i
-            while j < n and line[j] == "`":
+            while j < n and text[j] == "`":
                 j += 1
-            run = line[i:j]
-            close = _find_closing_run(line, run, j)
+            run = text[i:j]
+            close = _find_closing_run(text, run, j)
             if close == -1:
-                # Unclosed on this line: it may continue into the next one.
-                out.append("x" * (n - i) if blank_spans else line[i:])
-                return "".join(out), run, False
+                # No closer in this paragraph, so the run is literal text. Emit it and
+                # keep scanning what follows — it is ordinary prose.
+                out.append(run)
+                i = j
+                continue
             end = close + len(run)
-            out.append("x" * (end - i) if blank_spans else line[i:end])
+            out.append(
+                _blank_keeping_newlines(text[i:end], "x")
+                if blank_spans
+                else text[i:end]
+            )
             i = end
             continue
-        if line.startswith("<!--", i):
-            close = line.find("-->", i + 4)
+        if text.startswith("<!--", i):
+            close = text.find("-->", i + 4)
             if close == -1:
-                return "".join(out) + " " * (n - i), None, True
+                out.append(_blank_keeping_newlines(text[i:], " "))
+                return "".join(out), True
             # Spaces, not removal: a comment is a token boundary. Concatenating what
             # surrounds it invented syntax that does not render — `[x]<!--c-->(./y)`
             # became a link, and `<!--c--> ## H` became a heading. Callers that need the
             # heading *text* pass drop_comments and get the comment elided instead.
             if not drop_comments:
-                out.append(" " * (close + 3 - i))
+                out.append(_blank_keeping_newlines(text[i : close + 3], " "))
             i = close + 3
             continue
         out.append(char)
         i += 1
-    return "".join(out), None, False
+    return "".join(out), in_comment
 
 
 def slugify_heading(heading: str) -> str:

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -271,8 +271,19 @@ class Violation:
 
 # The whole delimiter run, not just its first three characters: a fence closes only
 # on the same marker at least as long, so the run length has to be known.
-FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
-HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*#*\s*$")
+# The delimiter run plus whatever follows it. A *closing* fence may carry only
+# whitespace after the run, so a same-length language-tagged line (```` ````python ````
+# inside a ```` block) is an opener, not a closer — treating it as one ended the block
+# early and exposed the rest to the link parser.
+FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})(.*)$")
+# Up to three leading spaces, which CommonMark permits on an ATX heading. Anchored at
+# column 0, an indented heading contributed no anchor and a valid link to it was
+# reported broken. Four or more spaces is an indented code block, not a heading, so the
+# bound matters.
+HEADING_RE = re.compile(r"^ {0,3}(#{1,6})\s+(.*?)\s*#*\s*$")
+# A complete HTML comment, possibly spanning lines. Only complete ones: blanking from an
+# unterminated `<!--` would silently swallow the rest of the file.
+HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 # A code span is delimited by a *run* of backticks and closed by a run of the same
 # length. Matching only single backticks left a ``double-backtick`` span unblanked,
 # so a link written inside one as an example was parsed as a real link and reported
@@ -318,17 +329,35 @@ def blank_fenced_blocks(text: str) -> str:
     for line in text.split("\n"):
         match = FENCE_RE.match(line)
         if match:
-            run = match.group(1)
+            run, rest = match.group(1), match.group(2)
             if fence is None:
                 fence = run
-            elif run[0] == fence[0] and len(run) >= len(fence):
+            elif (
+                run[0] == fence[0]
+                and len(run) >= len(fence)
+                # A closing fence carries no info string, so a same-length
+                # language-tagged line inside the block is content, not the closer.
+                and not rest.strip()
+            ):
                 fence = None
-            # Otherwise a shorter or differently-marked run inside a block: content,
-            # blanked like the rest of it.
+            # Otherwise a shorter, differently-marked, or tagged run inside a block:
+            # content, blanked like the rest of it.
             out.append("")
             continue
         out.append("" if fence is not None else line)
     return "\n".join(out)
+
+
+def blank_html_comments(text: str) -> str:
+    """Neutralize HTML comments, preserving offsets and line numbering.
+
+    A commented-out link or heading renders nothing, so scanning it reported a target
+    that no reader can reach — a false positive on valid markdown. Newlines survive so
+    reported line numbers stay right; everything else becomes filler.
+    """
+    return HTML_COMMENT_RE.sub(
+        lambda m: "".join("\n" if c == "\n" else "x" for c in m.group(0)), text
+    )
 
 
 def blank_code_spans(text: str) -> str:
@@ -366,7 +395,9 @@ def slugify_heading(heading: str) -> str:
 
 def collect_anchors(text: str) -> set[str]:
     """Every fragment a `#...` link in this file could target."""
-    body = blank_fenced_blocks(text)
+    # Comments blanked for both scans below: a commented-out `<a id>` *or* heading
+    # renders nothing, so neither defines a fragment.
+    body = blank_fenced_blocks(blank_html_comments(text))
     anchors: set[str] = set()
     # Code spans are blanked for the *tag* scan only: an `<a id="fake">` shown as an
     # inline-code example renders no anchor, so counting it let `[x](#fake)` pass. The
@@ -378,7 +409,13 @@ def collect_anchors(text: str) -> set[str]:
         # Every id/name in the tag: `<a name="old" id="new">` defines both.
         for attr in HTML_ANCHOR_ATTR_RE.finditer(tag):
             anchors.add(attr.group(1))
-    seen: dict[str, int] = {}
+    # GitHub disambiguates a repeated slug with -1, -2, ... leaving the first bare, and
+    # the suffix must land on an id nothing else already has. Counting per base instead
+    # collides with a *literal* heading of the suffixed name: headings `Foo`, `Foo`,
+    # `Foo-1` are `foo`, `foo-1`, `foo-1-1`, but per-base counting emitted `foo-1` twice
+    # and never `foo-1-1`, so a valid link to it was reported broken. Slugs are ids, so
+    # they cannot repeat — dedupe against the whole set.
+    used: set[str] = set()
     for line in body.split("\n"):
         m = HEADING_RE.match(line)
         if not m:
@@ -386,10 +423,12 @@ def collect_anchors(text: str) -> set[str]:
         base = slugify_heading(m.group(2))
         if not base:
             continue
-        n = seen.get(base, 0)
-        seen[base] = n + 1
-        # GitHub disambiguates repeats with -1, -2, ... leaving the first bare.
-        anchors.add(base if n == 0 else f"{base}-{n}")
+        slug, n = base, 0
+        while slug in used:
+            n += 1
+            slug = f"{base}-{n}"
+        used.add(slug)
+        anchors.add(slug)
     return anchors
 
 
@@ -977,7 +1016,7 @@ def iter_links(text: str):
     The label is discarded — comparing a link's label to its target is a separate
     check, deliberately out of scope here.
     """
-    body = blank_code_spans(blank_fenced_blocks(text))
+    body = blank_code_spans(blank_fenced_blocks(blank_html_comments(text)))
     for lineno, line in enumerate(body.split("\n"), 1):
         pos = 0
         while True:

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -275,7 +275,7 @@ class Violation:
 # whitespace after the run, so a same-length language-tagged line (```` ````python ````
 # inside a ```` block) is an opener, not a closer — treating it as one ended the block
 # early and exposed the rest to the link parser.
-FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})(.*)$")
+FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})(.*)$")
 # Up to three leading spaces, which CommonMark permits on an ATX heading. Anchored at
 # column 0, an indented heading contributed no anchor and a valid link to it was
 # reported broken. Four or more spaces is an indented code block, not a heading, so the
@@ -419,6 +419,20 @@ def _find_closing_run(text: str, run: str, start: int) -> int:
         i = at + 1
 
 
+def _starts_a_line(text: str, i: int) -> bool:
+    """Whether `i` is at a line start, allowing CommonMark's ≤3 columns of indent.
+
+    This is what separates an HTML *block* comment from an inline one, and the two behave
+    differently in ways that each caused a bug: a block runs to the end of the line
+    holding `-->` (so later text on that line is raw HTML, not markdown) and persists
+    across blank lines when unclosed, while an inline comment ends at the delimiter and,
+    unclosed, is merely literal text.
+    """
+    start = text.rfind("\n", 0, i) + 1
+    prefix = text[start:i]
+    return not prefix.strip() and len(prefix.expandtabs(4)) <= 3
+
+
 def _blank_keeping_newlines(text: str, char: str) -> str:
     """Same-length filler that leaves line breaks alone, so line numbers survive."""
     return "".join("\n" if c == "\n" else char for c in text)
@@ -439,8 +453,12 @@ def _scan_chunk(
             if close == -1:
                 out.append(_blank_keeping_newlines(text[i:], " "))
                 return "".join(out), True
-            out.append(_blank_keeping_newlines(text[i : close + 3], " "))
-            i = close + 3
+            # Only a block comment can be open across chunks, and a block runs to the end
+            # of its closing line.
+            line_end = text.find("\n", close + 3)
+            end = len(text) if line_end == -1 else line_end
+            out.append(_blank_keeping_newlines(text[i:end], " "))
+            i = end
             in_comment = False
             continue
         char = text[i]
@@ -471,17 +489,33 @@ def _scan_chunk(
             i = end
             continue
         if text.startswith("<!--", i):
+            block = _starts_a_line(text, i)
             close = text.find("-->", i + 4)
             if close == -1:
+                if not block:
+                    # An *inline* raw-HTML comment must be complete to be one. Unclosed,
+                    # it is literal text — so it must not carry across the paragraph, or
+                    # a later `-->` would blank every live link in between.
+                    out.append(text[i : i + 4])
+                    i += 4
+                    continue
                 out.append(_blank_keeping_newlines(text[i:], " "))
                 return "".join(out), True
+            # A comment that starts a line is an HTML *block*, and the block runs to the
+            # end of the line holding `-->` — so markdown-looking text later on that line
+            # is raw HTML, not a link. An inline comment ends at the delimiter, and the
+            # rest of its line really is markdown.
+            end = close + 3
+            if block:
+                line_end = text.find("\n", end)
+                end = len(text) if line_end == -1 else line_end
             # Spaces, not removal: a comment is a token boundary. Concatenating what
             # surrounds it invented syntax that does not render — `[x]<!--c-->(./y)`
             # became a link, and `<!--c--> ## H` became a heading. Callers that need the
             # heading *text* pass drop_comments and get the comment elided instead.
             if not drop_comments:
-                out.append(_blank_keeping_newlines(text[i : close + 3], " "))
-            i = close + 3
+                out.append(_blank_keeping_newlines(text[i:end], " "))
+            i = end
             continue
         out.append(char)
         i += 1

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -498,7 +498,13 @@ def _scan_chunk(
             continue
         if text.startswith("<!--", i):
             block = _starts_a_line(text, i)
-            close = text.find("-->", i + 4)
+            # `<!-->` and `<!--->` are complete empty comments, and their terminator
+            # overlaps the opener — searching for `-->` past the fourth character finds
+            # neither, so both were read as unterminated.
+            short = next(
+                (f for f in ("<!--->", "<!-->") if text.startswith(f, i)), None
+            )
+            close = i + len(short) - 3 if short else text.find("-->", i + 4)
             if close == -1:
                 if not block:
                     # An *inline* raw-HTML comment must be complete to be one. Unclosed,
@@ -521,7 +527,13 @@ def _scan_chunk(
             # surrounds it invented syntax that does not render — `[x]<!--c-->(./y)`
             # became a link, and `<!--c--> ## H` became a heading. Callers that need the
             # heading *text* pass drop_comments and get the comment elided instead.
-            if not drop_comments:
+            if drop_comments:
+                # Elide the comment's characters but keep its line breaks: the caller
+                # indexes this rendering by line number against the space-filled one, and
+                # dropping newlines desynced them — a heading then took its text from a
+                # later line, producing wrong slugs and invented duplicate suffixes.
+                out.append("\n" * text.count("\n", i, end))
+            else:
                 out.append(_blank_keeping_newlines(text[i:end], " "))
             i = end
             continue

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -348,16 +348,110 @@ def blank_fenced_blocks(text: str) -> str:
     return "\n".join(out)
 
 
-def blank_html_comments(text: str) -> str:
-    """Neutralize HTML comments, preserving offsets and line numbering.
+def blank_noncontent(text: str, *, blank_spans: bool = True) -> str:
+    """Blank fenced blocks, HTML comments, and optionally inline code spans.
 
-    A commented-out link or heading renders nothing, so scanning it reported a target
-    that no reader can reach — a false positive on valid markdown. Newlines survive so
-    reported line numbers stay right; everything else becomes filler.
+    **One pass, because these three contexts nest and no ordering of separate passes is
+    correct.** Blanking comments first let a `<!--` shown as code pair with a later real
+    `-->` and erase the live links between them (a silent miss); blanking fences first
+    let a ``` inside a genuine comment open a spurious fence (also a silent miss). Here
+    whichever construct opens first wins, which is what a Markdown renderer does.
+
+    Line count is always preserved so reported line numbers stay right.
+
+    `blank_spans` controls only whether a code span's *content* is replaced; spans are
+    recognized either way, since that recognition is what stops a code literal from
+    being read as a comment. Callers that slug headings pass False, because
+    `slugify_heading` strips backticks itself and filler would corrupt the slug.
+
+    Comments are **removed** rather than filled, so a heading sharing a line with one
+    (`## Setup <!-- old -->`) slugs from `Setup` as it renders. Filling would leave the
+    comment's width behind as hyphens, since GitHub does not collapse whitespace runs.
     """
-    return HTML_COMMENT_RE.sub(
-        lambda m: "".join("\n" if c == "\n" else "x" for c in m.group(0)), text
-    )
+    return "\n".join(_blank_scan(text, blank_spans)[0])
+
+
+def has_unterminated_comment(text: str) -> bool:
+    """Whether the doc opens an HTML comment it never closes.
+
+    Per CommonMark an unterminated `<!--` block "continues until the end of the
+    document", so everything after it renders as nothing — and therefore drops out of
+    every check. That is spec-correct but silent, so it is reported: an unclosed comment
+    is almost always an authoring slip, and it hides content from readers too.
+    """
+    return _blank_scan(text, True)[1]
+
+
+def _blank_scan(text: str, blank_spans: bool) -> tuple[list[str], bool]:
+    """The scan itself. Returns (blanked lines, ended inside an open comment)."""
+    out: list[str] = []
+    fence: str | None = None
+    in_comment = False
+    for line in text.split("\n"):
+        if in_comment:
+            end = line.find("-->")
+            if end == -1:
+                out.append("")
+                continue
+            rest, in_comment = line[end + 3 :], False
+            scanned, opened = _scan_inline(rest, blank_spans)
+            out.append(scanned)
+            in_comment = opened
+            continue
+        match = FENCE_RE.match(line)
+        if fence is not None:
+            if (
+                match
+                and match.group(1)[0] == fence[0]
+                and len(match.group(1)) >= len(fence)
+                and not match.group(2).strip()
+            ):
+                fence = None
+            out.append("")
+            continue
+        if match:
+            fence = match.group(1)
+            out.append("")
+            continue
+        scanned, in_comment = _scan_inline(line, blank_spans)
+        out.append(scanned)
+    return out, in_comment
+
+
+def _scan_inline(line: str, blank_spans: bool) -> tuple[str, bool]:
+    """Blank code spans and comments in one line. Returns (line, comment left open)."""
+    out: list[str] = []
+    i, n = 0, len(line)
+    while i < n:
+        if line[i] == "`":
+            j = i
+            while j < n and line[j] == "`":
+                j += 1
+            run = line[i:j]
+            close = line.find(run, j)
+            # A closing run must be exactly this long, not part of a longer one.
+            while (
+                close != -1 and close + len(run) < n and line[close + len(run)] == "`"
+            ):
+                close = line.find(run, close + 1)
+            if close == -1:
+                # Unterminated: not a span, so the backticks are literal text.
+                out.append(run)
+                i = j
+                continue
+            end = close + len(run)
+            out.append("x" * (end - i) if blank_spans else line[i:end])
+            i = end
+            continue
+        if line.startswith("<!--", i):
+            close = line.find("-->", i + 4)
+            if close == -1:
+                return "".join(out), True
+            i = close + 3
+            continue
+        out.append(line[i])
+        i += 1
+    return "".join(out), False
 
 
 def blank_code_spans(text: str) -> str:
@@ -397,7 +491,7 @@ def collect_anchors(text: str) -> set[str]:
     """Every fragment a `#...` link in this file could target."""
     # Comments blanked for both scans below: a commented-out `<a id>` *or* heading
     # renders nothing, so neither defines a fragment.
-    body = blank_fenced_blocks(blank_html_comments(text))
+    body = blank_noncontent(text, blank_spans=False)
     anchors: set[str] = set()
     # Code spans are blanked for the *tag* scan only: an `<a id="fake">` shown as an
     # inline-code example renders no anchor, so counting it let `[x](#fake)` pass. The
@@ -405,7 +499,7 @@ def collect_anchors(text: str) -> set[str]:
     # `slugify_heading` strips the backticks itself — slugging blanked text would turn
     # `## The \`foo\` helper` into `the-xxxxx-helper` and break every heading anchor
     # containing inline code.
-    for tag in HTML_ANCHOR_TAG_RE.findall(blank_code_spans(body)):
+    for tag in HTML_ANCHOR_TAG_RE.findall(blank_noncontent(text)):
         # Every id/name in the tag: `<a name="old" id="new">` defines both.
         for attr in HTML_ANCHOR_ATTR_RE.finditer(tag):
             anchors.add(attr.group(1))
@@ -1016,7 +1110,7 @@ def iter_links(text: str):
     The label is discarded — comparing a link's label to its target is a separate
     check, deliberately out of scope here.
     """
-    body = blank_code_spans(blank_fenced_blocks(blank_html_comments(text)))
+    body = blank_noncontent(text)
     for lineno, line in enumerate(body.split("\n"), 1):
         pos = 0
         while True:
@@ -1037,6 +1131,21 @@ def check_links_and_anchors(repo: Repo, enabled: frozenset[str]) -> list[Violati
     violations: list[Violation] = []
     for rel in repo.docs:
         text = repo.text(rel)
+        if (
+            "links" in enabled
+            and not repo.config.ignored(rel, "links")
+            and has_unterminated_comment(text)
+        ):
+            # Reported rather than tolerated: everything after the marker renders as
+            # nothing and so drops silently out of every check below.
+            violations.append(
+                Violation(
+                    "links",
+                    rel,
+                    "an HTML comment is opened but never closed; everything after "
+                    "`<!--` renders as nothing and is skipped by every check",
+                )
+            )
         for lineno, target in iter_links(text):
             if EXTERNAL_RE.match(target):
                 continue

--- a/tests/test_lint_docs.py
+++ b/tests/test_lint_docs.py
@@ -22,8 +22,7 @@ from pathlib import Path
 import pytest
 
 from lint_docs import (
-    blank_code_spans,
-    blank_fenced_blocks,
+    blank_noncontent,
     bump_date_line,
     collect_anchors,
     has_last_updated_key,
@@ -1343,6 +1342,97 @@ def test_unterminated_comment_is_reported(repo: FixtureRepo) -> None:
     assert "never closed" in result.stderr
 
 
+def test_escaped_comment_opener_is_not_a_comment(repo: FixtureRepo) -> None:
+    r"""`\<!--` renders the delimiter as text, so the links after it stay live.
+
+    Treating it as an opener swallowed them — a silent miss.
+    """
+    repo.write_doc(
+        "docs/references/a.md",
+        TODAY,
+        r"Write \<!-- then [x](./gone.md) and --> to comment out.",
+    )
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
+
+
+def test_escaped_backtick_does_not_open_a_span(repo: FixtureRepo) -> None:
+    r"""Same rule for ``\```: an escaped delimiter is literal text."""
+    repo.write_doc("docs/references/a.md", TODAY, r"\`not a span [x](./gone.md)")
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
+
+
+def test_code_span_may_cross_a_line_break(repo: FixtureRepo) -> None:
+    """CommonMark spans may contain line endings.
+
+    Scanning each line independently made a span opened on one line and closed on the
+    next look like literal backticks, so a `<!--` inside it opened a comment: a spurious
+    unterminated-comment error *and* the links after the span swallowed.
+    """
+    repo.write_doc(
+        "docs/references/a.md",
+        TODAY,
+        "Write `example\n<!-- draft\ntext` and it is code.",
+    )
+    repo.commit_all()
+    assert repo.lint("--check", "links").returncode == 0
+
+
+def test_link_after_a_multiline_span_is_still_checked(repo: FixtureRepo) -> None:
+    """Carrying span state must not blank past the span's close."""
+    repo.write_doc("docs/references/a.md", TODAY, "`a\nb` then [x](./gone.md).")
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
+
+
+def test_blank_line_ends_an_unclosed_span(repo: FixtureRepo) -> None:
+    """A span cannot cross a paragraph break, so the backtick was literal.
+
+    Without this bound, one stray backtick would blank the rest of the file.
+    """
+    repo.write_doc("docs/references/a.md", TODAY, "`unclosed\n\nThen [x](./gone.md).")
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
+
+
+def test_longer_backtick_run_cannot_close_a_shorter_span(
+    repo: FixtureRepo,
+) -> None:
+    """A closing run must be exactly the opener's length, checked on both sides.
+
+    Testing only the character *after* a candidate accepted a suffix of a longer run, so
+    the span closed early and its code content was scanned as live markdown — failing a
+    required check on valid input.
+    """
+    repo.write_doc("docs/references/a.md", TODAY, "`foo`` [x](./gone.md)`")
+    repo.commit_all()
+    assert repo.lint("--check", "links").returncode == 0
+
+
+def test_commented_out_map_row_is_not_validated(repo: FixtureRepo) -> None:
+    """A row inside an HTML comment renders nothing, so it routes no one.
+
+    Map parsing previously blanked only fenced blocks.
+    """
+    repo.write(
+        "AGENTS.md",
+        _map("References", "| T | `docs/references/a.md` | why |\n")
+        + "<!-- | Old | `docs/references/gone.md` | why | -->\n",
+    )
+    repo.write_doc("docs/references/a.md", TODAY, "body")
+    repo.commit_all()
+    assert repo.lint("--check", "map_paths").returncode == 0
+
+
 def test_comment_delimiter_shown_as_code_is_not_a_comment(repo: FixtureRepo) -> None:
     """A `<!--` displayed as code must not pair with a later real `-->`.
 
@@ -2016,13 +2106,13 @@ def test_bump_date_line_preserves_indentation() -> None:
     assert "  last-updated: 2026-01-01" in bump_date_line(text, "2026-01-01")
 
 
-def test_blank_fenced_blocks_preserves_line_count() -> None:
+def test_blanking_preserves_line_count() -> None:
     text = "a\n```\nb\n```\nc\n"
-    assert len(blank_fenced_blocks(text).split("\n")) == len(text.split("\n"))
+    assert len(blank_noncontent(text).split("\n")) == len(text.split("\n"))
 
 
-def test_blank_code_spans_preserves_offsets() -> None:
+def test_blanking_preserves_offsets() -> None:
     text = "see `[x](y.md)` here"
-    blanked = blank_code_spans(text)
+    blanked = blank_noncontent(text)
     assert len(blanked) == len(text)
     assert "[x](y.md)" not in blanked

--- a/tests/test_lint_docs.py
+++ b/tests/test_lint_docs.py
@@ -1327,13 +1327,12 @@ def test_link_after_a_comment_is_still_checked(repo: FixtureRepo) -> None:
     assert "gone.md" in result.stderr
 
 
-def test_unterminated_comment_marker_does_not_swallow_the_file(
-    repo: FixtureRepo,
-) -> None:
-    """Only complete comments are blanked.
+def test_unterminated_comment_is_reported(repo: FixtureRepo) -> None:
+    """Per CommonMark an unclosed `<!--` block runs to the end of the document.
 
-    Blanking from a bare `<!--` to EOF would silently drop every later link from the
-    scan — trading a false positive for a silent miss.
+    So everything after it renders as nothing and drops out of every check. That is
+    spec-correct but silent, so the unclosed marker itself is reported — an authoring
+    slip that hides content from readers should not also hide it from the linter.
     """
     repo.write_doc(
         "docs/references/a.md", TODAY, "A stray <!-- marker\n\nThen [x](./gone.md)."
@@ -1341,7 +1340,78 @@ def test_unterminated_comment_marker_does_not_swallow_the_file(
     repo.commit_all()
     result = repo.lint("--check", "links")
     assert result.returncode == 1
+    assert "never closed" in result.stderr
+
+
+def test_comment_delimiter_shown_as_code_is_not_a_comment(repo: FixtureRepo) -> None:
+    """A `<!--` displayed as code must not pair with a later real `-->`.
+
+    Blanking comments as a separate earlier pass let it do exactly that, erasing the
+    live links in between — a silent miss, and the worst outcome available.
+    """
+    repo.write_doc(
+        "docs/references/a.md",
+        TODAY,
+        "Write `<!--` then [x](./gone.md) and `-->` to comment out.",
+    )
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
     assert "gone.md" in result.stderr
+
+
+def test_comment_delimiter_in_a_fence_does_not_reach_outside(
+    repo: FixtureRepo,
+) -> None:
+    """Same defect across a fenced example rather than an inline span."""
+    repo.write_doc(
+        "docs/references/a.md",
+        TODAY,
+        "```\n<!--\n```\n\nThen [x](./gone.md).\n\n-->\n",
+    )
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
+
+
+def test_fence_inside_a_real_comment_does_not_open_a_fence(
+    repo: FixtureRepo,
+) -> None:
+    """The other ordering has the mirror bug, which is why this is one pass.
+
+    Blanking fences first would let a ``` inside a genuine comment open a block and
+    swallow the real prose after it.
+    """
+    repo.write_doc(
+        "docs/references/a.md", TODAY, "<!--\n```\n-->\n\nThen [x](./gone.md)."
+    )
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("heading", "fragment"),
+    [
+        ("## Setup <!-- old -->", "#setup"),
+        ("## Foo <!-- n --> Bar", "#foo--bar"),
+    ],
+    ids=["trailing", "mid-heading"],
+)
+def test_heading_sharing_a_line_with_a_comment_slugs_as_rendered(
+    repo: FixtureRepo, heading: str, fragment: str
+) -> None:
+    """The comment is removed, not filled.
+
+    Offset-preserving filler left the comment's width in the heading text, so the slug
+    carried filler characters (or, with spaces, its width in hyphens — GitHub does not
+    collapse whitespace runs). Either way a link to the rendered id was rejected.
+    """
+    repo.write_doc("docs/references/a.md", TODAY, f"{heading}\n\n[x]({fragment})")
+    repo.commit_all()
+    assert repo.lint("--check", "anchors").returncode == 0, heading
 
 
 @pytest.mark.parametrize("indent", ["", " ", "  ", "   "], ids=["0", "1", "2", "3"])

--- a/tests/test_lint_docs.py
+++ b/tests/test_lint_docs.py
@@ -1342,6 +1342,63 @@ def test_unterminated_comment_is_reported(repo: FixtureRepo) -> None:
     assert "never closed" in result.stderr
 
 
+def test_comment_between_link_tokens_is_a_boundary(repo: FixtureRepo) -> None:
+    """A comment separates tokens; eliding it invented link syntax.
+
+    `[x]<!-- c -->(./y)` is not a link — `]` and `(` are not adjacent in the source — so
+    reporting its target rejected valid markdown.
+    """
+    repo.write_doc(
+        "docs/references/a.md", TODAY, "See [x]<!-- note -->(./missing.md) here."
+    )
+    repo.commit_all()
+    assert repo.lint("--check", "links").returncode == 0
+
+
+def test_comment_before_a_hash_run_is_not_a_heading(repo: FixtureRepo) -> None:
+    """A line starting with raw HTML is not a heading, whatever follows.
+
+    Eliding the comment made `<!-- c --> ## Hidden` look like one, so a broken
+    `#hidden` fragment would have passed — a silent miss.
+    """
+    repo.write_doc(
+        "docs/references/a.md", TODAY, "<!-- note --> ## Hidden\n\n[x](#hidden)"
+    )
+    repo.commit_all()
+    result = repo.lint("--check", "anchors")
+    assert result.returncode == 1
+    assert "hidden" in result.stderr
+
+
+def test_indented_code_block_is_not_scanned_for_comments(repo: FixtureRepo) -> None:
+    """Four-space indented code showing a literal `<!--` opens no comment.
+
+    Otherwise documentation demonstrating the delimiter failed the required check.
+    """
+    repo.write_doc(
+        "docs/references/a.md",
+        TODAY,
+        "An example:\n\n    <!--\n    commented out\n\nBack to prose.",
+    )
+    repo.commit_all()
+    assert repo.lint("--check", "links").returncode == 0
+
+
+def test_list_continuation_is_not_treated_as_indented_code(
+    repo: FixtureRepo,
+) -> None:
+    """Indented code cannot interrupt a paragraph, so a continuation keeps its links.
+
+    Without the after-a-blank-line bound this would be blanked and its broken link
+    missed — trading a false positive for a silent miss.
+    """
+    repo.write_doc("docs/references/a.md", TODAY, "- item\n    see [x](./gone.md) here")
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
+
+
 def test_escaped_comment_opener_is_not_a_comment(repo: FixtureRepo) -> None:
     r"""`\<!--` renders the delimiter as text, so the links after it stay live.
 

--- a/tests/test_lint_docs.py
+++ b/tests/test_lint_docs.py
@@ -1267,6 +1267,120 @@ def test_cross_reference_alongside_an_owning_row_is_fine(repo: FixtureRepo) -> N
     assert repo.lint("--check", "map_paths").returncode == 0
 
 
+def test_language_tagged_fence_does_not_close_a_same_length_block(
+    repo: FixtureRepo,
+) -> None:
+    """A closing fence carries no info string.
+
+    Accepting any suffix meant `````python`` closed a same-length ```` block, ending it
+    early and exposing the rest to the link parser — so documentation demonstrating a
+    language-tagged fence failed a now-required check.
+    """
+    repo.write_doc(
+        "docs/references/a.md",
+        TODAY,
+        "````\nouter\n````python\n[x](./gone.md)\n````\n",
+    )
+    repo.commit_all()
+    assert repo.lint("--check", "links").returncode == 0
+
+
+def test_untagged_same_length_fence_still_closes(repo: FixtureRepo) -> None:
+    """The whitespace rule must not stop a real closer from closing."""
+    repo.write_doc(
+        "docs/references/a.md", TODAY, "````\nin code\n````   \n\nReal [x](./gone.md)."
+    )
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
+
+
+def test_commented_out_link_is_ignored(repo: FixtureRepo) -> None:
+    """An HTML-commented link renders nothing, so its target is unreachable anyway."""
+    repo.write_doc(
+        "docs/references/a.md", TODAY, "<!-- [draft](./missing.md) -->\n\nText."
+    )
+    repo.commit_all()
+    assert repo.lint("--check", "links").returncode == 0
+
+
+def test_commented_out_anchor_and_heading_define_nothing(repo: FixtureRepo) -> None:
+    """Neither a commented `<a id>` nor a commented heading is rendered."""
+    repo.write_doc(
+        "docs/references/a.md",
+        TODAY,
+        '<!-- <a id="fake"></a>\n## Hidden -->\n\n[x](#fake)',
+    )
+    repo.commit_all()
+    result = repo.lint("--check", "anchors")
+    assert result.returncode == 1
+    assert "fake" in result.stderr
+
+
+def test_link_after_a_comment_is_still_checked(repo: FixtureRepo) -> None:
+    """Blanking must end at `-->`, not run to the end of the file."""
+    repo.write_doc("docs/references/a.md", TODAY, "<!-- note --> then [x](./gone.md).")
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
+
+
+def test_unterminated_comment_marker_does_not_swallow_the_file(
+    repo: FixtureRepo,
+) -> None:
+    """Only complete comments are blanked.
+
+    Blanking from a bare `<!--` to EOF would silently drop every later link from the
+    scan — trading a false positive for a silent miss.
+    """
+    repo.write_doc(
+        "docs/references/a.md", TODAY, "A stray <!-- marker\n\nThen [x](./gone.md)."
+    )
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
+
+
+@pytest.mark.parametrize("indent", ["", " ", "  ", "   "], ids=["0", "1", "2", "3"])
+def test_indented_heading_still_defines_its_anchor(
+    repo: FixtureRepo, indent: str
+) -> None:
+    """CommonMark permits up to three spaces before an ATX heading."""
+    repo.write_doc("docs/references/a.md", TODAY, f"{indent}## Setup\n\n[x](#setup)")
+    repo.commit_all()
+    assert repo.lint("--check", "anchors").returncode == 0, f"indent={len(indent)}"
+
+
+def test_four_space_indent_is_a_code_block_not_a_heading(repo: FixtureRepo) -> None:
+    """Four spaces is an indented code block, so it defines no anchor."""
+    repo.write_doc("docs/references/a.md", TODAY, "    ## Setup\n\n[x](#setup)")
+    repo.commit_all()
+    result = repo.lint("--check", "anchors")
+    assert result.returncode == 1
+    assert "setup" in result.stderr
+
+
+def test_slug_suffix_avoids_a_literal_heading_of_that_name(
+    repo: FixtureRepo,
+) -> None:
+    """A generated suffix must not collide with a heading that already slugs to it.
+
+    Headings `Foo`, `Foo`, `Foo-1` render as `foo`, `foo-1`, `foo-1-1`. Counting per
+    base emitted `foo-1` twice — impossible for HTML ids — and never `foo-1-1`, so a
+    valid link to the third heading was reported broken.
+    """
+    repo.write_doc(
+        "docs/references/a.md",
+        TODAY,
+        "# Foo\n\n# Foo\n\n# Foo-1\n\n[a](#foo) [b](#foo-1) [c](#foo-1-1)",
+    )
+    repo.commit_all()
+    assert repo.lint("--check", "anchors").returncode == 0
+
+
 def test_multi_backtick_code_span_is_blanked(repo: FixtureRepo) -> None:
     """A code span is closed by a run of the same length as its opener.
 

--- a/tests/test_lint_docs.py
+++ b/tests/test_lint_docs.py
@@ -1370,18 +1370,95 @@ def test_comment_before_a_hash_run_is_not_a_heading(repo: FixtureRepo) -> None:
     assert "hidden" in result.stderr
 
 
-def test_indented_code_block_is_not_scanned_for_comments(repo: FixtureRepo) -> None:
-    """Four-space indented code showing a literal `<!--` opens no comment.
+def test_indented_code_is_not_special_cased(repo: FixtureRepo) -> None:
+    """Indented code blocks are deliberately *not* detected.
 
-    Otherwise documentation demonstrating the delimiter failed the required check.
+    Detecting them needs list-container tracking — indentation is relative to the
+    enclosing list marker, so a four-space line inside a list item is a paragraph, not
+    code. Getting that wrong blanks live prose and silently drops its links, which is
+    worse than what the detection bought: across all three repos, zero indented-code
+    lines contain a comment delimiter, and zero contain links. So a delimiter shown in an
+    *indented* example is read as markup, and a fenced example is the supported form.
+
+    This test pins the trade rather than the ideal, so a future change that adds
+    detection has to confront the list-indentation problem rather than rediscover it.
     """
     repo.write_doc(
         "docs/references/a.md",
         TODAY,
-        "An example:\n\n    <!--\n    commented out\n\nBack to prose.",
+        "An example:\n\n    <!-- shown as indented code\n\nBack to prose.",
+    )
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "never closed" in result.stderr
+
+
+def test_fenced_example_is_the_supported_form_for_delimiters(
+    repo: FixtureRepo,
+) -> None:
+    """The form documentation should use, and the one that works."""
+    repo.write_doc(
+        "docs/references/a.md",
+        TODAY,
+        "An example:\n\n```\n<!-- shown in a fence\n```\n\nBack to prose.",
     )
     repo.commit_all()
     assert repo.lint("--check", "links").returncode == 0
+
+
+def test_list_item_paragraph_keeps_its_links(repo: FixtureRepo) -> None:
+    """Four-space indent inside a list item is list content, not code.
+
+    This is what indented-code detection got wrong, and why it was removed rather than
+    extended: the link here is live and its broken target must be reported.
+    """
+    repo.write_doc(
+        "docs/references/a.md", TODAY, "- item\n\n    see [x](./gone.md) here"
+    )
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
+
+
+def test_unmatched_backtick_leaves_following_links_live(repo: FixtureRepo) -> None:
+    """An unclosed run is literal text, so the links after it still render.
+
+    Carrying a tentative span line by line blanked the rest of the paragraph
+    permanently, so one stray backtick silently dropped every link after it.
+    """
+    repo.write_doc(
+        "docs/references/a.md", TODAY, "Before ` typo then [x](./gone.md) here."
+    )
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
+
+
+def test_unmatched_backtick_across_lines_leaves_links_live(
+    repo: FixtureRepo,
+) -> None:
+    """Same, where the stray run and the link are on different lines."""
+    repo.write_doc(
+        "docs/references/a.md", TODAY, "Before ` typo\nthen [x](./gone.md) here."
+    )
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
+
+
+def test_three_space_indent_is_still_prose(repo: FixtureRepo) -> None:
+    """Under four columns is not code, so its links stay in scope."""
+    repo.write_doc(
+        "docs/references/a.md", TODAY, "Prose:\n\n   see [x](./gone.md) here"
+    )
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
 
 
 def test_list_continuation_is_not_treated_as_indented_code(

--- a/tests/test_lint_docs.py
+++ b/tests/test_lint_docs.py
@@ -1473,6 +1473,30 @@ def test_list_item_paragraph_keeps_its_links(repo: FixtureRepo) -> None:
     assert "gone.md" in result.stderr
 
 
+def test_heading_is_its_own_block_for_inline_scanning(repo: FixtureRepo) -> None:
+    """Inline constructs cannot span a heading boundary.
+
+    Grouped with the following line, an unmatched backtick in each paired up and blanked
+    the live link between them — a silent miss on valid markdown.
+    """
+    repo.write_doc(
+        "docs/references/a.md", TODAY, "## Heading `\n\nsee [x](./gone.md) `"
+    )
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
+
+
+def test_heading_with_a_real_code_span_still_slugs(repo: FixtureRepo) -> None:
+    """Flushing at headings must not disturb a span *within* one."""
+    repo.write_doc(
+        "docs/references/a.md", TODAY, "## The `foo` helper\n\n[x](#the-foo-helper)"
+    )
+    repo.commit_all()
+    assert repo.lint("--check", "anchors").returncode == 0
+
+
 def test_unmatched_backtick_leaves_following_links_live(repo: FixtureRepo) -> None:
     """An unclosed run is literal text, so the links after it still render.
 

--- a/tests/test_lint_docs.py
+++ b/tests/test_lint_docs.py
@@ -1317,9 +1317,38 @@ def test_commented_out_anchor_and_heading_define_nothing(repo: FixtureRepo) -> N
     assert "fake" in result.stderr
 
 
-def test_link_after_a_comment_is_still_checked(repo: FixtureRepo) -> None:
-    """Blanking must end at `-->`, not run to the end of the file."""
+def test_block_comment_closing_line_is_raw_html(repo: FixtureRepo) -> None:
+    """A comment starting a line is an HTML *block*, running to that line's end.
+
+    So markdown-looking text after `-->` on the same line renders as raw HTML, not a
+    link. An earlier version of this test asserted the opposite and was wrong.
+    """
     repo.write_doc("docs/references/a.md", TODAY, "<!-- note --> then [x](./gone.md).")
+    repo.commit_all()
+    assert repo.lint("--check", "links").returncode == 0
+
+
+def test_inline_comment_leaves_the_rest_of_its_line_live(repo: FixtureRepo) -> None:
+    """A comment *not* starting a line is inline HTML, so its line stays markdown.
+
+    Same delimiters, different position, and the surrounding text is real markdown here.
+    """
+    repo.write_doc(
+        "docs/references/a.md", TODAY, "Prose <!-- note --> then [x](./gone.md)."
+    )
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
+
+
+def test_link_after_a_block_comment_on_a_later_line_is_checked(
+    repo: FixtureRepo,
+) -> None:
+    """Blanking must end with the closing line, not run to the end of the file."""
+    repo.write_doc(
+        "docs/references/a.md", TODAY, "<!-- note -->\n\nThen [x](./gone.md)."
+    )
     repo.commit_all()
     result = repo.lint("--check", "links")
     assert result.returncode == 1
@@ -1334,12 +1363,32 @@ def test_unterminated_comment_is_reported(repo: FixtureRepo) -> None:
     slip that hides content from readers should not also hide it from the linter.
     """
     repo.write_doc(
-        "docs/references/a.md", TODAY, "A stray <!-- marker\n\nThen [x](./gone.md)."
+        "docs/references/a.md", TODAY, "<!-- stray marker\n\nThen [x](./gone.md)."
     )
     repo.commit_all()
     result = repo.lint("--check", "links")
     assert result.returncode == 1
     assert "never closed" in result.stderr
+
+
+def test_unclosed_inline_comment_marker_is_literal_text(repo: FixtureRepo) -> None:
+    """Only a line-start opener can begin an HTML block.
+
+    A mid-prose `<!--` with no close is an incomplete *inline* candidate, which
+    CommonMark renders literally. Carrying it across paragraphs meant a later `-->`
+    blanked every live link in between, and without one the linter rejected valid
+    markdown as an unterminated comment.
+    """
+    repo.write_doc(
+        "docs/references/a.md",
+        TODAY,
+        "A stray <!-- marker\n\nThen [x](./gone.md) and later -->.",
+    )
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
+    assert "never closed" not in result.stderr
 
 
 def test_comment_between_link_tokens_is_a_boundary(repo: FixtureRepo) -> None:
@@ -1389,9 +1438,11 @@ def test_indented_code_is_not_special_cased(repo: FixtureRepo) -> None:
         "An example:\n\n    <!-- shown as indented code\n\nBack to prose.",
     )
     repo.commit_all()
-    result = repo.lint("--check", "links")
-    assert result.returncode == 1
-    assert "never closed" in result.stderr
+    # Not reported — but for a better reason than indented-code detection. Four columns
+    # of indent means this is no line-start HTML-block opener, and an unclosed *inline*
+    # candidate is literal text. The block/inline distinction subsumes what the removed
+    # detection was for.
+    assert repo.lint("--check", "links").returncode == 0
 
 
 def test_fenced_example_is_the_supported_form_for_delimiters(

--- a/tests/test_lint_docs.py
+++ b/tests/test_lint_docs.py
@@ -1473,6 +1473,37 @@ def test_list_item_paragraph_keeps_its_links(repo: FixtureRepo) -> None:
     assert "gone.md" in result.stderr
 
 
+def test_multiline_comment_keeps_heading_lines_aligned(repo: FixtureRepo) -> None:
+    """The two renderings are indexed by line number, so both must keep line count.
+
+    Eliding a multi-line comment's newlines desynced them, so a heading took its text
+    from a later line — wrong slugs plus invented duplicate suffixes. Here `#a` resolved
+    to nothing and a phantom `c-1` appeared.
+    """
+    repo.write_doc(
+        "docs/references/a.md",
+        TODAY,
+        "<!--\nnote\n-->\n\n## A\n\n## B\n\n## C\n\n[x](#a) [y](#b) [z](#c)",
+    )
+    repo.commit_all()
+    assert repo.lint("--check", "anchors").returncode == 0
+
+
+@pytest.mark.parametrize("form", ["<!-->", "<!--->"], ids=["3-dash", "4-dash"])
+def test_short_empty_comment_forms_are_complete(repo: FixtureRepo, form: str) -> None:
+    """`<!-->` and `<!--->` are complete comments whose terminator overlaps the opener.
+
+    Searching for `-->` past the fourth character found neither, so both read as
+    unterminated: a spurious violation, and the links after them skipped.
+    """
+    repo.write_doc("docs/references/a.md", TODAY, f"Prose {form} then [x](./gone.md).")
+    repo.commit_all()
+    result = repo.lint("--check", "links")
+    assert result.returncode == 1
+    assert "gone.md" in result.stderr
+    assert "never closed" not in result.stderr
+
+
 def test_heading_is_its_own_block_for_inline_scanning(repo: FixtureRepo) -> None:
     """Inline constructs cannot span a heading boundary.
 


### PR DESCRIPTION
Follow-up to the documentation linter added in #319, from the last review round on it — those findings arrived after that change had merged.

`scripts/lint_docs.py` runs as a required check, so a false positive blocks legitimate work. That is a worse failure than a gap: a gap means the linter misses something, a false break stops correct work and teaches people to override it. All four cases were reproduced before being fixed.

| Case | What broke |
|---|---|
| A closing fence accepted any suffix | Per CommonMark a closing fence carries no info string, so a same-length language-tagged line inside a fenced block is an *opener*. Treating it as the closer ended the block early and exposed the rest to the link parser — any document demonstrating a language-tagged fence fails. |
| HTML comments not blanked | `<!-- [draft](missing.md) -->` renders no link, but its target was resolved and reported broken. The same applied to a commented-out `<a id>` or heading. |
| Headings anchored at column 0 | CommonMark permits up to three leading spaces, so an indented `## Setup` contributed no anchor and a valid link to `#setup` was reported broken. |
| Slug dedup counted per base | Headings `Foo`, `Foo`, `Foo-1` render as `foo`, `foo-1`, `foo-1-1`. Per-base counting emitted `foo-1` **twice** — impossible for HTML ids, which is the tell — and never `foo-1-1`. |

## Both directions are pinned

This is deliberate rather than thorough for its own sake. During the review cycle that built this linter, two fixes correcting a false positive introduced a false *negative*, and one round's blocking finding was a regression from the previous round's fix. So every case here tests the thing that should now pass **and** the thing that must still fail:

- a real, untagged closer still closes, and a link after it is still checked
- a link after `-->` is still checked, and an unterminated `<!--` does not swallow the rest of the file
- four spaces is still an indented code block, not a heading

Without those, each fix would have traded a false positive for a silent miss.

## One finding deliberately not included

A review reported that the fence pattern truncates a four-backtick opener. It does not — the pattern matches three or more backticks and is greedy, verified against the exact commit reviewed. That description matched the state before fence tracking was added. Detail is on the thread.

## Verified

- 165 tests, up from 153.
- The linter and its tests are kept byte-identical to the copies in the sibling repositories (checksum-verified), so these fixes land in all of them.
- Repo-wide `python3 scripts/lint_docs.py` exits 0; `ruff check`, `ruff format --check`, and `pyright` clean.