### PR TITLE
Add repo-local documentation conventions

### DIFF
--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
 
       # According to https://docs.astral.sh/uv/guides/integration/github/#setting-up-python
       # This can be faster, because GitHub caches the Python versions alongside the runner.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
 
       # According to https://docs.astral.sh/uv/guides/integration/github/#setting-up-python
       # This can be faster, because GitHub caches the Python versions alongside the runner.
@@ -49,6 +51,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Set up Python"
         uses: actions/setup-python@v6.3.0
@@ -73,6 +77,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Verify .immich-container-tag matches Dockerfile ARG
         run: |

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,8 @@
 # zizmor configuration. See: https://docs.zizmor.sh/configuration/
 #
-# Requires SHA-pin on third-party actions; allows tag refs on first-party actions/*.
+# Requires SHA-pin on third-party actions. `ref-pin` mechanically allows tags
+# or branches for first-party actions/*; the documented convention narrows that
+# exemption to version tags, which review must enforce.
 
 rules:
   unpinned-uses:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,23 +20,7 @@ Run from the `immich-adapter/` directory:
 
 # Documentation Checks
 
-`scripts/lint_docs.py` enforces the mechanically checkable half of the conventions below, and runs on every PR (the `lint-docs` job in `.github/workflows/ci.yml`). It is stdlib-only, so it needs no install step and runs anywhere `python3` does.
-
-| Check | Enforces |
-|-------|----------|
-| `freshness` | `last-updated:` is a real calendar date, and current whenever the body changed |
-| `links` | Every inline markdown link target resolves |
-| `anchors` | Every `#fragment` resolves to a real heading or `<a id>` |
-| `map_paths` | Every Documentation Map row's path resolves, as does every `superseded-by:`; a design doc with no row fails |
-| `map_status_section` | A design doc's map section matches its `status:` frontmatter |
-| `map_cells` | The Consult-when cell stays one line, under 250 characters |
-| `frontmatter` | `docs/design-docs/` needs `title`/`status`/`created`/`last-updated`, with `status` one of the four values; other `docs/` need `title`/`last-updated`. No required field may be present-but-empty, and `superseded-by` is validated when present rather than required |
-
-Only `freshness` is diff-scoped. The rest run repo-wide, deliberately: renaming a doc breaks inbound links and map rows in files the change never touched. Checks are individually switchable in `scripts/lint_docs.toml`, and `--check <name>` overrides that so a disabled rule can be swept before being switched on.
-
-Citations naming another repo are skipped rather than resolved — both the org-qualified form this repo's conventions require (`gumnut-ai/<repo>/...`) and a path that climbs out of the repo. CI clones one repo, so no such path can resolve there; the linter decides this by path arithmetic alone, so its verdict doesn't change on a machine that happens to have the sibling cloned.
-
-The file is kept byte-identical to the copy in the Gumnut Photos repo — repo differences belong in `lint_docs.toml`, not the script. A green run is not a full review: the linter buys reachability and structural consistency, never correctness.
+`scripts/lint_docs.py` runs on every PR in `.github/workflows/ci.yml`; use `--fix` to bump missed dates. The complete frontmatter, map, lifecycle, path, and review contract is local in `docs/references/documentation-conventions.md`. The linter is kept byte-identical to the Gumnut Photos copy, with repo differences in `scripts/lint_docs.toml`.
 
 # Documentation Map
 
@@ -60,6 +44,8 @@ The sections below follow that order, with design docs split by their `status:` 
 | Topic | Document | Consult when... |
 |-------|----------|-----------------|
 | Code practices | `docs/references/code-practices.md` | Python style, project conventions, endpoint patterns, checksum handling and deduplication, error handling, testing, logging, PR practices |
+| Documentation conventions | `docs/references/documentation-conventions.md` | Writing or maintaining docs — frontmatter, map rows, lifecycle, freshness, path citations |
+| GitHub Actions best practices | `docs/references/github-actions-best-practices.md` | Writing or reviewing workflows — action pins, permissions, untrusted triggers, shell interpolation, zizmor |
 | WebSocket events reference | `docs/references/websocket-events-reference.md` | WebSocket event types, payload formats |
 | Session & checkpoint reference | `docs/references/session-checkpoint-reference.md` | Session/checkpoint object shapes, field definitions |
 | Immich sync communication | `docs/references/immich-sync-communication.md` | Immich client-server sync protocol, message formats |

--- a/README.md
+++ b/README.md
@@ -109,5 +109,7 @@ This invokes `uvicorn` directly because the `fastapi` CLI doesn't expose `--ws`,
 
 - [Architecture](docs/architecture/adapter-architecture.md) — how the adapter works: auth, data translation, pagination, sync, error handling
 - [Code Practices](docs/references/code-practices.md) — Python style, endpoint patterns, testing, logging
