### PR TITLE
Allow a tolerance window for docs freshness

### DIFF
--- a/docs/references/documentation-conventions.md
+++ b/docs/references/documentation-conventions.md
@@ -31,7 +31,7 @@ It checks:
 
 | Check | Enforces |
 |-------|----------|
-| `freshness` | A changed doc's `last-updated:` is a real current date |
+| `freshness` | A changed doc's `last-updated:` is a real date within the configured tolerance |
 | `links` | Inline markdown link targets resolve |
 | `anchors` | `#fragment` targets resolve |
 | `map_paths` | Documentation Map paths and `superseded-by:` targets resolve; design docs are mapped |
@@ -131,7 +131,7 @@ Retire a completed doc when an evergreen doc owns the live subject, the body wou
 
 ## Freshness
 
-Bump `last-updated:` whenever a doc body changes meaningfully. Run `uv run scripts/lint_docs.py --fix` to update missed dates. A content-preserving rename does not require a bump; a renamed-and-edited doc does.
+Bump `last-updated:` to the current date whenever a doc body changes meaningfully. The linter allows the `freshness_window_days` tolerance in `scripts/lint_docs.toml` so a recently bumped doc does not need a churn-only re-bump on every later push to the same branch; dates older than that window and dates beyond the existing timezone upper boundary fail. Run `uv run scripts/lint_docs.py --fix` to update offenders to today. A content-preserving rename does not require a bump; a renamed-and-edited doc does.
 
 Do not leave a date-only bump after reverting the body edit that prompted it. Compare the final file against `main`.
 

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -19,8 +19,8 @@ repos, so any repo-specific path in it is wrong in at least one of them.
 Checks (each independently switchable in `lint_docs.toml`, so a new rule can
 land dark and be enabled once its sweep is done):
 
-  freshness           `last-updated:` is bumped on an edited doc, and current on
-                      a doc added on this branch
+  freshness           `last-updated:` is recent on an edited doc or a doc added
+                      on this branch
   links               inline markdown link targets resolve
   anchors             `#fragment` targets resolve to a real heading or <a id>
   map_paths           every Documentation Map row's path resolves, as does every
@@ -63,7 +63,7 @@ import sys
 import time
 import tomllib
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 from typing import NoReturn
 from urllib.parse import unquote as percent_decode
@@ -84,6 +84,7 @@ except ModuleNotFoundError:  # pragma: no cover - exercised by running without u
     raise SystemExit(1) from None
 
 DEFAULT_BASE = "origin/main"
+DEFAULT_FRESHNESS_WINDOW_DAYS = 7
 ISO_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 DOC_SUFFIXES = (".md", ".mdx")
 
@@ -166,6 +167,7 @@ class Config:
     template_paths: tuple[str, ...] = ()
     enabled: frozenset[str] = frozenset()
     consult_cell_chars: int = 250
+    freshness_window_days: int = DEFAULT_FRESHNESS_WINDOW_DAYS
     ignores: tuple[Ignore, ...] = ()
 
     def ignored(self, rel_path: str, check: str) -> bool:
@@ -211,7 +213,7 @@ CONFIG_TOP_KEYS = frozenset(
         "ignore",
     }
 )
-CONFIG_LIMIT_KEYS = frozenset({"consult_cell_chars"})
+CONFIG_LIMIT_KEYS = frozenset({"consult_cell_chars", "freshness_window_days"})
 CONFIG_IGNORE_KEYS = frozenset({"path", "checks", "reason"})
 
 
@@ -322,6 +324,12 @@ def load_config(path: Path, all_checks: tuple[str, ...]) -> Config:
         template_paths=config_str_list(path, raw, "template_paths", ()),
         enabled=enabled,
         consult_cell_chars=config_positive_int(path, limits, "consult_cell_chars", 250),
+        freshness_window_days=config_positive_int(
+            path,
+            limits,
+            "freshness_window_days",
+            DEFAULT_FRESHNESS_WINDOW_DAYS,
+        ),
         ignores=ignores,
     )
 
@@ -905,30 +913,34 @@ def fail(message: str) -> NoReturn:
 @dataclass(frozen=True)
 class Clock:
     today: str
-    current_dates: frozenset[str]
+    earliest_fresh_date: date
+    latest_fresh_date: date
+    freshness_window_days: int
 
     @classmethod