+- [Documentation Conventions](docs/references/documentation-conventions.md) — frontmatter, maps, lifecycle, paths, and freshness
 - [Development Tools](docs/references/development-tools.md) — model generator, API compatibility, OpenAPI spec, dependency automation
+- [GitHub Actions Best Practices](docs/references/github-actions-best-practices.md) — workflow security and review rules
 - See [docs/](docs/) for design docs and more

--- a/docs/references/documentation-conventions.md
+++ b/docs/references/documentation-conventions.md
@@ -1,11 +1,11 @@
 ---
 title: Documentation Conventions
-last-updated: 2026-07-29
+last-updated: 2026-07-30
 ---
 
 # Documentation Conventions
 
-How to write and maintain documentation in this repository. This file is self-contained: a contributor or cloud agent working from this checkout must not need access to a private sibling repository or issue tracker to understand the contract.
+How to write and maintain documentation in this repository.
 
 ## Doc Types
 

--- a/docs/references/documentation-conventions.md
+++ b/docs/references/documentation-conventions.md
@@ -1,0 +1,150 @@
+---
+title: Documentation Conventions
+last-updated: 2026-07-29
+---
+
+# Documentation Conventions
+
+How to write and maintain documentation in this repository. This file is self-contained: a contributor or cloud agent working from this checkout must not need access to a private sibling repository or issue tracker to understand the contract.
+
+## Doc Types
+
+| Directory | Nature | What it answers | Update expectation |
+|-----------|--------|----------------|-------------------|
+| `docs/architecture/` | Evergreen | "How does the adapter work?" | Update whenever the system changes |
+| `docs/references/` | Evergreen | "How do I perform this task correctly?" | Update whenever the pattern changes |
+| `docs/guides/` | Evergreen | "How do I set up or operate this workflow?" | Update whenever the workflow changes |
+| `docs/design-docs/` | Point-in-time | "Why was this decision made?" | Depends on `status` |
+
+`AGENTS.md` is the quick-reference and Documentation Map. Detailed conventions, examples, and extended rationale belong in the appropriate docs directory.
+
+## Documentation Checks
+
+`scripts/lint_docs.py` runs in CI and locally from anywhere in the repo:
+
+```bash
+python3 scripts/lint_docs.py
+python3 scripts/lint_docs.py --fix
+```
+
+It checks:
+
+| Check | Enforces |
+|-------|----------|
+| `freshness` | A changed doc's `last-updated:` is a real current date |
+| `links` | Inline markdown link targets resolve |
+| `anchors` | `#fragment` targets resolve |
+| `map_paths` | Documentation Map paths and `superseded-by:` targets resolve; design docs are mapped |
+| `map_status_section` | A design doc's map section matches its status |
+| `map_cells` | Consult-when cells remain one line and under the configured limit |
+| `frontmatter` | Required fields are present, non-empty, and valid |
+
+Only freshness is diff-scoped. The structural checks run repository-wide because moving one doc can break inbound links and map rows outside the diff.
+
+## Documentation Maps
+
+Every doc is reachable through the map in `AGENTS.md`. Add or update its row in the same PR as the document.
+
+Use these sections in order:
+
+| Section | Holds |
+|---------|-------|
+| `Architecture` | `docs/architecture/` |
+| `References` | `docs/references/` |
+| `Guides` | `docs/guides/` |
+| `Active Design Docs` | `status: proposed` or `status: active` |
+| `Historical & Deprecated Design Docs` | `status: completed` or `status: deprecated` |
+
+Put this sentence immediately above the Historical table:
+
+> Decision records, not descriptions of the running system — consult them for *why* something was chosen, never for how it works today.
+
+A design doc's status selects its section. Moving from `active` to `completed` moves the row; moving from `completed` to `deprecated` leaves it under Historical. Do not repeat the status with `(deprecated)` or `Historical:` labels in the row.
+
+The Consult-when cell is a routing trigger, not a summary. Keep it to one line and name the situations or concepts that should cause an agent to open the doc.
+
+## Required Frontmatter
+
+Architecture, reference, and guide docs require:
+
+```yaml
+---
+title: Human-readable title
+last-updated: 2026-07-29
+---
+```
+
+Design docs require:
+
+```yaml
+---
+title: Human-readable title
+status: active
+created: 2026-07-29
+last-updated: 2026-07-29
+---
+```
+
+Valid design statuses:
+
+- `proposed` — written but not yet accepted or started;
+- `active` — authoritative plan while work is in flight;
+- `completed` — implemented decision record whose body is frozen;
+- `deprecated` — retired record that no longer describes the current system.
+
+Add `superseded-by:` when a deprecated doc has an evergreen or newer design-doc successor. It is optional when no successor exists.
+
+## Writing Prescriptive Conventions
+
+Keep codebase-specific facts and traps that a capable contributor could reasonably miss. Do not pad the doc with generic framework, language, HTTP, SQL, or testing tutorials.
+
+- Explain a non-obvious rationale once and point to it elsewhere.
+- Scope absolute claims by checking the full repository for counterexamples.
+- Do not restate call-site counts, tunable constants, dependency inventories, or line numbers; point to the owning file, symbol, or grep.
+- Keep implementation mechanics in code. A reference doc states the durable pattern and cites the implementation.
+- Verify third-party and upstream-Immich behavior from primary sources or the checked-out upstream source.
+- Everything committed here must stand on its own for a public reader. Describe the contract and rationale instead of relying on a private ticket or sibling path; follow `code-practices.md` § Project Conventions.
+
+If a reference doc grows because it covers several legitimate topics, split it behind a short index instead of deleting high-signal rules.
+
+## Design Doc Lifecycle
+
+### Keeping Active Design Docs Consistent When Shipping
+
+An active design doc is the authoritative plan. Update it in the same PR when implementation changes a decision. When work fully ships, set `status: completed` and move its map row to Historical.
+
+### Evolution Notes for Completed Design Docs
+
+Do not rewrite the body. Append a dated `## Evolution Notes` entry when the running system moves past the decision, stating what changed and pointing to current code or an evergreen doc.
+
+### Retire Design Docs; Don't Maintain Them
+
+Retire a completed doc when an evergreen doc owns the live subject, the body would need repeated evolution notes, functionality was removed, or the decision was reversed.
+
+### Reclassifying a Completed Doc to Deprecated
+
+1. Move still-current architecture or operational guidance into an evergreen doc.
+2. Set `status: deprecated` and add `superseded-by:` when applicable.
+3. Add a banner after the H1 pointing to the live source.
+4. Preserve the historical decision and rationale, but remove instructions that pretend to be current.
+5. Keep the row under Historical and route its Consult-when cell toward the live source.
+
+## Freshness
+
+Bump `last-updated:` whenever a doc body changes meaningfully. Run `python3 scripts/lint_docs.py --fix` to update missed dates. A content-preserving rename does not require a bump; a renamed-and-edited doc does.
+
+Do not leave a date-only bump after reverting the body edit that prompted it. Compare the final file against `main`.
+
+## Path Citations
+
+Use the shortest path that resolves unambiguously from the citing file. Same-directory markdown links may use a local filename; other in-repo links use a correct relative target. Cite source by file plus symbol, never by line number.
+
+Do not cite a private sibling repository as the explanation for adapter behavior. State the public Gumnut API contract this repo relies on. When an external public source is useful, use a resolvable link.
+
+## Verify Claims
+
+Resolve every citation and check every named symbol, setting, CLI command, and upstream behavior before shipping. A task description and a correction are both claims to verify, not premises. Re-read source and documentation changed in the same PR against each other; each can look correct in isolation while contradicting the other.
+
+## Evergreen Framing
+
+Architecture, reference, and guide docs describe durable current knowledge. Remove intra-PR iteration, review-round narration, and "we just changed" framing. Keep the fact, rationale, and stable code anchor.