-    def build(cls) -> Clock:
+    def build(cls, freshness_window_days: int) -> Clock:
         # Tests pin the clock so a fixture and this process cannot straddle a
         # date boundary. Normal invocations use the system clock.
         now = int(os.environ.get("LINT_DOCS_NOW_EPOCH") or time.time())
         today = os.environ.get("LINT_DOCS_TODAY") or time.strftime(
             "%Y-%m-%d", time.localtime(now)
         )
+        earliest_current_date = date.fromisoformat(
+            time.strftime("%Y-%m-%d", time.gmtime(now - TZ_WINDOW_EARLIEST_SECONDS))
+        )
         return cls(
             today=today,
-            current_dates=frozenset(
-                time.strftime("%Y-%m-%d", time.gmtime(now + delta))
-                for delta in (
-                    -TZ_WINDOW_EARLIEST_SECONDS,
-                    0,
-                    TZ_WINDOW_LATEST_SECONDS,
-                )
+            earliest_fresh_date=earliest_current_date
+            - timedelta(days=freshness_window_days),
+            latest_fresh_date=date.fromisoformat(
+                time.strftime("%Y-%m-%d", time.gmtime(now + TZ_WINDOW_LATEST_SECONDS))
             ),
+            freshness_window_days=freshness_window_days,
         )
 
-    def is_current(self, date: str) -> bool:
-        return date in self.current_dates
+    def is_fresh(self, value: str) -> bool:
+        parsed = date.fromisoformat(value)
+        return self.earliest_fresh_date <= parsed <= self.latest_fresh_date
 
 
 # --------------------------------------------------------------------------
@@ -1089,7 +1101,7 @@ def check_freshness(
 
     # An untracked doc is in no diff, so without this a brand-new doc's date went
     # unchecked locally and only failed once committed. It has no base blob, so it
-    # takes the added-on-this-branch path below and must carry a current date.
+    # takes the added-on-this-branch path below and must carry a recent date.
     untracked = {rel for rel in repo.docs if rel not in repo.tracked}
     scope = sorted({p for p in changed if p} | untracked)
 
@@ -1127,13 +1139,21 @@ def check_freshness(
             # Only the date changed, and it is valid. Nothing to enforce — this is
             # the deliberate escape hatch for a pure freshness touch-up.
             continue
-        elif not clock.is_current(head_val):
-            # The body changed (or the doc is new), so the date must be current.
-            # Keying on "differs from the base value" instead would accept any
-            # change at all, including a bump *backwards* to another stale date.
+        elif not clock.is_fresh(head_val):
+            # The body changed (or the doc is new), so the date must be within
+            # the tolerance window. Keying on "differs from the base value"
+            # instead would accept any change at all, including a bump backwards
+            # to another stale date.
             what = "body changed" if exists_at_base else "doc was added on this branch"
+            parsed = date.fromisoformat(head_val)
+            if parsed > clock.latest_fresh_date:
+                reason = "post-dated beyond the timezone window"
+            else:
+                reason = (
+                    f"older than the {clock.freshness_window_days}-day freshness window"
+                )
             message = (
-                f"{what} but last-updated is {head_val}, not current; "
+                f"{what} but last-updated is {head_val}, {reason}; "
                 f"set it to {clock.today}"
             )
 
@@ -1927,7 +1947,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     repo = discover_repo(config)
-    clock = Clock.build()
+    clock = Clock.build(config.freshness_window_days)
 
     violations: list[Violation] = []
     fixed: list[str] = []

--- a/scripts/lint_docs.toml
+++ b/scripts/lint_docs.toml
@@ -27,6 +27,10 @@ map_cells = true
 frontmatter = true
 
 [limits]
+# A recently bumped date stays valid across later pushes to the same branch.
+# Future dates beyond the existing UTC+14 boundary remain invalid.
+freshness_window_days = 7
+
 # A "Consult when..." cell decides whether to open a doc. The longest here is 210
 # characters; the limit matches the Photos repo so the rule doesn't differ by repo.
 consult_cell_chars = 250

--- a/tests/test_lint_docs.py
+++ b/tests/test_lint_docs.py
@@ -18,6 +18,7 @@ import re
 import subprocess
 import sys
 import time
+from datetime import date, timedelta
 from pathlib import Path
 
 import pytest
@@ -47,25 +48,23 @@ def utc_date(offset_seconds: int = 0) -> str:
 
 
 TODAY = time.strftime("%Y-%m-%d", time.localtime(NOW_EPOCH))
-UTC_TODAY = utc_date()
 EARLIEST_CURRENT_DATE = utc_date(-43_200)
 LATEST_CURRENT_DATE = utc_date(50_400)
+FRESHNESS_WINDOW_DAYS = 7
 
 
-def _outside_timezone_window() -> str:
-    """A date no timezone currently considers "today".
-
-    Adjacent UTC dates are usually outside the window, but during the short
-    interval where all three are current somewhere, two days ago still isn't.
-    """
-    current = {EARLIEST_CURRENT_DATE, UTC_TODAY, LATEST_CURRENT_DATE}
-    for candidate in (utc_date(-86_400), utc_date(86_400)):
-        if candidate not in current:
-            return candidate
-    return utc_date(-172_800)
-
-
-OUTSIDE_TIMEZONE_WINDOW = _outside_timezone_window()
+EARLIEST_FRESH_DATE = (
+    date.fromisoformat(EARLIEST_CURRENT_DATE) - timedelta(days=FRESHNESS_WINDOW_DAYS)
+).isoformat()
+INSIDE_FRESHNESS_WINDOW = (
+    date.fromisoformat(EARLIEST_CURRENT_DATE)
+    - timedelta(days=FRESHNESS_WINDOW_DAYS - 1)
+).isoformat()
+OUTSIDE_FRESHNESS_WINDOW = (
+    date.fromisoformat(EARLIEST_CURRENT_DATE)
+    - timedelta(days=FRESHNESS_WINDOW_DAYS + 1)
+).isoformat()
+FUTURE_DATE = (date.fromisoformat(LATEST_CURRENT_DATE) + timedelta(days=1)).isoformat()
 
 # Every check on, no exemptions — the fixture repos are built to exercise one
 # check at a time, so inheriting this repo's config would only add noise.
@@ -85,6 +84,7 @@ frontmatter = true
 
 [limits]
 consult_cell_chars = 250
+freshness_window_days = 7
 """
 
 
@@ -169,7 +169,9 @@ def freshness_repo(repo: FixtureRepo) -> FixtureRepo:
     repo.write_doc("same_day.md", TODAY, "original body")
     repo.write_doc("timezone_behind.md", EARLIEST_CURRENT_DATE, "original body")
     repo.write_doc("timezone_ahead.md", LATEST_CURRENT_DATE, "original body")
-    repo.write_doc("stale_unchanged.md", OUTSIDE_TIMEZONE_WINDOW, "original body")
+    repo.write_doc("within_window.md", EARLIEST_FRESH_DATE, "original body")
+    repo.write_doc("stale_unchanged.md", OUTSIDE_FRESHNESS_WINDOW, "original body")
+    repo.write_doc("future_date.md", FUTURE_DATE, "original body")
     repo.write_doc("backward_bump.md", "2020-01-01", "original body")
     repo.write_doc("impossible_date.md", "2020-01-01", "stable body")
     # A doc that documents the convention: no frontmatter field, but the body
@@ -194,7 +196,9 @@ def freshness_repo(repo: FixtureRepo) -> FixtureRepo:
     repo.write_doc("same_day.md", TODAY, "EDITED body")
     repo.write_doc("timezone_behind.md", EARLIEST_CURRENT_DATE, "EDITED body")
     repo.write_doc("timezone_ahead.md", LATEST_CURRENT_DATE, "EDITED body")
-    repo.write_doc("stale_unchanged.md", OUTSIDE_TIMEZONE_WINDOW, "EDITED body")
+    repo.write_doc("within_window.md", EARLIEST_FRESH_DATE, "EDITED body")
+    repo.write_doc("stale_unchanged.md", OUTSIDE_FRESHNESS_WINDOW, "EDITED body")
+    repo.write_doc("future_date.md", FUTURE_DATE, "EDITED body")
     # Body edited and the date *did* change from its base value — but backwards, to
     # another stale date. Keying on "differs from base" would accept this.
     repo.write_doc("backward_bump.md", "2019-12-31", "EDITED body")
@@ -215,7 +219,8 @@ def freshness_repo(repo: FixtureRepo) -> FixtureRepo:
         ("bad_date.md", "body changed and the date is junk"),
         ("date_only_bad.md", "date-only edit to a junk value"),
         ("blank_value.md", "date value blanked out"),
-        ("stale_unchanged.md", "date is outside the timezone window"),
+        ("stale_unchanged.md", "date is older than the freshness window"),
+        ("future_date.md", "date is beyond the timezone upper bound"),
         ("backward_bump.md", "date changed from base, but backwards to a stale date"),
         ("impossible_date.md", "ISO-shaped but not a real calendar date"),
     ],
@@ -226,6 +231,16 @@ def test_freshness_flags(freshness_repo: FixtureRepo, doc: str, reason: str) -> 
     assert doc in result.stderr, f"{doc} should be flagged: {reason}"
 
 
+def test_freshness_explains_stale_and_future_dates(
+    freshness_repo: FixtureRepo,
+) -> None:
+    result = freshness_repo.lint("--check", "freshness", "--base", "main")
+    assert f"older than the {FRESHNESS_WINDOW_DAYS}-day freshness window" in (
+        result.stderr
+    )
+    assert "post-dated beyond the timezone window" in result.stderr
+
+
 @pytest.mark.parametrize(
     ("doc", "reason"),
     [
@@ -234,6 +249,7 @@ def test_freshness_flags(freshness_repo: FixtureRepo, doc: str, reason: str) -> 
         ("same_day.md", "same-day re-edit escape hatch"),
         ("timezone_behind.md", "UTC-12 boundary is current"),
         ("timezone_ahead.md", "UTC+14 boundary is current"),
+        ("within_window.md", "lower freshness boundary is accepted"),
         ("conventions.md", "no frontmatter field, only a body mention"),
         ("clean.md", "not edited"),
     ],
@@ -255,6 +271,7 @@ def test_freshness_fix_bumps_offenders_and_preserves_bodies(
         "date_only_bad.md",
         "blank_value.md",
         "stale_unchanged.md",
+        "future_date.md",
         "backward_bump.md",
         "impossible_date.md",
     ):
@@ -285,8 +302,8 @@ def test_fix_reports_when_nothing_needs_a_bump(repo: FixtureRepo) -> None:
 # --------------------------------------------------------------------------
 #
 # The bash predecessor skipped any doc absent at the merge-base, so a doc created
-# on day 1 and edited on day 2 kept its day-1 date and every run — including --fix
-# — reported clean. Observed on a real branch before this was fixed.
+# on the branch could age past the tolerance window and every run — including
+# --fix — still reported clean. Observed on a real branch before this was fixed.
 
 
 def _branch_with_added_doc(repo: FixtureRepo, date: str) -> None:
@@ -303,23 +320,29 @@ def test_new_doc_added_and_edited_same_day_passes(repo: FixtureRepo) -> None:
     assert result.returncode == 0, result.stderr
 
 
-def test_new_doc_edited_next_day_without_bump_fails(repo: FixtureRepo) -> None:
-    _branch_with_added_doc(repo, OUTSIDE_TIMEZONE_WINDOW)
+def test_new_doc_with_date_inside_window_passes(repo: FixtureRepo) -> None:
+    _branch_with_added_doc(repo, INSIDE_FRESHNESS_WINDOW)
+    result = repo.lint("--check", "freshness", "--base", "main")
+    assert result.returncode == 0, result.stderr
+
+
+def test_new_doc_with_date_outside_window_fails(repo: FixtureRepo) -> None:
+    _branch_with_added_doc(repo, OUTSIDE_FRESHNESS_WINDOW)
     result = repo.lint("--check", "freshness", "--base", "main")
     assert result.returncode == 1
     assert "added.md" in result.stderr
     assert "added on this branch" in result.stderr
 
 
-def test_new_doc_edited_next_day_with_bump_passes(repo: FixtureRepo) -> None:
-    _branch_with_added_doc(repo, OUTSIDE_TIMEZONE_WINDOW)
+def test_new_doc_with_stale_date_then_current_bump_passes(repo: FixtureRepo) -> None:
+    _branch_with_added_doc(repo, OUTSIDE_FRESHNESS_WINDOW)
     repo.write_doc("added.md", TODAY, "brand new doc, edited")
     result = repo.lint("--check", "freshness", "--base", "main")
     assert result.returncode == 0, result.stderr
 
 
 def test_new_doc_stale_date_is_fixable(repo: FixtureRepo) -> None:
-    _branch_with_added_doc(repo, OUTSIDE_TIMEZONE_WINDOW)
+    _branch_with_added_doc(repo, OUTSIDE_FRESHNESS_WINDOW)
     result = repo.lint("--check", "freshness", "--base", "main", "--fix")
     assert result.returncode == 0
     assert f"last-updated: {TODAY}" in repo.read("added.md")
@@ -328,7 +351,7 @@ def test_new_doc_stale_date_is_fixable(repo: FixtureRepo) -> None:
 def test_preexisting_doc_with_unchanged_body_and_stale_date_passes(
     repo: FixtureRepo,
 ) -> None:
-    repo.write_doc("stale.md", OUTSIDE_TIMEZONE_WINDOW, "body")
+    repo.write_doc("stale.md", OUTSIDE_FRESHNESS_WINDOW, "body")
     repo.commit_all()
     result = repo.lint("--check", "freshness", "--base", "main")
     assert result.returncode == 0, result.stderr
@@ -341,7 +364,7 @@ def test_pure_rename_does_not_require_a_bump(repo: FixtureRepo) -> None:
     absent at the merge-base. Treating that as "added" would fail every
     content-preserving move — exactly what a docs reorganization is made of.
     """
-    repo.write_doc("docs/references/a.md", OUTSIDE_TIMEZONE_WINDOW, "body")
+    repo.write_doc("docs/references/a.md", OUTSIDE_FRESHNESS_WINDOW, "body")
     repo.commit_all()
     repo.git("checkout", "-q", "-b", "feature")
     repo.git("mv", "docs/references/a.md", "docs/references/b.md")
@@ -350,11 +373,11 @@ def test_pure_rename_does_not_require_a_bump(repo: FixtureRepo) -> None:
 
 
 def test_rename_with_a_body_edit_still_requires_a_bump(repo: FixtureRepo) -> None:
-    repo.write_doc("docs/references/a.md", OUTSIDE_TIMEZONE_WINDOW, "body")
+    repo.write_doc("docs/references/a.md", OUTSIDE_FRESHNESS_WINDOW, "body")
     repo.commit_all()
     repo.git("checkout", "-q", "-b", "feature")
     repo.git("mv", "docs/references/a.md", "docs/references/b.md")
-    repo.write_doc("docs/references/b.md", OUTSIDE_TIMEZONE_WINDOW, "EDITED body")
+    repo.write_doc("docs/references/b.md", OUTSIDE_FRESHNESS_WINDOW, "EDITED body")
     result = repo.lint("--check", "freshness", "--base", "main")
     assert result.returncode == 1
     assert "docs/references/b.md" in result.stderr
@@ -934,6 +957,33 @@ def test_valid_list_config_still_loads(repo: FixtureRepo) -> None:
     )
     repo.commit_all()
     assert repo.lint("--check", "links").returncode == 0
+
+
+def test_configured_freshness_window_is_applied(repo: FixtureRepo) -> None:
+    repo.config_path.write_text(
+        FIXTURE_CONFIG.replace(
+            "freshness_window_days = 7", "freshness_window_days = 1"
+        ),
+        encoding="utf-8",
+    )
+    repo.write_doc("a.md", "2020-01-01", "original body")
+    repo.commit_all()
+    repo.write_doc("a.md", INSIDE_FRESHNESS_WINDOW, "EDITED body")
+    result = repo.lint("--check", "freshness", "--base", "main")
+    assert result.returncode == 1
+    assert "older than the 1-day freshness window" in result.stderr
+
+
+def test_missing_freshness_window_uses_default(repo: FixtureRepo) -> None:
+    repo.config_path.write_text(
+        FIXTURE_CONFIG.replace("freshness_window_days = 7\n", ""),
+        encoding="utf-8",
+    )
+    repo.write_doc("a.md", "2020-01-01", "original body")
+    repo.commit_all()
+    repo.write_doc("a.md", EARLIEST_FRESH_DATE, "EDITED body")
+    result = repo.lint("--check", "freshness", "--base", "main")
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.parametrize("value", ['"wide"', "true", "0", "-5", "1.5"])


### PR DESCRIPTION
## What

- accept recently updated documentation dates within a configurable seven-day tolerance
- preserve invalid-date, future-date, rename, new-document, and automatic-fix behavior
- add boundary/configuration coverage and update the local documentation convention

## Why

A same-day-only freshness rule forces churn whenever a branch remains open or is resumed after its documentation date changes. A bounded tolerance keeps the date useful as a coarse staleness signal without requiring precision already available from Git history.

## Test plan

- `uv run pytest` (1,531 passed)
- `uv run ruff format --check`
- `uv run ruff check`
- `uv run pyright`
- `uv run --locked --script scripts/lint_docs.py --base main`

Generated by an AI coding agent.