--- a/docs/references/github-actions-best-practices.md
+++ b/docs/references/github-actions-best-practices.md
@@ -1,6 +1,6 @@
 ---
 title: GitHub Actions Best Practices
-last-updated: 2026-07-29
+last-updated: 2026-07-30
 ---
 
 # GitHub Actions Best Practices
@@ -17,7 +17,7 @@ Pin every third-party action—anything outside `actions/*`—to a full 40-chara
 
 Tags and branches are mutable. The comment keeps the intended release legible and lets dependency automation update the SHA and version together.
 
-GitHub-owned `actions/*` actions are tag-pinned for readability under the checked-in `.github/zizmor.yml` policy. When bumping any action, update its version comment in the same edit.
+Use version tags for GitHub-owned `actions/*` actions. The checked-in `.github/zizmor.yml` uses `ref-pin` for this exemption, which mechanically permits tags or branches; the written convention is narrower, so reject branch refs in review. When bumping any action, update its version comment in the same edit.
 
 ## Declare Token Permissions
 

--- a/docs/references/github-actions-best-practices.md
+++ b/docs/references/github-actions-best-practices.md
@@ -1,0 +1,106 @@
+---
+title: GitHub Actions Best Practices
+last-updated: 2026-07-29
+---
+
+# GitHub Actions Best Practices
+
+Security and maintenance rules for `.github/workflows/*.yml` in this repository. A workflow executes third-party code inside the repository trust boundary with whatever token, secrets, and write scope it receives, so workflow changes get the same review rigor as application code.
+
+## Pin Actions Deliberately
+
+Pin every third-party action—anything outside `actions/*`—to a full 40-character commit SHA with a trailing version comment:
+
+```yaml
+- uses: owner/action@<40-character-commit-sha> # vX.Y.Z
+```
+
+Tags and branches are mutable. The comment keeps the intended release legible and lets dependency automation update the SHA and version together.
+
+GitHub-owned `actions/*` actions are tag-pinned for readability under the checked-in `.github/zizmor.yml` policy. When bumping any action, update its version comment in the same edit.
+
+## Declare Token Permissions
+
+Set `permissions:` explicitly at workflow level. The usual default is:
+
+```yaml
+permissions:
+  contents: read
+```
+
+Add only scopes the workflow needs. Use job-level permissions only when one job needs a wider scope than the rest, and use `permissions: {}` when no token access is required.
+
+## Keep Untrusted Code Out of Privileged Contexts
+
+Use `pull_request` for ordinary CI. It gives forked pull requests a read-only token and no secrets.
+
+Avoid `pull_request_target`. If a workflow genuinely needs to label or comment on a forked PR, prefer a deferred `workflow_run` job that reads metadata without checking out the contributor's code. A metadata-only `pull_request_target` job is acceptable only when it:
+
+- never checks out the PR head;
+- never runs PR-controlled code or installs PR-controlled dependencies;
+- never restores caches populated by fork PRs.
+
+Treat adding checkout or dependency execution to such a workflow as a security regression.
+
+## Gate Comment and Issue Triggers
+
+`issue_comment` and `issues` can be triggered by untrusted users. Jobs using them must:
+
+- gate on a trusted author association and a structured command;
+- avoid publishing-capable tokens;
+- avoid executing or shell-interpolating the comment body.
+
+A body substring check by itself is not authorization.
+
+## Keep Event Data Out of Shell Source
+
+GitHub expressions expand before the shell parses `run:`. Never interpolate PR titles, branch names, commit messages, issue bodies, comments, or workflow inputs directly into shell source.
+
+```yaml
+# unsafe
+- run: echo "${{ github.event.pull_request.title }}"
+
+# safe
+- env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+  run: echo "$PR_TITLE"
+```
+
+GitHub expression context such as an `if:` condition is evaluated by Actions and is not shell interpolation.
+
+## Disable Checkout Credentials
+
+Set `persist-credentials: false` on `actions/checkout` unless the job intentionally pushes commits or tags:
+
+```yaml
+- uses: actions/checkout@<current-major>
+  with:
+    persist-credentials: false
+```
+
+If a job must push, grant the narrow permission explicitly and document why credentials are retained.
+
+## Run zizmor
+
+`.github/workflows/zizmor.yml` audits workflow changes for unpinned actions, excessive permissions, template injection, dangerous triggers, and cache poisoning. `.github/zizmor.yml` owns the pin policy.
+
+Those checked-in files are the source of truth for the current action version, triggers, severity threshold, and SARIF/annotation mode. Do not copy those tunable values into prose. The workflow must run when either `.github/workflows/**` or `.github/zizmor.yml` changes.
+
+Prefer fixing a finding. Suppress one only with a narrow `# zizmor: ignore[rule]` annotation and an adjacent justification.
+
+## Review Checklist
+
+- [ ] Workflow-level `permissions:` is explicit and minimal.
+- [ ] Third-party actions use a full SHA plus version comment.
+- [ ] `actions/checkout` disables persisted credentials unless the job pushes.
+- [ ] CI uses `pull_request`, not a privileged trigger that executes PR code.
+- [ ] Comment/issue triggers strongly authorize the caller.
+- [ ] Event data reaches shell through `env:`, not direct interpolation.
+- [ ] Cache use does not cross from untrusted to privileged execution.
+- [ ] The local zizmor workflow and configuration cover this change.
+
+## References
+
+- [GitHub Actions security hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
+- [zizmor documentation](https://docs.zizmor.sh)
+- [CISA: tj-actions/changed-files compromise](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files)


### PR DESCRIPTION
## What

- Add self-contained documentation and GitHub Actions convention references to this repository.
- Route contributors and cloud agents to those local references from AGENTS.md and README.md.
- Disable persisted checkout credentials in non-publishing CI jobs and align local zizmor guidance with the written version-tag rule.

## Why

Contributors and cloud agents working from this checkout should have the complete codebase contract without depending on an unavailable sibling repository or private issue tracker.

## Test plan

- python3 scripts/lint_docs.py
- uv run pytest tests/test_lint_docs.py (194 passed)
- actionlint .github/workflows/ci.yml .github/workflows/api-compatibility.yml
- git diff --check

Generated by an AI coding agent.