### PR TITLE
Add Immich mobile stack snapshot to the sync stream

### DIFF
--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -73,56 +73,19 @@ delete from the album-user pass would duplicate `AlbumDeleteV1`. No
 
 ## Stack Snapshot (StacksV1)
 
-Stacks reach the mobile client two ways, both driven from the initial/full sync:
+Each sync asset carries its stack membership in `stackId`. Before streaming
+assets, `_stream_stacks` re-pages the stack table and emits rows after the
+client's checkpoint in `(updated_at, id)` order. This provides incremental
+upserts and resumes a truncated pass without a stack lifecycle event stream.
 
-1. **Asset membership.** Each sync asset row carries its `stackId` — the Gumnut
-   `stack_id` FK mapped to the Immich UUID (loose assets stay null). V2 inherits
-   it through the V1 delegation. This is what groups burst members under a stack
-   on the client.
-2. **Stack rows.** `StacksV1` streams `StackV1` rows, handled specially
-   (`_stream_stacks`) alongside the user types rather than via the events API —
-   the Gumnut backend emits no stack lifecycle events yet, so there is nothing to
-   feed the event stream. Each row's `primaryAssetId` is the **effective primary**
-   resolved by the shared `resolve_effective_primary`/`hydrate_stack` helpers (the
-   exact rule the REST `/stacks` surfaces use), so an auto-detected burst with no
-   pinned cover still gets a valid non-null primary. A member-less stack has no
-   honest primary and is skipped with a warning. `ownerId` is always the current
-   user (Gumnut is single-user; no stack sharing).
+Each row uses the same effective-primary resolution as the REST stack endpoints;
+member-less stacks are skipped because `primaryAssetId` is required. Incremental
+upserts prevent assets from referencing a missing stack, which would hide the
+burst in the mobile timeline.
 
-The stack rows are emitted **before** the phase-1 asset loop, so a stack row
-exists on the client before any asset naming it via `stackId` arrives. (The
-mobile client's `stackId` / `primaryAssetId` columns are unenforced indexes, not
-FKs, so the circular reference is not order-sensitive in practice — stacks-first
-is a deliberate, defensive choice for the asset→stack direction.)
-
-**Scope boundary — upserts only, no delete detection.** With no lifecycle event
-stream, `_stream_stacks` re-pages the whole stack table on **every** sync and
-emits the rows the client has not yet acked: it orders by `(updated_at, id)` and
-skips rows at or before the `StackV1` checkpoint cursor. This is upsert-only
-incremental delivery, and it exists for a concrete reason — asset rows carry
-`stackId` from current entity state unconditionally, so a burst created *after*
-the initial sync would otherwise leave its member assets pointing at a stack row
-the client never received. A dangling `stackId` is not benign: the mobile
-timeline join (`merged_asset.drift.dart`,
-`... AND (rae.stack_id IS NULL OR rae.id = se.primary_asset_id)`) hides **every
-frame** of a burst whose stack row is missing. Emitting the new stack keeps the
-burst visible and grouped.
-
-Ordering by the ack cursor also makes the pass **resumable**: if a snapshot
-truncates mid-stream, the checkpoint holds the last acked row's cursor and the
-next sync skips at-or-before it, so the un-streamed tail is not lost. This is
-also why a Gumnut API error while hydrating one stack is caught at the call site
-and ends the pass gracefully rather than propagating: the snapshot runs *before*
-the asset loop, so an unhandled error would suppress assets/albums/faces too —
-instead the already-streamed rows are acked, the asset loop still runs, and the
-remaining stacks resume next sync.
-
-**Delete detection stays out of scope**, tracked on a separate event-support
-track. A dissolved stack's row goes stale but is harmless: unstacking clears each
-member's `asset.stack_id` via asset events, and a stack row no asset references
-satisfies the `rae.stack_id IS NULL` branch of the join. `PartnerStacksV1` stays
-a no-op (partner sharing is unsupported), and `on_asset_stack_update` is **not**
-in the supported WebSocket table.
+Delete detection remains unsupported. A dissolved stack row is harmless once
+asset events clear its members' `stackId`. `PartnerStacksV1` remains a no-op
+because partner sharing is unsupported.
 
 ## Adding a New Sync Type Version
 
@@ -140,7 +103,10 @@ The invariant tests in `test_sync_v2.py` assert that every V2 type in `_SYNC_TYP
 
 Immich sync types that are accepted but have no Gumnut equivalent (e.g., `AssetEditsV1` — we don't support editing) go in `_NOOP_REQUEST_TYPES` in `stream.py`. This prevents "unsupported type" warnings while making the no-op explicit. Do not just add them to `_SUPPORTED_REQUEST_TYPES` without `_SYNC_TYPE_ORDER` — that silently drops them.
 
-The v3 mobile client requests a broad set of these on **every** sync (partner-*, `PartnerStacksV1`, memories-*, `AssetMetadataV1`, `AssetOcrV1`, `AlbumAssetExifsV1`, the V2 partner/album-asset variants) — all no-ops because the adapter has no sync-stream source for them, whether the underlying feature is absent (sharing, OCR) or reachable only through the REST surfaces (memories). They all belong in `_NOOP_REQUEST_TYPES` so the per-sync "unsupported types" warning stays quiet. Two requested types the adapter *does* handle are deliberately **not** no-ops, both handled specially alongside `UsersV1`/`AuthUsersV1` rather than via `_SYNC_TYPE_ORDER`: `UserMetadataV1` (synthesized preferences row — see "User Preferences" above) and `StacksV1` (current-state snapshot — see "Stack Snapshot" above). `PartnerStacksV1` remains a no-op regardless.
+The v3 mobile client requests these types on every sync, so keep unsupported
+ones in `_NOOP_REQUEST_TYPES` to avoid repeated warnings. `UserMetadataV1` and
+`StacksV1` are handled specially outside `_SYNC_TYPE_ORDER` and must not be
+listed as no-ops.
 
 ## Contract with the Gumnut API
 

--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -71,6 +71,42 @@ pass: an `album_deleted` event emits `AlbumDeleteV1`, and the client's
 delete from the album-user pass would duplicate `AlbumDeleteV1`. No
 `AlbumUserDeleteV1` is emitted (Gumnut has no unshare operation).
 
+## Stack Snapshot (StacksV1)
+
+Stacks reach the mobile client two ways, both driven from the initial/full sync:
+
+1. **Asset membership.** Each sync asset row carries its `stackId` — the Gumnut
+   `stack_id` FK mapped to the Immich UUID (loose assets stay null). V2 inherits
+   it through the V1 delegation. This is what groups burst members under a stack
+   on the client.
+2. **Stack rows.** `StacksV1` streams a **current-state snapshot** of `StackV1`
+   rows, handled specially (`_stream_stacks`) alongside the user types rather
+   than via the events API — the Gumnut backend emits no stack lifecycle events
+   yet, so there is nothing to feed the event stream. Each row's
+   `primaryAssetId` is the **effective primary** resolved by the shared
+   `resolve_effective_primary`/`hydrate_stack` helpers (the exact rule the REST
+   `/stacks` surfaces use), so an auto-detected burst with no pinned cover still
+   gets a valid non-null primary. A member-less stack has no honest primary and
+   is skipped with a warning. `ownerId` is always the current user (Gumnut is
+   single-user; no stack sharing).
+
+The snapshot is emitted **before** the phase-1 asset loop, so a stack row exists
+on the client before any asset naming it via `stackId` arrives. (The mobile
+client's `stackId` / `primaryAssetId` columns are unenforced indexes, not FKs,
+so the circular reference is not order-sensitive in practice — stacks-first is a
+deliberate, defensive choice for the asset→stack direction.)
+
+**Scope boundary — snapshot only.** The snapshot streams only on **reset / first
+sync** (no `StackV1` checkpoint). Once a client has acked, an existing `StackV1`
+checkpoint suppresses the pass entirely: no speculative updates are emitted.
+Incremental stack create/update/delete propagation is intentionally out of scope
+and tracked on a separate event-support track — re-emitting the full stack table
+on every delta is **not** a substitute, because it still cannot express deletes
+and wastes bandwidth. Per-row acks are `stack.updated_at` + id (pipe-free,
+stable), so a reset replays deterministically. `PartnerStacksV1` stays a no-op
+(partner sharing is unsupported), and `on_asset_stack_update` is **not** in the
+supported WebSocket table.
+
 ## Adding a New Sync Type Version
 
 When the same gumnut entity type maps to multiple Immich sync versions (e.g., AssetFacesV2 alongside V1), update these files in coordination:
@@ -87,7 +123,7 @@ The invariant tests in `test_sync_v2.py` assert that every V2 type in `_SYNC_TYP
 
 Immich sync types that are accepted but have no Gumnut equivalent (e.g., `AssetEditsV1` — we don't support editing) go in `_NOOP_REQUEST_TYPES` in `stream.py`. This prevents "unsupported type" warnings while making the no-op explicit. Do not just add them to `_SUPPORTED_REQUEST_TYPES` without `_SYNC_TYPE_ORDER` — that silently drops them.
 
-The v3 mobile client requests a broad set of these on **every** sync (partner-*, stacks-*, memories-*, `AssetMetadataV1`, `AssetOcrV1`, `AlbumAssetExifsV1`, the V2 partner/album-asset variants) — all no-ops because the adapter has no sync-stream source for them, whether the underlying feature is absent (sharing, OCR) or reachable only through the REST surfaces (stacks, memories). They all belong in `_NOOP_REQUEST_TYPES` so the per-sync "unsupported types" warning stays quiet. `UserMetadataV1` is the one requested type the adapter *does* synthesize (see "User Preferences" above), so it is deliberately **not** a no-op — it's handled specially alongside `UsersV1`/`AuthUsersV1`.
+The v3 mobile client requests a broad set of these on **every** sync (partner-*, `PartnerStacksV1`, memories-*, `AssetMetadataV1`, `AssetOcrV1`, `AlbumAssetExifsV1`, the V2 partner/album-asset variants) — all no-ops because the adapter has no sync-stream source for them, whether the underlying feature is absent (sharing, OCR) or reachable only through the REST surfaces (memories). They all belong in `_NOOP_REQUEST_TYPES` so the per-sync "unsupported types" warning stays quiet. Two requested types the adapter *does* handle are deliberately **not** no-ops, both handled specially alongside `UsersV1`/`AuthUsersV1` rather than via `_SYNC_TYPE_ORDER`: `UserMetadataV1` (synthesized preferences row — see "User Preferences" above) and `StacksV1` (current-state snapshot — see "Stack Snapshot" above). `PartnerStacksV1` remains a no-op regardless.
 
 ## Contract with the Gumnut API
 

--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Sync Stream Architecture"
-last-updated: 2026-07-30
+last-updated: 2026-08-03
 ---
 
 # Sync Stream Architecture
@@ -79,33 +79,50 @@ Stacks reach the mobile client two ways, both driven from the initial/full sync:
    `stack_id` FK mapped to the Immich UUID (loose assets stay null). V2 inherits
    it through the V1 delegation. This is what groups burst members under a stack
    on the client.
-2. **Stack rows.** `StacksV1` streams a **current-state snapshot** of `StackV1`
-   rows, handled specially (`_stream_stacks`) alongside the user types rather
-   than via the events API — the Gumnut backend emits no stack lifecycle events
-   yet, so there is nothing to feed the event stream. Each row's
-   `primaryAssetId` is the **effective primary** resolved by the shared
-   `resolve_effective_primary`/`hydrate_stack` helpers (the exact rule the REST
-   `/stacks` surfaces use), so an auto-detected burst with no pinned cover still
-   gets a valid non-null primary. A member-less stack has no honest primary and
-   is skipped with a warning. `ownerId` is always the current user (Gumnut is
-   single-user; no stack sharing).
+2. **Stack rows.** `StacksV1` streams `StackV1` rows, handled specially
+   (`_stream_stacks`) alongside the user types rather than via the events API —
+   the Gumnut backend emits no stack lifecycle events yet, so there is nothing to
+   feed the event stream. Each row's `primaryAssetId` is the **effective primary**
+   resolved by the shared `resolve_effective_primary`/`hydrate_stack` helpers (the
+   exact rule the REST `/stacks` surfaces use), so an auto-detected burst with no
+   pinned cover still gets a valid non-null primary. A member-less stack has no
+   honest primary and is skipped with a warning. `ownerId` is always the current
+   user (Gumnut is single-user; no stack sharing).
 
-The snapshot is emitted **before** the phase-1 asset loop, so a stack row exists
-on the client before any asset naming it via `stackId` arrives. (The mobile
-client's `stackId` / `primaryAssetId` columns are unenforced indexes, not FKs,
-so the circular reference is not order-sensitive in practice — stacks-first is a
-deliberate, defensive choice for the asset→stack direction.)
+The stack rows are emitted **before** the phase-1 asset loop, so a stack row
+exists on the client before any asset naming it via `stackId` arrives. (The
+mobile client's `stackId` / `primaryAssetId` columns are unenforced indexes, not
+FKs, so the circular reference is not order-sensitive in practice — stacks-first
+is a deliberate, defensive choice for the asset→stack direction.)
 
-**Scope boundary — snapshot only.** The snapshot streams only on **reset / first
-sync** (no `StackV1` checkpoint). Once a client has acked, an existing `StackV1`
-checkpoint suppresses the pass entirely: no speculative updates are emitted.
-Incremental stack create/update/delete propagation is intentionally out of scope
-and tracked on a separate event-support track — re-emitting the full stack table
-on every delta is **not** a substitute, because it still cannot express deletes
-and wastes bandwidth. Per-row acks are `stack.updated_at` + id (pipe-free,
-stable), so a reset replays deterministically. `PartnerStacksV1` stays a no-op
-(partner sharing is unsupported), and `on_asset_stack_update` is **not** in the
-supported WebSocket table.
+**Scope boundary — upserts only, no delete detection.** With no lifecycle event
+stream, `_stream_stacks` re-pages the whole stack table on **every** sync and
+emits the rows the client has not yet acked: it orders by `(updated_at, id)` and
+skips rows at or before the `StackV1` checkpoint cursor. This is upsert-only
+incremental delivery, and it exists for a concrete reason — asset rows carry
+`stackId` from current entity state unconditionally, so a burst created *after*
+the initial sync would otherwise leave its member assets pointing at a stack row
+the client never received. A dangling `stackId` is not benign: the mobile
+timeline join (`merged_asset.drift.dart`,
+`... AND (rae.stack_id IS NULL OR rae.id = se.primary_asset_id)`) hides **every
+frame** of a burst whose stack row is missing. Emitting the new stack keeps the
+burst visible and grouped.
+
+Ordering by the ack cursor also makes the pass **resumable**: if a snapshot
+truncates mid-stream, the checkpoint holds the last acked row's cursor and the
+next sync skips at-or-before it, so the un-streamed tail is not lost. This is
+also why a Gumnut API error while hydrating one stack is caught at the call site
+and ends the pass gracefully rather than propagating: the snapshot runs *before*
+the asset loop, so an unhandled error would suppress assets/albums/faces too —
+instead the already-streamed rows are acked, the asset loop still runs, and the
+remaining stacks resume next sync.
+
+**Delete detection stays out of scope**, tracked on a separate event-support
+track. A dissolved stack's row goes stale but is harmless: unstacking clears each
+member's `asset.stack_id` via asset events, and a stack row no asset references
+satisfies the `rae.stack_id IS NULL` branch of the join. `PartnerStacksV1` stays
+a no-op (partner sharing is unsupported), and `on_asset_stack_update` is **not**
+in the supported WebSocket table.
 
 ## Adding a New Sync Type Version
 

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -259,7 +259,14 @@ for asset_uuid in request.ids:
 
 Use `map_gumnut_error(e, context, extra=..., exc_info=True)` only when the call site needs to enrich the upstream log record with context the global handler can't see — most commonly the upload paths logging filename / device ids / tracebacks.
 
-**Exception — streaming responses swallow errors after the 200.** The "just let it bubble" rule holds only until a `StreamingResponse` commits its 200. After that a raised error no longer reaches the global handler: `generate_sync_stream`'s broad `except Exception` logs and returns, truncating the stream (no `SyncCompleteV1`, so the client re-fails identically every sync). Resolve auth/setup errors *before* streaming (the sync route pre-fetches the user for exactly this), and make per-item work inside the generator degrade rather than raise — e.g. `_immich_stack_id` falls back to a loose asset instead of letting a bad stack-prefix `ValueError` abort the whole sync. Scope such a degradation guard to the decode call itself, not the surrounding hydration: pydantic `ValidationError` subclasses `ValueError`, so an `except ValueError` wrapping model construction (an SDK member fetch, a DTO build) would swallow a real validation failure and mislabel it as the benign decode case. And when a per-item pass runs *before* other work in the same generator (the `StackV1` snapshot precedes the asset loop), catch its transport errors at the call site — an unhandled error there suppresses everything downstream, not just its own rows.
+**Streaming responses.** Once a `StreamingResponse` commits its headers,
+generator exceptions cannot reach the global error handler. Resolve
+authentication and setup errors before returning the response, and handle
+expected per-item failures inside the generator so they do not truncate the
+stream. Keep degradation guards narrow: `ValidationError` subclasses
+`ValueError`, so catch decoding failures around the decode call rather than
+around model construction. Catch transport errors at the call site when an
+early pass should not suppress later stream work.
 
 ### Omit vs explicit-null in update-style DTOs — use `model_fields_set`
 

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -259,6 +259,8 @@ for asset_uuid in request.ids:
 
 Use `map_gumnut_error(e, context, extra=..., exc_info=True)` only when the call site needs to enrich the upstream log record with context the global handler can't see — most commonly the upload paths logging filename / device ids / tracebacks.
 
+**Exception — streaming responses swallow errors after the 200.** The "just let it bubble" rule holds only until a `StreamingResponse` commits its 200. After that a raised error no longer reaches the global handler: `generate_sync_stream`'s broad `except Exception` logs and returns, truncating the stream (no `SyncCompleteV1`, so the client re-fails identically every sync). Resolve auth/setup errors *before* streaming (the sync route pre-fetches the user for exactly this), and make per-item work inside the generator degrade rather than raise — e.g. `_immich_stack_id` falls back to a loose asset instead of letting a bad stack-prefix `ValueError` abort the whole sync.
+
 ### Omit vs explicit-null in update-style DTOs — use `model_fields_set`
 
 Many generated Immich update DTOs declare each field as `T | None = None` (e.g., `UpdateAssetDto`'s `description`, `latitude`, `longitude`, `dateTimeOriginal`). On the wire, Immich clients distinguish two different intents:

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -1,6 +1,6 @@
 ---
 title: "Code Practices"
-last-updated: 2026-07-31
+last-updated: 2026-08-03
 ---
 
 # Code Practices
@@ -259,7 +259,7 @@ for asset_uuid in request.ids:
 
 Use `map_gumnut_error(e, context, extra=..., exc_info=True)` only when the call site needs to enrich the upstream log record with context the global handler can't see — most commonly the upload paths logging filename / device ids / tracebacks.
 
-**Exception — streaming responses swallow errors after the 200.** The "just let it bubble" rule holds only until a `StreamingResponse` commits its 200. After that a raised error no longer reaches the global handler: `generate_sync_stream`'s broad `except Exception` logs and returns, truncating the stream (no `SyncCompleteV1`, so the client re-fails identically every sync). Resolve auth/setup errors *before* streaming (the sync route pre-fetches the user for exactly this), and make per-item work inside the generator degrade rather than raise — e.g. `_immich_stack_id` falls back to a loose asset instead of letting a bad stack-prefix `ValueError` abort the whole sync.
+**Exception — streaming responses swallow errors after the 200.** The "just let it bubble" rule holds only until a `StreamingResponse` commits its 200. After that a raised error no longer reaches the global handler: `generate_sync_stream`'s broad `except Exception` logs and returns, truncating the stream (no `SyncCompleteV1`, so the client re-fails identically every sync). Resolve auth/setup errors *before* streaming (the sync route pre-fetches the user for exactly this), and make per-item work inside the generator degrade rather than raise — e.g. `_immich_stack_id` falls back to a loose asset instead of letting a bad stack-prefix `ValueError` abort the whole sync. Scope such a degradation guard to the decode call itself, not the surrounding hydration: pydantic `ValidationError` subclasses `ValueError`, so an `except ValueError` wrapping model construction (an SDK member fetch, a DTO build) would swallow a real validation failure and mislabel it as the benign decode case. And when a per-item pass runs *before* other work in the same generator (the `StackV1` snapshot precedes the asset loop), catch its transport errors at the call site — an unhandled error there suppresses everything downstream, not just its own rows.
 
 ### Omit vs explicit-null in update-style DTOs — use `model_fields_set`
 

--- a/docs/references/immich-sync-communication.md
+++ b/docs/references/immich-sync-communication.md
@@ -218,14 +218,11 @@ Notes (discussed below):
 
 **Adapter behavior for `StacksV1`:** the table above is what the upstream client
 accepts. The adapter emits `StacksV1` as a **current-state snapshot** — `StackV1`
-upserts only, never `StackDeleteV1` — and only on reset / first sync (no
-`StackV1` checkpoint); an already-synced client receives nothing. Assets carry
-their `stackId` in the same sync so members group under the snapshot's stack
-rows. Incremental stack create/update/delete propagation is out of scope until a
-Gumnut stack event source lands, so a stack changed after a client's initial
-sync is not reflected until that client resets. `PartnerStacksV1` is a no-op
-(no partner sharing). See the "Stack Snapshot" section of
-`docs/architecture/sync-stream-architecture.md` for the full rationale.
+upserts only, never `StackDeleteV1`, and only on reset / first sync — with assets
+carrying their `stackId` in the same sync so members group under the snapshot's
+stack rows. `PartnerStacksV1` stays a no-op (no partner sharing). See the "Stack
+Snapshot" section of `docs/architecture/sync-stream-architecture.md` for the
+snapshot semantics and the incremental-support scope boundary.
 
 ## Special SyncEntityTypes
 

--- a/docs/references/immich-sync-communication.md
+++ b/docs/references/immich-sync-communication.md
@@ -217,12 +217,10 @@ Notes (discussed below):
 - `SyncAckV1`\*\* = Phase transition marker (before first CREATE, marks updates complete)
 
 **Adapter behavior for `StacksV1`:** the table above is what the upstream client
-accepts. The adapter emits `StacksV1` as a **current-state snapshot** — `StackV1`
-upserts only, never `StackDeleteV1`, and only on reset / first sync — with assets
-carrying their `stackId` in the same sync so members group under the snapshot's
-stack rows. `PartnerStacksV1` stays a no-op (no partner sharing). See the "Stack
-Snapshot" section of `docs/architecture/sync-stream-architecture.md` for the
-snapshot semantics and the incremental-support scope boundary.
+accepts; the adapter emits `StackV1` upserts only, never `StackDeleteV1`.
+`PartnerStacksV1` stays a no-op (no partner sharing). See the "Stack Snapshot
+(StacksV1)" section of `docs/architecture/sync-stream-architecture.md` for the
+delivery semantics and the delete-detection scope boundary.
 
 ## Special SyncEntityTypes
 

--- a/docs/references/immich-sync-communication.md
+++ b/docs/references/immich-sync-communication.md
@@ -1,6 +1,6 @@
 ---
 title: "Immich Client<>Server Sync Communication"
-last-updated: 2026-07-12
+last-updated: 2026-08-03
 ---
 
 # Immich Client<>Server Sync Communication
@@ -215,6 +215,17 @@ The 22 SyncRequestTypes generate 50 SyncEntityTypes in specific orders.
 Notes (discussed below):
 - `SyncAckV1`\* = Backfill completion marker (via `sendEntityBackfillCompleteAck()`, one per entity)
 - `SyncAckV1`\*\* = Phase transition marker (before first CREATE, marks updates complete)
+
+**Adapter behavior for `StacksV1`:** the table above is what the upstream client
+accepts. The adapter emits `StacksV1` as a **current-state snapshot** — `StackV1`
+upserts only, never `StackDeleteV1` — and only on reset / first sync (no
+`StackV1` checkpoint); an already-synced client receives nothing. Assets carry
+their `stackId` in the same sync so members group under the snapshot's stack
+rows. Incremental stack create/update/delete propagation is out of scope until a
+Gumnut stack event source lands, so a stack changed after a client's initial
+sync is not reflected until that client resets. `PartnerStacksV1` is a no-op
+(no partner sharing). See the "Stack Snapshot" section of
+`docs/architecture/sync-stream-architecture.md` for the full rationale.
 
 ## Special SyncEntityTypes
 

--- a/docs/references/immich-sync-communication.md
+++ b/docs/references/immich-sync-communication.md
@@ -216,11 +216,7 @@ Notes (discussed below):
 - `SyncAckV1`\* = Backfill completion marker (via `sendEntityBackfillCompleteAck()`, one per entity)
 - `SyncAckV1`\*\* = Phase transition marker (before first CREATE, marks updates complete)
 
-**Adapter behavior for `StacksV1`:** the table above is what the upstream client
-accepts; the adapter emits `StackV1` upserts only, never `StackDeleteV1`.
-`PartnerStacksV1` stays a no-op (no partner sharing). See the "Stack Snapshot
-(StacksV1)" section of `docs/architecture/sync-stream-architecture.md` for the
-delivery semantics and the delete-detection scope boundary.
+Adapter-specific behavior is documented in [Stack Snapshot](../architecture/sync-stream-architecture.md#stack-snapshot-stacksv1).
 
 ## Special SyncEntityTypes
 

--- a/routers/api/sync/converters.py
+++ b/routers/api/sync/converters.py
@@ -65,28 +65,13 @@ logger = logging.getLogger(__name__)
 
 
 def _immich_stack_id(gumnut_stack_id: str | None) -> str | None:
-    """Map an asset's Gumnut stack FK to the Immich ``stackId``, or None.
-
-    Returns None for a loose (unstacked) asset, and — critically — also for a
-    stack_id that fails to decode rather than letting the ValueError abort the
-    whole sync stream. A stacked asset then syncs as loose (an inert
-    degradation), the same fallback ``resolve_timeline_stacks`` takes for this
-    prefix contract; the alternative is the streaming generator's broad handler
-    swallowing the error mid-stream, so the client never receives
-    ``SyncCompleteV1`` and every subsequent sync fails identically on the same
-    asset. The decode failure is logged at debug, not warning — see below.
-    """
+    """Map a stack FK, degrading invalid IDs to an unstacked asset."""
     if not gumnut_stack_id:
         return None
     try:
         return str(safe_uuid_from_stack_id(gumnut_stack_id))
     except ValueError:
-        # Logged at debug, not warning: the only cause is a backend change to the
-        # asset_stack_ prefix, which is systemic — it breaks every stacked asset
-        # at once, so a per-asset warning would flood a full-library sync with
-        # thousands of identical lines. That break already surfaces loudly and
-        # aggregated on the app's primary view via resolve_timeline_stacks; this
-        # path only needs to degrade quietly to a loose asset.
+        # Prefix drift affects every stack, so avoid one warning per asset.
         logger.debug(
             "Asset stack_id is not decodable to an Immich UUID; syncing the "
             "asset as loose (stackId=None)",
@@ -246,10 +231,6 @@ def gumnut_asset_to_sync_asset_v1(asset: AssetResponse, owner_id: UUID) -> SyncA
         height=asset.height if asset.height else None,
         libraryId=None,
         livePhotoVideoId=None,
-        # The asset's stack FK, so the client can group burst members under the
-        # stack row streamed by StacksV1. Loose (unstacked) assets stay null, as
-        # does an undecodable stack_id — see _immich_stack_id. V2 inherits this
-        # through the model_dump delegation below.
         stackId=_immich_stack_id(asset.stack_id),
         thumbhash=asset.thumbhash,
         width=asset.width if asset.width else None,
@@ -457,19 +438,7 @@ def gumnut_album_asset_to_sync_album_to_asset_v1(
 def gumnut_stack_to_sync_stack_v1(
     stack: StackListStacksResponse, primary_asset_id: UUID, owner_id: UUID
 ) -> SyncStackV1:
-    """Convert a Gumnut stack row to Immich SyncStackV1 format.
-
-    ``primary_asset_id`` is the *effective* cover resolved by the shared
-    ``resolve_effective_primary`` helper (via ``hydrate_stack``) — never the raw
-    Gumnut row's pinned cover, which is null for an auto-detected burst.
-    ``SyncStackV1.primaryAssetId`` is required and non-null, so callers must
-    resolve a cover before converting; a member-less stack has none and is
-    skipped upstream rather than reaching here.
-
-    Gumnut is single-user with no stack sharing, so ``ownerId`` is always the
-    current user — the row itself carries no owner. Member assets are not
-    embedded: each carries this stack's id in its own ``stackId`` field.
-    """
+    """Convert a stack using its resolved effective primary."""
     return SyncStackV1(
         id=safe_uuid_from_stack_id(stack.id),
         ownerId=owner_id,

--- a/routers/api/sync/converters.py
+++ b/routers/api/sync/converters.py
@@ -4,6 +4,7 @@ Converter functions mapping Gumnut SDK types to Immich sync models.
 Pure functions with no internal dependencies.
 """
 
+import logging
 from uuid import UUID
 
 from gumnut.types.album_asset_response import AlbumAssetResponse
@@ -58,6 +59,40 @@ from routers.utils.gumnut_id_conversion import (
     safe_uuid_from_stack_id,
     safe_uuid_from_user_id,
 )
+
+
+logger = logging.getLogger(__name__)
+
+
+def _immich_stack_id(gumnut_stack_id: str | None) -> str | None:
+    """Map an asset's Gumnut stack FK to the Immich ``stackId``, or None.
+
+    Returns None for a loose (unstacked) asset, and — critically — also for a
+    stack_id that fails to decode rather than letting the ValueError abort the
+    whole sync stream. A stacked asset then syncs as loose (an inert
+    degradation), the same fallback ``resolve_timeline_stacks`` takes for this
+    prefix contract; the alternative is the streaming generator's broad handler
+    swallowing the error mid-stream, so the client never receives
+    ``SyncCompleteV1`` and every subsequent sync fails identically on the same
+    asset. The decode failure is logged at debug, not warning — see below.
+    """
+    if not gumnut_stack_id:
+        return None
+    try:
+        return str(safe_uuid_from_stack_id(gumnut_stack_id))
+    except ValueError:
+        # Logged at debug, not warning: the only cause is a backend change to the
+        # asset_stack_ prefix, which is systemic — it breaks every stacked asset
+        # at once, so a per-asset warning would flood a full-library sync with
+        # thousands of identical lines. That break already surfaces loudly and
+        # aggregated on the app's primary view via resolve_timeline_stacks; this
+        # path only needs to degrade quietly to a loose asset.
+        logger.debug(
+            "Asset stack_id is not decodable to an Immich UUID; syncing the "
+            "asset as loose (stackId=None)",
+            extra={"stack_id": gumnut_stack_id},
+        )
+        return None
 
 
 def _format_exposure_time(exposure_time: float | None) -> str | None:
@@ -212,11 +247,10 @@ def gumnut_asset_to_sync_asset_v1(asset: AssetResponse, owner_id: UUID) -> SyncA
         libraryId=None,
         livePhotoVideoId=None,
         # The asset's stack FK, so the client can group burst members under the
-        # stack row streamed by StacksV1. Loose (unstacked) assets stay null.
-        # V2 inherits this through the model_dump delegation below.
-        stackId=(
-            str(safe_uuid_from_stack_id(asset.stack_id)) if asset.stack_id else None
-        ),
+        # stack row streamed by StacksV1. Loose (unstacked) assets stay null, as
+        # does an undecodable stack_id — see _immich_stack_id. V2 inherits this
+        # through the model_dump delegation below.
+        stackId=_immich_stack_id(asset.stack_id),
         thumbhash=asset.thumbhash,
         width=asset.width if asset.width else None,
     )

--- a/routers/api/sync/converters.py
+++ b/routers/api/sync/converters.py
@@ -11,6 +11,7 @@ from gumnut.types.album_response import AlbumResponse
 from gumnut.types.asset_response import AssetResponse
 from gumnut.types.face_response import FaceResponse
 from gumnut.types.person_response import PersonResponse
+from gumnut.types.stack_list_stacks_response import StackListStacksResponse
 from gumnut.types.user_response import UserResponse
 
 from routers.immich_models import (
@@ -28,6 +29,7 @@ from routers.immich_models import (
     SyncAssetV2,
     SyncAuthUserV1,
     SyncPersonV1,
+    SyncStackV1,
     SyncUserMetadataV1,
     SyncUserV1,
     UserMetadataKey,
@@ -53,6 +55,7 @@ from routers.utils.gumnut_id_conversion import (
     safe_uuid_from_asset_id,
     safe_uuid_from_face_id,
     safe_uuid_from_person_id,
+    safe_uuid_from_stack_id,
     safe_uuid_from_user_id,
 )
 
@@ -208,7 +211,12 @@ def gumnut_asset_to_sync_asset_v1(asset: AssetResponse, owner_id: UUID) -> SyncA
         height=asset.height if asset.height else None,
         libraryId=None,
         livePhotoVideoId=None,
-        stackId=None,
+        # The asset's stack FK, so the client can group burst members under the
+        # stack row streamed by StacksV1. Loose (unstacked) assets stay null.
+        # V2 inherits this through the model_dump delegation below.
+        stackId=(
+            str(safe_uuid_from_stack_id(asset.stack_id)) if asset.stack_id else None
+        ),
         thumbhash=asset.thumbhash,
         width=asset.width if asset.width else None,
     )
@@ -409,4 +417,29 @@ def gumnut_album_asset_to_sync_album_to_asset_v1(
     return SyncAlbumToAssetV1(
         albumId=safe_uuid_from_album_id(album_asset.album_id),
         assetId=safe_uuid_from_asset_id(album_asset.asset_id),
+    )
+
+
+def gumnut_stack_to_sync_stack_v1(
+    stack: StackListStacksResponse, primary_asset_id: UUID, owner_id: UUID
+) -> SyncStackV1:
+    """Convert a Gumnut stack row to Immich SyncStackV1 format.
+
+    ``primary_asset_id`` is the *effective* cover resolved by the shared
+    ``resolve_effective_primary`` helper (via ``hydrate_stack``) — never the raw
+    Gumnut row's pinned cover, which is null for an auto-detected burst.
+    ``SyncStackV1.primaryAssetId`` is required and non-null, so callers must
+    resolve a cover before converting; a member-less stack has none and is
+    skipped upstream rather than reaching here.
+
+    Gumnut is single-user with no stack sharing, so ``ownerId`` is always the
+    current user — the row itself carries no owner. Member assets are not
+    embedded: each carries this stack's id in its own ``stackId`` field.
+    """
+    return SyncStackV1(
+        id=safe_uuid_from_stack_id(stack.id),
+        ownerId=owner_id,
+        primaryAssetId=primary_asset_id,
+        createdAt=stack.created_at,
+        updatedAt=stack.updated_at,
     )

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -532,6 +532,23 @@ async def _stream_stacks(
     The per-row ack cursor is ``stack.updated_at`` + id: pipe-free and stable, so
     a reset replays deterministically and the last row's ack becomes the StackV1
     checkpoint that suppresses future snapshots.
+
+    Two accepted trade-offs, both cheap because this pass is reset-only:
+
+    - Each stack is hydrated through the shared ``hydrate_stack`` — the same
+      helper REST ``/stacks`` uses, so the effective primary matches exactly
+      (including the trashed-pin rule) — which fetches every member with
+      ``ASSET_INCLUDE`` even though only the resolved primary id is used here.
+      Reusing the single source of truth is worth the unused member payload on a
+      reset; a lean member read is a later optimization if a large, burst-heavy
+      library ever makes reset latency matter.
+    - A client with no stacks (or only member-less ones) emits no StackV1 row, so
+      never acks one, so never stores a checkpoint — it re-pages ``list_stacks``
+      (one empty page) on every sync until it has a real stack to checkpoint.
+      A consequence: the first stack a stackless client gains after its initial
+      sync does propagate on the next delta (there is no checkpoint yet to
+      suppress it) — strictly more than the "snapshot only on reset" guarantee,
+      never less, so it is harmless.
     """
     if checkpoint is not None:
         # An existing checkpoint means the client already holds the snapshot;
@@ -676,11 +693,8 @@ async def generate_sync_stream(
         event_counts: dict[str, int] = {}
         total_events = 0
 
-        # Stream the stack snapshot before the asset loop (StacksV1). Stacks are
-        # a current-state snapshot rather than events, emitted first so every
-        # asset's stackId names a stack row the client already holds. Only a
-        # reset / first sync produces rows — see _stream_stacks for the
-        # checkpoint semantics and the incremental-support scope boundary.
+        # Stream the StackV1 snapshot before the asset loop (so each asset's
+        # stackId names a stack the client already holds). See _stream_stacks.
         if SyncRequestType.StacksV1 in requested_types:
             stack_checkpoint = checkpoint_map.get(SyncEntityType.StackV1)
             async for stack_line in _stream_stacks(

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -28,6 +28,7 @@ from services.checkpoint_store import Checkpoint
 
 from routers.api.constants import GUMNUT_API_MAX_PAGE_SIZE
 from routers.api.sync.converters import (
+    gumnut_stack_to_sync_stack_v1,
     gumnut_user_to_sync_auth_user_v1,
     gumnut_user_to_sync_user_metadata_v1,
     gumnut_user_to_sync_user_v1,
@@ -46,6 +47,7 @@ from routers.api.sync.fk_integrity import (
     null_deleted_fk_references,
     payload_override,
 )
+from routers.utils.stack_conversion import hydrate_stack
 
 logger = logging.getLogger(__name__)
 
@@ -144,11 +146,9 @@ _DELETE_TYPE_ORDER: list[SyncEntityType] = [
 #                          EXIF arrives via AssetExifsV1.
 #   - MemoriesV1 /
 #     MemoryToAssetsV1:    Gumnut has no memories feature; the tab renders empty.
-#   - StacksV1:            stacks exist and are readable over REST (`/api/stacks`),
-#                          but nothing feeds them into the sync stream, and the
-#                          sync asset converters still emit stackId=None — so a
-#                          stack row here would name a grouping no synced asset
-#                          claims membership in.
+# StacksV1 is deliberately NOT here — it is emitted as a current-state snapshot
+# (see _stream_stacks), alongside the special user types below rather than via
+# the events API. PartnerStacksV1 stays a no-op: partner sharing is unsupported.
 # UserMetadataV1 is deliberately NOT here — it is emitted (a synthesized
 # preferences row); see gumnut_user_to_sync_user_metadata_v1.
 _NOOP_REQUEST_TYPES: dict[SyncRequestType, SyncEntityType] = {
@@ -163,19 +163,20 @@ _NOOP_REQUEST_TYPES: dict[SyncRequestType, SyncEntityType] = {
     SyncRequestType.AlbumAssetExifsV1: SyncEntityType.AlbumAssetExifCreateV1,
     SyncRequestType.MemoriesV1: SyncEntityType.MemoryV1,
     SyncRequestType.MemoryToAssetsV1: SyncEntityType.MemoryToAssetV1,
-    SyncRequestType.StacksV1: SyncEntityType.StackV1,
 }
 
 # Supported SyncRequestTypes (used to detect unsupported types requested by
-# client). AuthUsersV1/UsersV1/UserMetadataV1 are handled specially (not via
-# _SYNC_TYPE_ORDER): the first two stream the user record, and UserMetadataV1
-# streams a synthesized preferences row (see gumnut_user_to_sync_user_metadata_v1).
+# client). AuthUsersV1/UsersV1/UserMetadataV1/StacksV1 are handled specially (not
+# via _SYNC_TYPE_ORDER): the first two stream the user record, UserMetadataV1
+# streams a synthesized preferences row (see gumnut_user_to_sync_user_metadata_v1),
+# and StacksV1 streams a current-state snapshot (see _stream_stacks).
 _SUPPORTED_REQUEST_TYPES: frozenset[SyncRequestType] = frozenset(
     {request_type for request_type, _, _ in _SYNC_TYPE_ORDER}
     | {
         SyncRequestType.AuthUsersV1,
         SyncRequestType.UsersV1,
         SyncRequestType.UserMetadataV1,
+        SyncRequestType.StacksV1,
     }
     | _NOOP_REQUEST_TYPES.keys()
 )
@@ -503,6 +504,58 @@ def _yield_buffered_deletes(
             yield json_line, delete_type
 
 
+async def _stream_stacks(
+    gumnut_client: AsyncGumnut,
+    owner_id: UUID,
+    checkpoint: Checkpoint | None,
+) -> AsyncGenerator[str, None]:
+    """Stream StackV1 rows as a current-state snapshot.
+
+    Stacks are not sourced from the events API — the Gumnut backend emits no
+    stack lifecycle events yet — so this is a point-in-time snapshot, not a
+    delta. Incremental create/update/delete support is intentionally out of
+    scope (tracked on a separate event-support track):
+
+    - **Checkpoint present** → emit nothing. An already-synced client keeps the
+      stacks it has until that track lands; re-emitting the whole table every
+      delta cannot express deletes and only wastes bandwidth.
+    - **Checkpoint absent** (reset / first sync) → page every stack, resolve its
+      effective cover, and emit a StackV1 row.
+
+    The caller emits this before the phase-1 asset loop, so a stack row exists on
+    the client before any asset naming it via ``stackId`` arrives.
+
+    A member-less stack has no honest ``primaryAssetId`` (``SyncStackV1`` requires
+    a non-null one), so ``hydrate_stack`` returns ``None`` — logging a warning —
+    and it is skipped here.
+
+    The per-row ack cursor is ``stack.updated_at`` + id: pipe-free and stable, so
+    a reset replays deterministically and the last row's ack becomes the StackV1
+    checkpoint that suppresses future snapshots.
+    """
+    if checkpoint is not None:
+        # An existing checkpoint means the client already holds the snapshot;
+        # emit no speculative updates. See the docstring's scope boundary.
+        return
+
+    async for stack in gumnut_client.stacks.list_stacks(limit=GUMNUT_API_MAX_PAGE_SIZE):
+        hydrated = await hydrate_stack(gumnut_client, stack)
+        if hydrated is None:
+            # Member-less stack — hydrate_stack already logged a warning. Skipped
+            # rather than emitting an invalid required primary.
+            continue
+
+        sync_stack = gumnut_stack_to_sync_stack_v1(
+            stack, hydrated.primary_asset_id, owner_id
+        )
+        cursor = f"{stack.updated_at.isoformat()}_{stack.id}"
+        yield make_sync_event(
+            SyncEntityType.StackV1,
+            sync_stack.model_dump(mode="json"),
+            cursor,
+        )
+
+
 async def generate_sync_stream(
     gumnut_client: AsyncGumnut,
     request: SyncStreamDto,
@@ -622,6 +675,22 @@ async def generate_sync_stream(
         # Counters for logging
         event_counts: dict[str, int] = {}
         total_events = 0
+
+        # Stream the stack snapshot before the asset loop (StacksV1). Stacks are
+        # a current-state snapshot rather than events, emitted first so every
+        # asset's stackId names a stack row the client already holds. Only a
+        # reset / first sync produces rows — see _stream_stacks for the
+        # checkpoint semantics and the incremental-support scope boundary.
+        if SyncRequestType.StacksV1 in requested_types:
+            stack_checkpoint = checkpoint_map.get(SyncEntityType.StackV1)
+            async for stack_line in _stream_stacks(
+                gumnut_client, owner_uuid, stack_checkpoint
+            ):
+                yield stack_line
+                event_counts[SyncEntityType.StackV1.value] = (
+                    event_counts.get(SyncEntityType.StackV1.value, 0) + 1
+                )
+                total_events += 1
 
         # Phase 1: Stream upserts for all entity types in FK dependency order,
         # buffering delete events for phase 2.

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -13,7 +13,7 @@ from collections.abc import Iterator
 from typing import Any, AsyncGenerator
 from uuid import UUID
 
-from gumnut import AsyncGumnut
+from gumnut import AsyncGumnut, GumnutError
 from gumnut.types.album_response import AlbumResponse
 from gumnut.types.face_response import FaceResponse
 from gumnut.types.user_response import UserResponse
@@ -23,7 +23,11 @@ from routers.immich_models import (
     SyncRequestType,
     SyncStreamDto,
 )
-from routers.utils.gumnut_id_conversion import safe_uuid_from_user_id
+from routers.utils.datetime_utils import to_actual_utc
+from routers.utils.gumnut_id_conversion import (
+    safe_uuid_from_stack_id,
+    safe_uuid_from_user_id,
+)
 from services.checkpoint_store import Checkpoint
 
 from routers.api.constants import GUMNUT_API_MAX_PAGE_SIZE
@@ -509,67 +513,84 @@ async def _stream_stacks(
     owner_id: UUID,
     checkpoint: Checkpoint | None,
 ) -> AsyncGenerator[str, None]:
-    """Stream StackV1 rows as a current-state snapshot.
+    """Stream StackV1 rows for the StacksV1 sync type.
 
-    Stacks are not sourced from the events API — the Gumnut backend emits no
-    stack lifecycle events yet — so this is a point-in-time snapshot, not a
-    delta. Incremental create/update/delete support is intentionally out of
-    scope (tracked on a separate event-support track):
+    Every sync re-pages the whole stack table (the Gumnut backend emits no stack
+    lifecycle events yet) and emits rows in ``(updated_at, id)`` order, filtered
+    strictly after the checkpoint cursor — which gives incremental upsert and
+    mid-stream resume, with delete detection out of scope. The "Stack Snapshot
+    (StacksV1)" section of ``docs/architecture/sync-stream-architecture.md`` owns
+    why each of those matters and what stays out of scope.
 
-    - **Checkpoint present** → emit nothing. An already-synced client keeps the
-      stacks it has until that track lands; re-emitting the whole table every
-      delta cannot express deletes and only wastes bandwidth.
-    - **Checkpoint absent** (reset / first sync) → page every stack, resolve its
-      effective cover, and emit a StackV1 row.
+    Two code-local details:
 
-    The caller emits this before the phase-1 asset loop, so a stack row exists on
-    the client before any asset naming it via ``stackId`` arrives.
+    - Each surviving stack is hydrated through the shared ``hydrate_stack`` — the
+      same helper REST ``/stacks`` uses, so the effective primary matches exactly
+      — which fetches every member even though only the resolved primary id is
+      used here. Reusing the single source of truth is worth the unused member
+      payload; a lean member read is a later optimization if reset latency ever
+      matters.
+    - Only an undecodable ``stack.id`` (a systemic ``asset_stack_`` prefix change)
+      is degraded to a skip, and it is decoded *up front* so the guard cannot also
+      swallow a ``ValidationError`` or ``GumnutError`` raised during member
+      hydration — those are real failures that must surface, not be mislabeled.
 
     A member-less stack has no honest ``primaryAssetId`` (``SyncStackV1`` requires
     a non-null one), so ``hydrate_stack`` returns ``None`` — logging a warning —
     and it is skipped here.
-
-    The per-row ack cursor is ``stack.updated_at`` + id: pipe-free and stable, so
-    a reset replays deterministically and the last row's ack becomes the StackV1
-    checkpoint that suppresses future snapshots.
-
-    Two accepted trade-offs, both cheap because this pass is reset-only:
-
-    - Each stack is hydrated through the shared ``hydrate_stack`` — the same
-      helper REST ``/stacks`` uses, so the effective primary matches exactly
-      (including the trashed-pin rule) — which fetches every member with
-      ``ASSET_INCLUDE`` even though only the resolved primary id is used here.
-      Reusing the single source of truth is worth the unused member payload on a
-      reset; a lean member read is a later optimization if a large, burst-heavy
-      library ever makes reset latency matter.
-    - A client with no stacks (or only member-less ones) emits no StackV1 row, so
-      never acks one, so never stores a checkpoint — it re-pages ``list_stacks``
-      (one empty page) on every sync until it has a real stack to checkpoint.
-      A consequence: the first stack a stackless client gains after its initial
-      sync does propagate on the next delta (there is no checkpoint yet to
-      suppress it) — strictly more than the "snapshot only on reset" guarantee,
-      never less, so it is harmless.
     """
-    if checkpoint is not None:
-        # An existing checkpoint means the client already holds the snapshot;
-        # emit no speculative updates. See the docstring's scope boundary.
-        return
+    # Collect so the rows can be emitted in a stable (updated_at, id) order — a
+    # plain async-for can't reorder. Normalize to UTC so a naive/aware mix can't
+    # crash the sort or invert the cursor comparison below (same normalization
+    # stack_conversion applies to its member sort).
+    stacks = [
+        stack
+        async for stack in gumnut_client.stacks.list_stacks(
+            limit=GUMNUT_API_MAX_PAGE_SIZE
+        )
+    ]
+    stacks.sort(key=lambda s: (to_actual_utc(s.updated_at), s.id))
 
-    async for stack in gumnut_client.stacks.list_stacks(limit=GUMNUT_API_MAX_PAGE_SIZE):
-        hydrated = await hydrate_stack(gumnut_client, stack)
-        if hydrated is None:
-            # Member-less stack — hydrate_stack already logged a warning. Skipped
-            # rather than emitting an invalid required primary.
+    checkpoint_cursor = checkpoint.cursor if checkpoint is not None else None
+    undecodable_ids: list[str] = []
+
+    for stack in stacks:
+        cursor = f"{to_actual_utc(stack.updated_at).isoformat()}_{stack.id}"
+        if checkpoint_cursor is not None and cursor <= checkpoint_cursor:
             continue
 
+        # Decode the id first: it is the only ValueError this pass degrades on.
+        # Keeping it out of the hydrate call below means a member ValidationError
+        # (pydantic subclasses ValueError) or GumnutError truncates loudly instead
+        # of being mislabeled as an undecodable stack id and silently dropped.
+        try:
+            safe_uuid_from_stack_id(stack.id)
+        except ValueError:
+            undecodable_ids.append(stack.id)
+            continue
+
+        hydrated = await hydrate_stack(gumnut_client, stack)
+        if hydrated is None:
+            # Member-less stack — hydrate_stack already logged a warning.
+            continue
         sync_stack = gumnut_stack_to_sync_stack_v1(
             stack, hydrated.primary_asset_id, owner_id
         )
-        cursor = f"{stack.updated_at.isoformat()}_{stack.id}"
         yield make_sync_event(
             SyncEntityType.StackV1,
             sync_stack.model_dump(mode="json"),
             cursor,
+        )
+
+    if undecodable_ids:
+        logger.warning(
+            "Skipped %d stack(s) with undecodable ids in the StackV1 snapshot; "
+            "syncing their assets as loose",
+            len(undecodable_ids),
+            extra={
+                "undecodable_stack_count": len(undecodable_ids),
+                "sample_stack_ids": undecodable_ids[:10],
+            },
         )
 
 
@@ -695,16 +716,29 @@ async def generate_sync_stream(
 
         # Stream the StackV1 snapshot before the asset loop (so each asset's
         # stackId names a stack the client already holds). See _stream_stacks.
+        # A GumnutError while hydrating one stack ends the pass gracefully rather
+        # than truncating the whole sync: because this runs first, an unhandled
+        # error would suppress assets/albums/faces too. Rows already yielded are
+        # acked, so the remaining stacks resume from the checkpoint next sync,
+        # and the asset loop below still runs this cycle.
         if SyncRequestType.StacksV1 in requested_types:
             stack_checkpoint = checkpoint_map.get(SyncEntityType.StackV1)
-            async for stack_line in _stream_stacks(
-                gumnut_client, owner_uuid, stack_checkpoint
-            ):
-                yield stack_line
-                event_counts[SyncEntityType.StackV1.value] = (
-                    event_counts.get(SyncEntityType.StackV1.value, 0) + 1
+            try:
+                async for stack_line in _stream_stacks(
+                    gumnut_client, owner_uuid, stack_checkpoint
+                ):
+                    yield stack_line
+                    event_counts[SyncEntityType.StackV1.value] = (
+                        event_counts.get(SyncEntityType.StackV1.value, 0) + 1
+                    )
+                    total_events += 1
+            except GumnutError:
+                logger.warning(
+                    "StackV1 snapshot cut short by a Gumnut API error; already "
+                    "streamed rows are acked and the rest resume next sync",
+                    extra={"user_id": owner_id},
+                    exc_info=True,
                 )
-                total_events += 1
 
         # Phase 1: Stream upserts for all entity types in FK dependency order,
         # buffering delete events for phase 2.

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -150,9 +150,7 @@ _DELETE_TYPE_ORDER: list[SyncEntityType] = [
 #                          EXIF arrives via AssetExifsV1.
 #   - MemoriesV1 /
 #     MemoryToAssetsV1:    Gumnut has no memories feature; the tab renders empty.
-# StacksV1 is deliberately NOT here — it is emitted as a current-state snapshot
-# (see _stream_stacks), alongside the special user types below rather than via
-# the events API. PartnerStacksV1 stays a no-op: partner sharing is unsupported.
+# StacksV1 is emitted by _stream_stacks; PartnerStacksV1 remains a no-op.
 # UserMetadataV1 is deliberately NOT here — it is emitted (a synthesized
 # preferences row); see gumnut_user_to_sync_user_metadata_v1.
 _NOOP_REQUEST_TYPES: dict[SyncRequestType, SyncEntityType] = {
@@ -169,11 +167,7 @@ _NOOP_REQUEST_TYPES: dict[SyncRequestType, SyncEntityType] = {
     SyncRequestType.MemoryToAssetsV1: SyncEntityType.MemoryToAssetV1,
 }
 
-# Supported SyncRequestTypes (used to detect unsupported types requested by
-# client). AuthUsersV1/UsersV1/UserMetadataV1/StacksV1 are handled specially (not
-# via _SYNC_TYPE_ORDER): the first two stream the user record, UserMetadataV1
-# streams a synthesized preferences row (see gumnut_user_to_sync_user_metadata_v1),
-# and StacksV1 streams a current-state snapshot (see _stream_stacks).
+# User and stack types below are handled outside _SYNC_TYPE_ORDER.
 _SUPPORTED_REQUEST_TYPES: frozenset[SyncRequestType] = frozenset(
     {request_type for request_type, _, _ in _SYNC_TYPE_ORDER}
     | {
@@ -513,36 +507,13 @@ async def _stream_stacks(
     owner_id: UUID,
     checkpoint: Checkpoint | None,
 ) -> AsyncGenerator[str, None]:
-    """Stream StackV1 rows for the StacksV1 sync type.
+    """Stream incremental StackV1 upserts in stable checkpoint order.
 
-    Every sync re-pages the whole stack table (the Gumnut backend emits no stack
-    lifecycle events yet) and emits rows in ``(updated_at, id)`` order, filtered
-    strictly after the checkpoint cursor — which gives incremental upsert and
-    mid-stream resume, with delete detection out of scope. The "Stack Snapshot
-    (StacksV1)" section of ``docs/architecture/sync-stream-architecture.md`` owns
-    why each of those matters and what stays out of scope.
-
-    Two code-local details:
-
-    - Each surviving stack is hydrated through the shared ``hydrate_stack`` — the
-      same helper REST ``/stacks`` uses, so the effective primary matches exactly
-      — which fetches every member even though only the resolved primary id is
-      used here. Reusing the single source of truth is worth the unused member
-      payload; a lean member read is a later optimization if reset latency ever
-      matters.
-    - Only an undecodable ``stack.id`` (a systemic ``asset_stack_`` prefix change)
-      is degraded to a skip, and it is decoded *up front* so the guard cannot also
-      swallow a ``ValidationError`` or ``GumnutError`` raised during member
-      hydration — those are real failures that must surface, not be mislabeled.
-
-    A member-less stack has no honest ``primaryAssetId`` (``SyncStackV1`` requires
-    a non-null one), so ``hydrate_stack`` returns ``None`` — logging a warning —
-    and it is skipped here.
+    The pass re-pages the stack table because the Gumnut API has no stack
+    lifecycle events. Hydration reuses the REST effective-primary rules;
+    undecodable IDs and member-less stacks are skipped.
     """
-    # Collect so the rows can be emitted in a stable (updated_at, id) order — a
-    # plain async-for can't reorder. Normalize to UTC so a naive/aware mix can't
-    # crash the sort or invert the cursor comparison below (same normalization
-    # stack_conversion applies to its member sort).
+    # Stable UTC ordering makes checkpoint comparison and resume deterministic.
     stacks = [
         stack
         async for stack in gumnut_client.stacks.list_stacks(
@@ -559,10 +530,7 @@ async def _stream_stacks(
         if checkpoint_cursor is not None and cursor <= checkpoint_cursor:
             continue
 
-        # Decode the id first: it is the only ValueError this pass degrades on.
-        # Keeping it out of the hydrate call below means a member ValidationError
-        # (pydantic subclasses ValueError) or GumnutError truncates loudly instead
-        # of being mislabeled as an undecodable stack id and silently dropped.
+        # Keep the ValueError guard separate from hydration failures.
         try:
             safe_uuid_from_stack_id(stack.id)
         except ValueError:
@@ -571,7 +539,6 @@ async def _stream_stacks(
 
         hydrated = await hydrate_stack(gumnut_client, stack)
         if hydrated is None:
-            # Member-less stack — hydrate_stack already logged a warning.
             continue
         sync_stack = gumnut_stack_to_sync_stack_v1(
             stack, hydrated.primary_asset_id, owner_id
@@ -714,13 +681,7 @@ async def generate_sync_stream(
         event_counts: dict[str, int] = {}
         total_events = 0
 
-        # Stream the StackV1 snapshot before the asset loop (so each asset's
-        # stackId names a stack the client already holds). See _stream_stacks.
-        # A GumnutError while hydrating one stack ends the pass gracefully rather
-        # than truncating the whole sync: because this runs first, an unhandled
-        # error would suppress assets/albums/faces too. Rows already yielded are
-        # acked, so the remaining stacks resume from the checkpoint next sync,
-        # and the asset loop below still runs this cycle.
+        # Emit stacks before assets; hydration errors must not suppress later types.
         if SyncRequestType.StacksV1 in requested_types:
             stack_checkpoint = checkpoint_map.get(SyncEntityType.StackV1)
             try:

--- a/tests/unit/api/sync/conftest.py
+++ b/tests/unit/api/sync/conftest.py
@@ -72,10 +72,6 @@ def create_mock_gumnut_client(user: Mock) -> Mock:
     client.album_assets.list.return_value = empty_page
     client.people.list.return_value = empty_page
     client.faces.list.return_value = empty_page
-    # Default: no stacks. The StacksV1 snapshot pages this on reset/first sync;
-    # a bare Mock would not be async-iterable and break any test that requests
-    # StacksV1 without setting up its own stacks. Tests that model stacks
-    # override this.
     client.stacks.list_stacks.return_value = empty_page
     return client
 
@@ -173,10 +169,7 @@ def create_mock_asset_data(updated_at: datetime) -> Mock:
     asset.file_data.file_size_bytes = 1059218
     asset.metadata = None
     asset.trashed_at = None
-    # Loose (unstacked) by default. Set explicitly because the sync asset
-    # converter now reads stack_id — a bare Mock attribute would be truthy and
-    # feed a Mock into safe_uuid_from_stack_id. Tests that model a stacked asset
-    # override this with an asset_stack_-prefixed Gumnut ID.
+    # Avoid a truthy auto-created Mock for unstacked assets.
     asset.stack_id = None
     return asset
 

--- a/tests/unit/api/sync/conftest.py
+++ b/tests/unit/api/sync/conftest.py
@@ -72,6 +72,11 @@ def create_mock_gumnut_client(user: Mock) -> Mock:
     client.album_assets.list.return_value = empty_page
     client.people.list.return_value = empty_page
     client.faces.list.return_value = empty_page
+    # Default: no stacks. The StacksV1 snapshot pages this on reset/first sync;
+    # a bare Mock would not be async-iterable and break any test that requests
+    # StacksV1 without setting up its own stacks. Tests that model stacks
+    # override this.
+    client.stacks.list_stacks.return_value = empty_page
     return client
 
 
@@ -168,6 +173,11 @@ def create_mock_asset_data(updated_at: datetime) -> Mock:
     asset.file_data.file_size_bytes = 1059218
     asset.metadata = None
     asset.trashed_at = None
+    # Loose (unstacked) by default. Set explicitly because the sync asset
+    # converter now reads stack_id — a bare Mock attribute would be truthy and
+    # feed a Mock into safe_uuid_from_stack_id. Tests that model a stacked asset
+    # override this with an asset_stack_-prefixed Gumnut ID.
+    asset.stack_id = None
     return asset
 
 

--- a/tests/unit/api/sync/test_datetime_conversion.py
+++ b/tests/unit/api/sync/test_datetime_conversion.py
@@ -297,8 +297,7 @@ class TestGumnutAssetToSyncAssetV1DateHandling:
         # an explicit None the unset Mock attribute would silently produce a
         # truthy Mock and walk the wrong branch.
         asset.metadata = None
-        # Loose by default — the sync asset converter reads stack_id, and an
-        # unset Mock attribute is truthy (see conftest's create_mock_asset_data).
+        # Avoid a truthy auto-created Mock for an unstacked asset.
         asset.stack_id = None
         return asset
 

--- a/tests/unit/api/sync/test_datetime_conversion.py
+++ b/tests/unit/api/sync/test_datetime_conversion.py
@@ -297,6 +297,9 @@ class TestGumnutAssetToSyncAssetV1DateHandling:
         # an explicit None the unset Mock attribute would silently produce a
         # truthy Mock and walk the wrong branch.
         asset.metadata = None
+        # Loose by default — the sync asset converter reads stack_id, and an
+        # unset Mock attribute is truthy (see conftest's create_mock_asset_data).
+        asset.stack_id = None
         return asset
 
     def test_file_created_at_uses_local_datetime_not_file_created_at(self):

--- a/tests/unit/api/sync/test_sync_stream.py
+++ b/tests/unit/api/sync/test_sync_stream.py
@@ -674,9 +674,6 @@ class TestGenerateSyncStream:
         request = SyncStreamDto(
             types=[
                 SyncRequestType.MemoriesV1,
-                # StacksV1 is no longer a no-op — it streams a current-state
-                # snapshot (covered in test_sync_stream_stacks.py). PartnerStacksV1
-                # stays a no-op and stands in for the stack family here.
                 SyncRequestType.PartnerStacksV1,
                 SyncRequestType.PartnersV1,
                 SyncRequestType.AssetMetadataV1,

--- a/tests/unit/api/sync/test_sync_stream.py
+++ b/tests/unit/api/sync/test_sync_stream.py
@@ -674,7 +674,10 @@ class TestGenerateSyncStream:
         request = SyncStreamDto(
             types=[
                 SyncRequestType.MemoriesV1,
-                SyncRequestType.StacksV1,
+                # StacksV1 is no longer a no-op — it streams a current-state
+                # snapshot (covered in test_sync_stream_stacks.py). PartnerStacksV1
+                # stays a no-op and stands in for the stack family here.
+                SyncRequestType.PartnerStacksV1,
                 SyncRequestType.PartnersV1,
                 SyncRequestType.AssetMetadataV1,
             ]

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -101,6 +101,18 @@ class TestAssetStackIdConversion:
 
         assert gumnut_asset_to_sync_asset_v2(asset, TEST_UUID).stackId is None
 
+    def test_undecodable_stack_id_degrades_to_loose_without_raising(self, caplog):
+        """A malformed stack_id (e.g. a backend prefix change) must not abort the
+        sync stream — the asset syncs as loose, with only a debug log (a prefix
+        break is systemic; a per-asset warning would flood the sync)."""
+        asset = make_gumnut_asset(stack_id="not_a_valid_stack_prefix")
+
+        with caplog.at_level("DEBUG"):
+            sync = gumnut_asset_to_sync_asset_v1(asset, TEST_UUID)
+
+        assert sync.stackId is None
+        assert any("not decodable" in record.message for record in caplog.records)
+
 
 # --- Stack converter -----------------------------------------------------------
 

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -1,0 +1,324 @@
+"""Tests for Immich mobile stack-snapshot sync.
+
+Two behaviors ship together here:
+
+- The sync asset converters carry each asset's ``stackId`` (V1 and V2), so a
+  stacked asset names the stack row it belongs to; loose assets stay null.
+- ``StacksV1`` streams a *current-state snapshot* of ``StackV1`` rows on reset /
+  first sync only. There is no Gumnut stack event source yet, so an
+  already-synced client (checkpoint present) receives nothing — incremental
+  create/update/delete support is intentionally out of scope.
+"""
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import Mock
+
+import pytest
+
+from routers.api.sync.converters import (
+    gumnut_asset_to_sync_asset_v1,
+    gumnut_asset_to_sync_asset_v2,
+    gumnut_stack_to_sync_stack_v1,
+)
+from routers.api.sync.stream import _stream_stacks, generate_sync_stream
+from routers.immich_models import SyncEntityType, SyncRequestType, SyncStreamDto
+from routers.utils.gumnut_id_conversion import (
+    safe_uuid_from_asset_id,
+    safe_uuid_from_stack_id,
+)
+from services.checkpoint_store import Checkpoint
+from tests.conftest import (
+    MockSyncCursorPage,
+    make_gumnut_asset,
+    make_gumnut_stack,
+    make_gumnut_stack_with_members,
+)
+from tests.unit.api.sync.conftest import (
+    TEST_UUID,
+    collect_stream,
+    create_mock_event,
+    create_mock_events_response,
+    create_mock_gumnut_client,
+    create_mock_user,
+)
+
+
+def _stacks_page(*stacks):
+    """A ``client.stacks.list_stacks`` mock returning ``stacks`` on any call.
+
+    The snapshot pages with ``limit=`` and no ``ids`` filter, so — unlike the
+    REST ``mock_list_stacks`` helper — this ignores kwargs and replays the full
+    page in the order given, which is the order the snapshot must preserve.
+    """
+    return Mock(return_value=MockSyncCursorPage(list(stacks)))
+
+
+def _members_by_stack(mapping):
+    """A ``client.assets.list`` mock keyed by the ``stack_id`` hydrate_stack asks for."""
+    return Mock(
+        side_effect=lambda **kwargs: MockSyncCursorPage(
+            mapping.get(kwargs.get("stack_id"), [])
+        )
+    )
+
+
+async def _collect(gen):
+    """Collect an async generator of JSON lines into parsed dicts."""
+    return [json.loads(line) async for line in gen]
+
+
+# --- Asset stackId conversion --------------------------------------------------
+
+
+class TestAssetStackIdConversion:
+    """The sync asset converters map the Gumnut stack FK to Immich's stackId."""
+
+    def test_v1_maps_stack_id_to_uuid_string(self):
+        stack = make_gumnut_stack()
+        asset = make_gumnut_asset(stack_id=stack.id)
+
+        sync = gumnut_asset_to_sync_asset_v1(asset, TEST_UUID)
+
+        assert sync.stackId == str(safe_uuid_from_stack_id(stack.id))
+
+    def test_v1_loose_asset_is_null(self):
+        asset = make_gumnut_asset(stack_id=None)
+
+        assert gumnut_asset_to_sync_asset_v1(asset, TEST_UUID).stackId is None
+
+    def test_v2_inherits_stack_id(self):
+        """V2 delegates to V1, so it carries the same stackId."""
+        stack = make_gumnut_stack()
+        asset = make_gumnut_asset(stack_id=stack.id)
+
+        sync = gumnut_asset_to_sync_asset_v2(asset, TEST_UUID)
+
+        assert sync.stackId == str(safe_uuid_from_stack_id(stack.id))
+
+    def test_v2_loose_asset_is_null(self):
+        asset = make_gumnut_asset(stack_id=None)
+
+        assert gumnut_asset_to_sync_asset_v2(asset, TEST_UUID).stackId is None
+
+
+# --- Stack converter -----------------------------------------------------------
+
+
+class TestStackConverter:
+    """gumnut_stack_to_sync_stack_v1 maps a stack row + resolved primary."""
+
+    def test_maps_all_fields(self):
+        created = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        updated = datetime(2025, 2, 2, tzinfo=timezone.utc)
+        stack = make_gumnut_stack()
+        stack.created_at = created
+        stack.updated_at = updated
+        primary = safe_uuid_from_asset_id(make_gumnut_asset().id)
+
+        sync = gumnut_stack_to_sync_stack_v1(stack, primary, TEST_UUID)
+
+        assert sync.id == safe_uuid_from_stack_id(stack.id)
+        assert sync.ownerId == TEST_UUID
+        assert sync.primaryAssetId == primary
+        assert sync.createdAt == created
+        assert sync.updatedAt == updated
+
+
+# --- Stack snapshot streaming (_stream_stacks) ---------------------------------
+
+
+class TestStreamStacks:
+    """The StacksV1 snapshot pass: reset-only, effective-primary, zero-member skip."""
+
+    @pytest.mark.anyio
+    async def test_existing_checkpoint_emits_nothing(self):
+        """A present checkpoint means the client already holds the snapshot —
+        emit no speculative updates and don't even page the stacks."""
+        client = create_mock_gumnut_client(create_mock_user(datetime.now(timezone.utc)))
+        checkpoint = Checkpoint(
+            entity_type=SyncEntityType.StackV1,
+            updated_at=datetime.now(timezone.utc),
+            cursor="StackV1|already-synced",
+        )
+
+        lines = await _collect(_stream_stacks(client, TEST_UUID, checkpoint))
+
+        assert lines == []
+        client.stacks.list_stacks.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_no_checkpoint_uses_pinned_primary(self):
+        """The effective primary honors a pinned cover (matching REST)."""
+        stack, members = make_gumnut_stack_with_members(count=3)
+        stack.primary_asset_id = members[2].id  # user pinned the 3rd frame
+        client = Mock()
+        client.stacks.list_stacks = _stacks_page(stack)
+        client.assets.list = _members_by_stack({stack.id: members})
+
+        lines = await _collect(_stream_stacks(client, TEST_UUID, None))
+
+        assert len(lines) == 1
+        assert lines[0]["type"] == "StackV1"
+        assert lines[0]["data"]["primaryAssetId"] == str(
+            safe_uuid_from_asset_id(members[2].id)
+        )
+        assert lines[0]["data"]["id"] == str(safe_uuid_from_stack_id(stack.id))
+
+    @pytest.mark.anyio
+    async def test_no_checkpoint_synthesizes_primary_for_unpinned_burst(self):
+        """An unpinned burst has no server cover, so the snapshot synthesizes one:
+        the first live frame (fetch_stack_members pins ascending order)."""
+        stack, members = make_gumnut_stack_with_members(count=3)  # unpinned auto_burst
+        assert stack.primary_asset_id is None
+        client = Mock()
+        client.stacks.list_stacks = _stacks_page(stack)
+        client.assets.list = _members_by_stack({stack.id: members})
+
+        lines = await _collect(_stream_stacks(client, TEST_UUID, None))
+
+        assert lines[0]["data"]["primaryAssetId"] == str(
+            safe_uuid_from_asset_id(members[0].id)
+        )
+
+    @pytest.mark.anyio
+    async def test_zero_member_stack_skipped_with_warning(self, caplog):
+        """A member-less stack has no honest required primary — skip it, don't
+        emit an invalid row. hydrate_stack logs the warning."""
+        stack = make_gumnut_stack(asset_count=0)
+        client = Mock()
+        client.stacks.list_stacks = _stacks_page(stack)
+        client.assets.list = _members_by_stack({stack.id: []})
+
+        with caplog.at_level("WARNING"):
+            lines = await _collect(_stream_stacks(client, TEST_UUID, None))
+
+        assert lines == []
+        assert any("no members" in record.message for record in caplog.records)
+
+    @pytest.mark.anyio
+    async def test_multiple_stacks_stream_in_order_with_deterministic_acks(self):
+        """Every stack streams in page order, each with a stable updated_at+id ack,
+        so a reset replays deterministically."""
+        stack_a, members_a = make_gumnut_stack_with_members(count=2)
+        stack_a.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        stack_b, members_b = make_gumnut_stack_with_members(count=2)
+        stack_b.updated_at = datetime(2025, 2, 2, tzinfo=timezone.utc)
+
+        client = Mock()
+        client.stacks.list_stacks = _stacks_page(stack_a, stack_b)
+        client.assets.list = _members_by_stack(
+            {stack_a.id: members_a, stack_b.id: members_b}
+        )
+
+        lines = [
+            (json.loads(line), line)
+            async for line in _stream_stacks(client, TEST_UUID, None)
+        ]
+
+        assert [data["data"]["id"] for data, _ in lines] == [
+            str(safe_uuid_from_stack_id(stack_a.id)),
+            str(safe_uuid_from_stack_id(stack_b.id)),
+        ]
+        assert lines[0][0]["ack"] == (
+            f"StackV1|{stack_a.updated_at.isoformat()}_{stack_a.id}|"
+        )
+        assert lines[1][0]["ack"] == (
+            f"StackV1|{stack_b.updated_at.isoformat()}_{stack_b.id}|"
+        )
+
+
+# --- Snapshot ordering within the full stream ----------------------------------
+
+
+class TestSnapshotOrdering:
+    """StackV1 must precede the assets that name it, and the stream still completes."""
+
+    @pytest.mark.anyio
+    async def test_stack_streamed_before_its_stacked_asset(self):
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        user = create_mock_user(updated_at)
+        client = create_mock_gumnut_client(user)
+
+        stack, members = make_gumnut_stack_with_members(count=1)
+        asset = members[0]  # the lone member, so it is also the effective primary
+
+        client.events.get.return_value = create_mock_events_response(
+            [
+                create_mock_event(
+                    entity_type="asset",
+                    entity_id=asset.id,
+                    event_type="asset_created",
+                    created_at=updated_at,
+                    cursor="cursor_asset_1",
+                )
+            ]
+        )
+        # assets.list serves both the sync entity fetch (ids=) and the stack
+        # member fetch (stack_id=); the same stacked asset satisfies each.
+        client.assets.list = Mock(
+            side_effect=lambda **kwargs: MockSyncCursorPage([asset])
+        )
+        client.stacks.list_stacks = _stacks_page(stack)
+
+        request = SyncStreamDto(
+            types=[SyncRequestType.StacksV1, SyncRequestType.AssetsV2]
+        )
+        events = await collect_stream(generate_sync_stream(client, request, {}, user))
+
+        types = [e["type"] for e in events]
+        assert types.index("StackV1") < types.index("AssetV2")
+
+        stack_event = next(e for e in events if e["type"] == "StackV1")
+        asset_event = next(e for e in events if e["type"] == "AssetV2")
+        # The asset points at exactly the stack row that preceded it.
+        assert asset_event["data"]["stackId"] == str(safe_uuid_from_stack_id(stack.id))
+        assert asset_event["data"]["stackId"] == stack_event["data"]["id"]
+        assert events[-1]["type"] == "SyncCompleteV1"
+
+    @pytest.mark.anyio
+    async def test_existing_stack_checkpoint_streams_no_stacks(self):
+        """With a StackV1 checkpoint, the full stream emits no StackV1 rows."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        user = create_mock_user(updated_at)
+        client = create_mock_gumnut_client(user)
+        client.stacks.list_stacks = _stacks_page(make_gumnut_stack())
+
+        checkpoint_map = {
+            SyncEntityType.StackV1: Checkpoint(
+                entity_type=SyncEntityType.StackV1,
+                updated_at=updated_at,
+                cursor="StackV1|synced",
+            )
+        }
+        request = SyncStreamDto(types=[SyncRequestType.StacksV1])
+
+        events = await collect_stream(
+            generate_sync_stream(client, request, checkpoint_map, user)
+        )
+
+        assert [e["type"] for e in events] == ["SyncCompleteV1"]
+        client.stacks.list_stacks.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_partner_stacks_v1_is_silent_noop(self, caplog):
+        """PartnerStacksV1 stays an intentional no-op: no rows, no 'unsupported'
+        warning, and it never triggers the stack snapshot."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        user = create_mock_user(updated_at)
+        client = create_mock_gumnut_client(user)
+        client.stacks.list_stacks = _stacks_page(make_gumnut_stack())
+
+        request = SyncStreamDto(types=[SyncRequestType.PartnerStacksV1])
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="routers.api.sync.stream"):
+            events = await collect_stream(
+                generate_sync_stream(client, request, {}, user)
+            )
+
+        assert [e["type"] for e in events] == ["SyncCompleteV1"]
+        assert not any(
+            "unsupported sync types" in record.message for record in caplog.records
+        )
+        client.stacks.list_stacks.assert_not_called()

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -1,13 +1,7 @@
-"""Tests for Immich mobile stack-snapshot sync.
-
-Two behaviors ship together here:
-
-- The sync asset converters carry each asset's ``stackId`` (V1 and V2), so a
-  stacked asset names the stack row it belongs to; loose assets stay null.
-- ``StacksV1`` streams a *current-state snapshot* of ``StackV1`` rows on reset /
-  first sync only. There is no Gumnut stack event source yet, so an
-  already-synced client (checkpoint present) receives nothing — incremental
-  create/update/delete support is intentionally out of scope.
+"""Tests for Immich mobile stack-snapshot sync: the asset ``stackId`` mapping and
+the ``StacksV1`` upsert pass. The delivery semantics and scope boundary these
+tests pin live in the "Stack Snapshot (StacksV1)" section of
+``docs/architecture/sync-stream-architecture.md``.
 """
 
 import json
@@ -15,6 +9,7 @@ from datetime import datetime, timezone
 from unittest.mock import Mock
 
 import pytest
+from gumnut import GumnutError
 
 from routers.api.sync.converters import (
     gumnut_asset_to_sync_asset_v1,
@@ -49,7 +44,8 @@ def _stacks_page(*stacks):
 
     The snapshot pages with ``limit=`` and no ``ids`` filter, so — unlike the
     REST ``mock_list_stacks`` helper — this ignores kwargs and replays the full
-    page in the order given, which is the order the snapshot must preserve.
+    page in the order given. ``_stream_stacks`` then re-sorts by ``(updated_at,
+    id)``, so passing rows out of order here exercises that ordering.
     """
     return Mock(return_value=MockSyncCursorPage(list(stacks)))
 
@@ -61,11 +57,6 @@ def _members_by_stack(mapping):
             mapping.get(kwargs.get("stack_id"), [])
         )
     )
-
-
-async def _collect(gen):
-    """Collect an async generator of JSON lines into parsed dicts."""
-    return [json.loads(line) async for line in gen]
 
 
 # --- Asset stackId conversion --------------------------------------------------
@@ -140,24 +131,94 @@ class TestStackConverter:
 # --- Stack snapshot streaming (_stream_stacks) ---------------------------------
 
 
+def _stack_cursor(stack):
+    """The inner ack cursor `_stream_stacks` assigns a stack (no `StackV1|…|` wrapper).
+
+    This is exactly what `_parse_ack` stores as `Checkpoint.cursor`, so a test
+    can build a checkpoint that sits at a known stack's position.
+    """
+    return f"{stack.updated_at.isoformat()}_{stack.id}"
+
+
 class TestStreamStacks:
-    """The StacksV1 snapshot pass: reset-only, effective-primary, zero-member skip."""
+    """The StacksV1 upsert pass: (updated_at, id) order, checkpoint filter,
+    effective-primary, zero-member skip, undecodable-id degrade."""
 
     @pytest.mark.anyio
-    async def test_existing_checkpoint_emits_nothing(self):
-        """A present checkpoint means the client already holds the snapshot —
-        emit no speculative updates and don't even page the stacks."""
-        client = create_mock_gumnut_client(create_mock_user(datetime.now(timezone.utc)))
+    async def test_checkpoint_at_or_after_all_stacks_emits_nothing(self):
+        """A checkpoint at/after every current stack's cursor yields no rows —
+        the client is fully caught up. The pass still re-pages (there is no
+        lifecycle event stream, so every sync must scan for newer stacks)."""
+        stack, members = make_gumnut_stack_with_members(count=2)
+        client = Mock()
+        client.stacks.list_stacks = _stacks_page(stack)
+        client.assets.list = _members_by_stack({stack.id: members})
         checkpoint = Checkpoint(
             entity_type=SyncEntityType.StackV1,
-            updated_at=datetime.now(timezone.utc),
-            cursor="StackV1|already-synced",
+            updated_at=stack.updated_at,
+            cursor=_stack_cursor(stack),  # exactly at the only stack
         )
 
-        lines = await _collect(_stream_stacks(client, TEST_UUID, checkpoint))
+        lines = await collect_stream(_stream_stacks(client, TEST_UUID, checkpoint))
 
         assert lines == []
-        client.stacks.list_stacks.assert_not_called()
+        client.stacks.list_stacks.assert_called_once()  # re-paged, not suppressed
+        # The checkpoint filter runs before hydrate_stack, so a caught-up client
+        # pays zero per-stack member fetches. Locks that ordering in.
+        client.assets.list.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_checkpoint_emits_only_stacks_after_its_cursor(self):
+        """Incremental upsert (and, by the same mechanism, resume after a
+        truncated snapshot): a checkpoint at stack_a's cursor emits only stack_b,
+        so a burst created after the initial sync reaches the client instead of
+        leaving its assets pointing at a stack row the client never received."""
+        stack_a, members_a = make_gumnut_stack_with_members(count=2)
+        stack_a.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        stack_b, members_b = make_gumnut_stack_with_members(count=2)
+        stack_b.updated_at = datetime(2025, 2, 2, tzinfo=timezone.utc)
+        client = Mock()
+        client.stacks.list_stacks = _stacks_page(stack_a, stack_b)
+        client.assets.list = _members_by_stack(
+            {stack_a.id: members_a, stack_b.id: members_b}
+        )
+        checkpoint = Checkpoint(
+            entity_type=SyncEntityType.StackV1,
+            updated_at=stack_a.updated_at,
+            cursor=_stack_cursor(stack_a),
+        )
+
+        lines = await collect_stream(_stream_stacks(client, TEST_UUID, checkpoint))
+
+        assert [line["data"]["id"] for line in lines] == [
+            str(safe_uuid_from_stack_id(stack_b.id))
+        ]
+
+    @pytest.mark.anyio
+    async def test_undecodable_stack_id_skipped_without_aborting(self, caplog):
+        """An undecodable stack id (a systemic prefix change) must not truncate
+        the stream — skip that stack, still emit the decodable ones, and log one
+        aggregated warning. Mirrors _immich_stack_id on the asset side."""
+        good, good_members = make_gumnut_stack_with_members(count=2)
+        good.updated_at = datetime(2025, 2, 2, tzinfo=timezone.utc)
+        bad, bad_members = make_gumnut_stack_with_members(
+            count=2, stack_id="not_a_valid_stack_prefix"
+        )
+        # Sorts before `good`, so the skip has to not abort the rest of the loop.
+        bad.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        client = Mock()
+        client.stacks.list_stacks = _stacks_page(good, bad)
+        client.assets.list = _members_by_stack(
+            {good.id: good_members, bad.id: bad_members}
+        )
+
+        with caplog.at_level("WARNING"):
+            lines = await collect_stream(_stream_stacks(client, TEST_UUID, None))
+
+        assert [line["data"]["id"] for line in lines] == [
+            str(safe_uuid_from_stack_id(good.id))
+        ]
+        assert any("undecodable" in record.message for record in caplog.records)
 
     @pytest.mark.anyio
     async def test_no_checkpoint_uses_pinned_primary(self):
@@ -168,7 +229,7 @@ class TestStreamStacks:
         client.stacks.list_stacks = _stacks_page(stack)
         client.assets.list = _members_by_stack({stack.id: members})
 
-        lines = await _collect(_stream_stacks(client, TEST_UUID, None))
+        lines = await collect_stream(_stream_stacks(client, TEST_UUID, None))
 
         assert len(lines) == 1
         assert lines[0]["type"] == "StackV1"
@@ -187,7 +248,7 @@ class TestStreamStacks:
         client.stacks.list_stacks = _stacks_page(stack)
         client.assets.list = _members_by_stack({stack.id: members})
 
-        lines = await _collect(_stream_stacks(client, TEST_UUID, None))
+        lines = await collect_stream(_stream_stacks(client, TEST_UUID, None))
 
         assert lines[0]["data"]["primaryAssetId"] == str(
             safe_uuid_from_asset_id(members[0].id)
@@ -203,22 +264,23 @@ class TestStreamStacks:
         client.assets.list = _members_by_stack({stack.id: []})
 
         with caplog.at_level("WARNING"):
-            lines = await _collect(_stream_stacks(client, TEST_UUID, None))
+            lines = await collect_stream(_stream_stacks(client, TEST_UUID, None))
 
         assert lines == []
         assert any("no members" in record.message for record in caplog.records)
 
     @pytest.mark.anyio
     async def test_multiple_stacks_stream_in_order_with_deterministic_acks(self):
-        """Every stack streams in page order, each with a stable updated_at+id ack,
-        so a reset replays deterministically."""
+        """Stacks stream in (updated_at, id) order regardless of page order, each
+        with a stable updated_at+id ack, so the ack cursor advances monotonically
+        and a reset replays deterministically. Fed newest-first to prove the sort."""
         stack_a, members_a = make_gumnut_stack_with_members(count=2)
         stack_a.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
         stack_b, members_b = make_gumnut_stack_with_members(count=2)
         stack_b.updated_at = datetime(2025, 2, 2, tzinfo=timezone.utc)
 
         client = Mock()
-        client.stacks.list_stacks = _stacks_page(stack_a, stack_b)
+        client.stacks.list_stacks = _stacks_page(stack_b, stack_a)  # out of order
         client.assets.list = _members_by_stack(
             {stack_a.id: members_a, stack_b.id: members_b}
         )
@@ -238,6 +300,33 @@ class TestStreamStacks:
         assert lines[1][0]["ack"] == (
             f"StackV1|{stack_b.updated_at.isoformat()}_{stack_b.id}|"
         )
+
+    @pytest.mark.anyio
+    async def test_checkpoint_tiebreak_on_id_at_equal_updated_at(self):
+        """When two stacks share an updated_at, the id breaks the tie in both the
+        sort key and the cursor comparison. A checkpoint at the lower id emits
+        only the higher one — so the string cursor and the (updated_at, id) sort
+        can't disagree at the same-instant boundary."""
+        shared = datetime(2025, 3, 3, tzinfo=timezone.utc)
+        s1, m1 = make_gumnut_stack_with_members(count=2)
+        s2, m2 = make_gumnut_stack_with_members(count=2)
+        s1.updated_at = s2.updated_at = shared
+        # Designate low/high by actual (shortuuid-encoded) id order.
+        low, high = sorted([s1, s2], key=lambda s: s.id)
+        client = Mock()
+        client.stacks.list_stacks = _stacks_page(high, low)  # out of order
+        client.assets.list = _members_by_stack({s1.id: m1, s2.id: m2})
+        checkpoint = Checkpoint(
+            entity_type=SyncEntityType.StackV1,
+            updated_at=shared,
+            cursor=_stack_cursor(low),
+        )
+
+        lines = await collect_stream(_stream_stacks(client, TEST_UUID, checkpoint))
+
+        assert [line["data"]["id"] for line in lines] == [
+            str(safe_uuid_from_stack_id(high.id))
+        ]
 
 
 # --- Snapshot ordering within the full stream ----------------------------------
@@ -289,18 +378,21 @@ class TestSnapshotOrdering:
         assert events[-1]["type"] == "SyncCompleteV1"
 
     @pytest.mark.anyio
-    async def test_existing_stack_checkpoint_streams_no_stacks(self):
-        """With a StackV1 checkpoint, the full stream emits no StackV1 rows."""
+    async def test_caught_up_stack_checkpoint_streams_no_stacks(self):
+        """With a StackV1 checkpoint at/after the only stack, the full stream
+        emits no StackV1 rows (the client is caught up). The pass still pages —
+        it must scan for stacks newer than the checkpoint."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         user = create_mock_user(updated_at)
         client = create_mock_gumnut_client(user)
-        client.stacks.list_stacks = _stacks_page(make_gumnut_stack())
+        stack = make_gumnut_stack()
+        client.stacks.list_stacks = _stacks_page(stack)
 
         checkpoint_map = {
             SyncEntityType.StackV1: Checkpoint(
                 entity_type=SyncEntityType.StackV1,
-                updated_at=updated_at,
-                cursor="StackV1|synced",
+                updated_at=stack.updated_at,
+                cursor=_stack_cursor(stack),
             )
         }
         request = SyncStreamDto(types=[SyncRequestType.StacksV1])
@@ -310,7 +402,54 @@ class TestSnapshotOrdering:
         )
 
         assert [e["type"] for e in events] == ["SyncCompleteV1"]
-        client.stacks.list_stacks.assert_not_called()
+        client.stacks.list_stacks.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_stack_hydration_error_does_not_truncate_sync(self, caplog):
+        """A GumnutError while hydrating a stack ends the snapshot pass gracefully
+        — the asset loop still runs and the stream still completes — rather than
+        truncating the whole sync (the pass runs before the asset loop)."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        user = create_mock_user(updated_at)
+        client = create_mock_gumnut_client(user)
+        stack, members = make_gumnut_stack_with_members(count=1)
+        asset = members[0]
+
+        client.events.get.return_value = create_mock_events_response(
+            [
+                create_mock_event(
+                    entity_type="asset",
+                    entity_id=asset.id,
+                    event_type="asset_created",
+                    created_at=updated_at,
+                    cursor="cursor_asset_1",
+                )
+            ]
+        )
+        client.stacks.list_stacks = _stacks_page(stack)
+
+        def assets_list(**kwargs):
+            # The member fetch (stack_id=) fails; the asset entity fetch (ids=)
+            # succeeds, so we can prove the asset loop still ran.
+            if "stack_id" in kwargs:
+                raise GumnutError("stack member fetch failed")
+            return MockSyncCursorPage([asset])
+
+        client.assets.list = Mock(side_effect=assets_list)
+
+        request = SyncStreamDto(
+            types=[SyncRequestType.StacksV1, SyncRequestType.AssetsV2]
+        )
+        with caplog.at_level("WARNING"):
+            events = await collect_stream(
+                generate_sync_stream(client, request, {}, user)
+            )
+
+        types = [e["type"] for e in events]
+        assert "StackV1" not in types  # the only stack failed to hydrate
+        assert "AssetV2" in types  # asset loop still ran this cycle
+        assert events[-1]["type"] == "SyncCompleteV1"  # completed, not truncated
+        assert any("cut short" in record.message for record in caplog.records)
 
     @pytest.mark.anyio
     async def test_partner_stacks_v1_is_silent_noop(self, caplog):
@@ -322,9 +461,8 @@ class TestSnapshotOrdering:
         client.stacks.list_stacks = _stacks_page(make_gumnut_stack())
 
         request = SyncStreamDto(types=[SyncRequestType.PartnerStacksV1])
-        import logging
 
-        with caplog.at_level(logging.INFO, logger="routers.api.sync.stream"):
+        with caplog.at_level("INFO", logger="routers.api.sync.stream"):
             events = await collect_stream(
                 generate_sync_stream(client, request, {}, user)
             )

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -1,8 +1,4 @@
-"""Tests for Immich mobile stack-snapshot sync: the asset ``stackId`` mapping and
-the ``StacksV1`` upsert pass. The delivery semantics and scope boundary these
-tests pin live in the "Stack Snapshot (StacksV1)" section of
-``docs/architecture/sync-stream-architecture.md``.
-"""
+"""Tests for stack membership and incremental StackV1 upserts."""
 
 import json
 from datetime import datetime, timezone
@@ -40,18 +36,12 @@ from tests.unit.api.sync.conftest import (
 
 
 def _stacks_page(*stacks):
-    """A ``client.stacks.list_stacks`` mock returning ``stacks`` on any call.
-
-    The snapshot pages with ``limit=`` and no ``ids`` filter, so — unlike the
-    REST ``mock_list_stacks`` helper — this ignores kwargs and replays the full
-    page in the order given. ``_stream_stacks`` then re-sorts by ``(updated_at,
-    id)``, so passing rows out of order here exercises that ordering.
-    """
+    """Return the given stacks for any list_stacks call."""
     return Mock(return_value=MockSyncCursorPage(list(stacks)))
 
 
 def _members_by_stack(mapping):
-    """A ``client.assets.list`` mock keyed by the ``stack_id`` hydrate_stack asks for."""
+    """Return members by stack_id."""
     return Mock(
         side_effect=lambda **kwargs: MockSyncCursorPage(
             mapping.get(kwargs.get("stack_id"), [])
@@ -59,12 +49,7 @@ def _members_by_stack(mapping):
     )
 
 
-# --- Asset stackId conversion --------------------------------------------------
-
-
 class TestAssetStackIdConversion:
-    """The sync asset converters map the Gumnut stack FK to Immich's stackId."""
-
     def test_v1_maps_stack_id_to_uuid_string(self):
         stack = make_gumnut_stack()
         asset = make_gumnut_asset(stack_id=stack.id)
@@ -79,7 +64,6 @@ class TestAssetStackIdConversion:
         assert gumnut_asset_to_sync_asset_v1(asset, TEST_UUID).stackId is None
 
     def test_v2_inherits_stack_id(self):
-        """V2 delegates to V1, so it carries the same stackId."""
         stack = make_gumnut_stack()
         asset = make_gumnut_asset(stack_id=stack.id)
 
@@ -93,9 +77,6 @@ class TestAssetStackIdConversion:
         assert gumnut_asset_to_sync_asset_v2(asset, TEST_UUID).stackId is None
 
     def test_undecodable_stack_id_degrades_to_loose_without_raising(self, caplog):
-        """A malformed stack_id (e.g. a backend prefix change) must not abort the
-        sync stream — the asset syncs as loose, with only a debug log (a prefix
-        break is systemic; a per-asset warning would flood the sync)."""
         asset = make_gumnut_asset(stack_id="not_a_valid_stack_prefix")
 
         with caplog.at_level("DEBUG"):
@@ -105,12 +86,7 @@ class TestAssetStackIdConversion:
         assert any("not decodable" in record.message for record in caplog.records)
 
 
-# --- Stack converter -----------------------------------------------------------
-
-
 class TestStackConverter:
-    """gumnut_stack_to_sync_stack_v1 maps a stack row + resolved primary."""
-
     def test_maps_all_fields(self):
         created = datetime(2025, 1, 1, tzinfo=timezone.utc)
         updated = datetime(2025, 2, 2, tzinfo=timezone.utc)
@@ -128,27 +104,14 @@ class TestStackConverter:
         assert sync.updatedAt == updated
 
 
-# --- Stack snapshot streaming (_stream_stacks) ---------------------------------
-
-
 def _stack_cursor(stack):
-    """The inner ack cursor `_stream_stacks` assigns a stack (no `StackV1|…|` wrapper).
-
-    This is exactly what `_parse_ack` stores as `Checkpoint.cursor`, so a test
-    can build a checkpoint that sits at a known stack's position.
-    """
+    """Return the checkpoint cursor for a stack."""
     return f"{stack.updated_at.isoformat()}_{stack.id}"
 
 
 class TestStreamStacks:
-    """The StacksV1 upsert pass: (updated_at, id) order, checkpoint filter,
-    effective-primary, zero-member skip, undecodable-id degrade."""
-
     @pytest.mark.anyio
     async def test_checkpoint_at_or_after_all_stacks_emits_nothing(self):
-        """A checkpoint at/after every current stack's cursor yields no rows —
-        the client is fully caught up. The pass still re-pages (there is no
-        lifecycle event stream, so every sync must scan for newer stacks)."""
         stack, members = make_gumnut_stack_with_members(count=2)
         client = Mock()
         client.stacks.list_stacks = _stacks_page(stack)
@@ -156,23 +119,17 @@ class TestStreamStacks:
         checkpoint = Checkpoint(
             entity_type=SyncEntityType.StackV1,
             updated_at=stack.updated_at,
-            cursor=_stack_cursor(stack),  # exactly at the only stack
+            cursor=_stack_cursor(stack),
         )
 
         lines = await collect_stream(_stream_stacks(client, TEST_UUID, checkpoint))
 
         assert lines == []
-        client.stacks.list_stacks.assert_called_once()  # re-paged, not suppressed
-        # The checkpoint filter runs before hydrate_stack, so a caught-up client
-        # pays zero per-stack member fetches. Locks that ordering in.
+        client.stacks.list_stacks.assert_called_once()
         client.assets.list.assert_not_called()
 
     @pytest.mark.anyio
     async def test_checkpoint_emits_only_stacks_after_its_cursor(self):
-        """Incremental upsert (and, by the same mechanism, resume after a
-        truncated snapshot): a checkpoint at stack_a's cursor emits only stack_b,
-        so a burst created after the initial sync reaches the client instead of
-        leaving its assets pointing at a stack row the client never received."""
         stack_a, members_a = make_gumnut_stack_with_members(count=2)
         stack_a.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
         stack_b, members_b = make_gumnut_stack_with_members(count=2)
@@ -196,15 +153,11 @@ class TestStreamStacks:
 
     @pytest.mark.anyio
     async def test_undecodable_stack_id_skipped_without_aborting(self, caplog):
-        """An undecodable stack id (a systemic prefix change) must not truncate
-        the stream — skip that stack, still emit the decodable ones, and log one
-        aggregated warning. Mirrors _immich_stack_id on the asset side."""
         good, good_members = make_gumnut_stack_with_members(count=2)
         good.updated_at = datetime(2025, 2, 2, tzinfo=timezone.utc)
         bad, bad_members = make_gumnut_stack_with_members(
             count=2, stack_id="not_a_valid_stack_prefix"
         )
-        # Sorts before `good`, so the skip has to not abort the rest of the loop.
         bad.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
         client = Mock()
         client.stacks.list_stacks = _stacks_page(good, bad)
@@ -222,9 +175,8 @@ class TestStreamStacks:
 
     @pytest.mark.anyio
     async def test_no_checkpoint_uses_pinned_primary(self):
-        """The effective primary honors a pinned cover (matching REST)."""
         stack, members = make_gumnut_stack_with_members(count=3)
-        stack.primary_asset_id = members[2].id  # user pinned the 3rd frame
+        stack.primary_asset_id = members[2].id
         client = Mock()
         client.stacks.list_stacks = _stacks_page(stack)
         client.assets.list = _members_by_stack({stack.id: members})
@@ -240,9 +192,7 @@ class TestStreamStacks:
 
     @pytest.mark.anyio
     async def test_no_checkpoint_synthesizes_primary_for_unpinned_burst(self):
-        """An unpinned burst has no server cover, so the snapshot synthesizes one:
-        the first live frame (fetch_stack_members pins ascending order)."""
-        stack, members = make_gumnut_stack_with_members(count=3)  # unpinned auto_burst
+        stack, members = make_gumnut_stack_with_members(count=3)
         assert stack.primary_asset_id is None
         client = Mock()
         client.stacks.list_stacks = _stacks_page(stack)
@@ -256,8 +206,6 @@ class TestStreamStacks:
 
     @pytest.mark.anyio
     async def test_zero_member_stack_skipped_with_warning(self, caplog):
-        """A member-less stack has no honest required primary — skip it, don't
-        emit an invalid row. hydrate_stack logs the warning."""
         stack = make_gumnut_stack(asset_count=0)
         client = Mock()
         client.stacks.list_stacks = _stacks_page(stack)
@@ -271,16 +219,13 @@ class TestStreamStacks:
 
     @pytest.mark.anyio
     async def test_multiple_stacks_stream_in_order_with_deterministic_acks(self):
-        """Stacks stream in (updated_at, id) order regardless of page order, each
-        with a stable updated_at+id ack, so the ack cursor advances monotonically
-        and a reset replays deterministically. Fed newest-first to prove the sort."""
         stack_a, members_a = make_gumnut_stack_with_members(count=2)
         stack_a.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
         stack_b, members_b = make_gumnut_stack_with_members(count=2)
         stack_b.updated_at = datetime(2025, 2, 2, tzinfo=timezone.utc)
 
         client = Mock()
-        client.stacks.list_stacks = _stacks_page(stack_b, stack_a)  # out of order
+        client.stacks.list_stacks = _stacks_page(stack_b, stack_a)
         client.assets.list = _members_by_stack(
             {stack_a.id: members_a, stack_b.id: members_b}
         )
@@ -303,18 +248,13 @@ class TestStreamStacks:
 
     @pytest.mark.anyio
     async def test_checkpoint_tiebreak_on_id_at_equal_updated_at(self):
-        """When two stacks share an updated_at, the id breaks the tie in both the
-        sort key and the cursor comparison. A checkpoint at the lower id emits
-        only the higher one — so the string cursor and the (updated_at, id) sort
-        can't disagree at the same-instant boundary."""
         shared = datetime(2025, 3, 3, tzinfo=timezone.utc)
         s1, m1 = make_gumnut_stack_with_members(count=2)
         s2, m2 = make_gumnut_stack_with_members(count=2)
         s1.updated_at = s2.updated_at = shared
-        # Designate low/high by actual (shortuuid-encoded) id order.
         low, high = sorted([s1, s2], key=lambda s: s.id)
         client = Mock()
-        client.stacks.list_stacks = _stacks_page(high, low)  # out of order
+        client.stacks.list_stacks = _stacks_page(high, low)
         client.assets.list = _members_by_stack({s1.id: m1, s2.id: m2})
         checkpoint = Checkpoint(
             entity_type=SyncEntityType.StackV1,
@@ -329,12 +269,7 @@ class TestStreamStacks:
         ]
 
 
-# --- Snapshot ordering within the full stream ----------------------------------
-
-
 class TestSnapshotOrdering:
-    """StackV1 must precede the assets that name it, and the stream still completes."""
-
     @pytest.mark.anyio
     async def test_stack_streamed_before_its_stacked_asset(self):
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
@@ -342,7 +277,7 @@ class TestSnapshotOrdering:
         client = create_mock_gumnut_client(user)
 
         stack, members = make_gumnut_stack_with_members(count=1)
-        asset = members[0]  # the lone member, so it is also the effective primary
+        asset = members[0]
 
         client.events.get.return_value = create_mock_events_response(
             [
@@ -355,8 +290,7 @@ class TestSnapshotOrdering:
                 )
             ]
         )
-        # assets.list serves both the sync entity fetch (ids=) and the stack
-        # member fetch (stack_id=); the same stacked asset satisfies each.
+        # Serve both the entity fetch (ids=) and stack hydration (stack_id=).
         client.assets.list = Mock(
             side_effect=lambda **kwargs: MockSyncCursorPage([asset])
         )
@@ -372,16 +306,12 @@ class TestSnapshotOrdering:
 
         stack_event = next(e for e in events if e["type"] == "StackV1")
         asset_event = next(e for e in events if e["type"] == "AssetV2")
-        # The asset points at exactly the stack row that preceded it.
         assert asset_event["data"]["stackId"] == str(safe_uuid_from_stack_id(stack.id))
         assert asset_event["data"]["stackId"] == stack_event["data"]["id"]
         assert events[-1]["type"] == "SyncCompleteV1"
 
     @pytest.mark.anyio
     async def test_caught_up_stack_checkpoint_streams_no_stacks(self):
-        """With a StackV1 checkpoint at/after the only stack, the full stream
-        emits no StackV1 rows (the client is caught up). The pass still pages —
-        it must scan for stacks newer than the checkpoint."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         user = create_mock_user(updated_at)
         client = create_mock_gumnut_client(user)
@@ -406,9 +336,6 @@ class TestSnapshotOrdering:
 
     @pytest.mark.anyio
     async def test_stack_hydration_error_does_not_truncate_sync(self, caplog):
-        """A GumnutError while hydrating a stack ends the snapshot pass gracefully
-        — the asset loop still runs and the stream still completes — rather than
-        truncating the whole sync (the pass runs before the asset loop)."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         user = create_mock_user(updated_at)
         client = create_mock_gumnut_client(user)
@@ -429,8 +356,7 @@ class TestSnapshotOrdering:
         client.stacks.list_stacks = _stacks_page(stack)
 
         def assets_list(**kwargs):
-            # The member fetch (stack_id=) fails; the asset entity fetch (ids=)
-            # succeeds, so we can prove the asset loop still ran.
+            # Fail stack hydration but allow the later asset fetch.
             if "stack_id" in kwargs:
                 raise GumnutError("stack member fetch failed")
             return MockSyncCursorPage([asset])
@@ -446,15 +372,13 @@ class TestSnapshotOrdering:
             )
 
         types = [e["type"] for e in events]
-        assert "StackV1" not in types  # the only stack failed to hydrate
-        assert "AssetV2" in types  # asset loop still ran this cycle
-        assert events[-1]["type"] == "SyncCompleteV1"  # completed, not truncated
+        assert "StackV1" not in types
+        assert "AssetV2" in types
+        assert events[-1]["type"] == "SyncCompleteV1"
         assert any("cut short" in record.message for record in caplog.records)
 
     @pytest.mark.anyio
     async def test_partner_stacks_v1_is_silent_noop(self, caplog):
-        """PartnerStacksV1 stays an intentional no-op: no rows, no 'unsupported'
-        warning, and it never triggers the stack snapshot."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         user = create_mock_user(updated_at)
         client = create_mock_gumnut_client(user)

--- a/tests/unit/api/sync/test_sync_v2.py
+++ b/tests/unit/api/sync/test_sync_v2.py
@@ -228,7 +228,7 @@ def test_album_user_converter_sets_owner_role():
 def test_requested_empty_v3_types_are_explicit_noops():
     """Every v3 type the client requests but the adapter has no data for is an
     explicit no-op (so it is not logged "unsupported" on every sync). Excludes
-    UserMetadataV1, which is emitted, not a no-op."""
+    UserMetadataV1 and StacksV1, which are emitted, not no-ops."""
     empty_requested = {
         SyncRequestType.AssetMetadataV1,
         SyncRequestType.PartnersV1,
@@ -237,7 +237,6 @@ def test_requested_empty_v3_types_are_explicit_noops():
         SyncRequestType.AlbumAssetExifsV1,
         SyncRequestType.MemoriesV1,
         SyncRequestType.MemoryToAssetsV1,
-        SyncRequestType.StacksV1,
     }
     assert empty_requested <= set(_NOOP_REQUEST_TYPES)
     assert empty_requested <= _SUPPORTED_REQUEST_TYPES
@@ -247,6 +246,11 @@ def test_requested_empty_v3_types_are_explicit_noops():
     # UserMetadataV1 is emitted, so it must NOT be a no-op, but still supported.
     assert SyncRequestType.UserMetadataV1 not in _NOOP_REQUEST_TYPES
     assert SyncRequestType.UserMetadataV1 in _SUPPORTED_REQUEST_TYPES
+    # StacksV1 became a current-state snapshot (see _stream_stacks): supported,
+    # emitted, and therefore no longer a no-op. PartnerStacksV1 stays a no-op.
+    assert SyncRequestType.StacksV1 not in _NOOP_REQUEST_TYPES
+    assert SyncRequestType.StacksV1 in _SUPPORTED_REQUEST_TYPES
+    assert SyncRequestType.PartnerStacksV1 in _NOOP_REQUEST_TYPES
 
 
 # --- UserMetadataV1 preferences (minimumFaces override) ------------------------

--- a/tests/unit/api/sync/test_sync_v2.py
+++ b/tests/unit/api/sync/test_sync_v2.py
@@ -246,8 +246,6 @@ def test_requested_empty_v3_types_are_explicit_noops():
     # UserMetadataV1 is emitted, so it must NOT be a no-op, but still supported.
     assert SyncRequestType.UserMetadataV1 not in _NOOP_REQUEST_TYPES
     assert SyncRequestType.UserMetadataV1 in _SUPPORTED_REQUEST_TYPES
-    # StacksV1 became a current-state snapshot (see _stream_stacks): supported,
-    # emitted, and therefore no longer a no-op. PartnerStacksV1 stays a no-op.
     assert SyncRequestType.StacksV1 not in _NOOP_REQUEST_TYPES
     assert SyncRequestType.StacksV1 in _SUPPORTED_REQUEST_TYPES
     assert SyncRequestType.PartnerStacksV1 in _NOOP_REQUEST_TYPES


### PR DESCRIPTION
## What

- Sync asset rows now carry their `stackId` (Gumnut stack FK → Immich UUID) in both `SyncAssetV1` and `SyncAssetV2`; loose assets stay null. An undecodable stack_id degrades the asset to loose rather than aborting the stream.
- New `StacksV1` pass (`_stream_stacks`, before the asset loop): emits `StackV1` rows as **upsert-only incremental** delivery — every sync re-pages the stack table, sorts by `(updated_at, id)`, and emits rows after the checkpoint cursor. `primaryAssetId` is resolved by the same effective-primary helper the REST `/stacks` surfaces use; member-less stacks are skipped with a warning.
- `StacksV1` moved out of `_NOOP_REQUEST_TYPES` into the special current-state handling; `PartnerStacksV1` stays a no-op.

## Why

Immich mobile groups burst members under a stack via each asset's `stackId` and the `StacksV1` stream. Neither existed in the adapter — assets emitted `stackId=None` and `StacksV1` was a no-op, so bursts never collapsed on mobile.

Gumnut emits no stack lifecycle events yet, so stacks are delivered by re-paging the table each sync rather than as an event delta. The delivery is **upsert-only incremental**, not reset-only: asset rows carry `stackId` from current entity state unconditionally, so a burst created *after* the initial sync would otherwise leave its member assets pointing at a stack row the client never received — and the mobile timeline join (`... AND (rae.stack_id IS NULL OR rae.id = se.primary_asset_id)`) hides **every frame** of a burst whose stack row is missing. Emitting rows after the checkpoint cursor keeps new bursts visible and makes the pass resumable after a truncated stream. **Delete detection stays out of scope** (a separate event-support track): a dissolved stack's row goes stale but is benign under that same join, and the full table is never re-emitted to express a delete.

Because the pass runs before the asset loop, a Gumnut API error while hydrating one stack is caught at the call site and ends the pass gracefully — already-streamed rows are acked, the asset loop still runs, and the remaining stacks resume next sync — rather than truncating the whole sync. Stacks are emitted before assets for the asset→stack direction; the mobile client's `stackId`/`primaryAssetId` columns are unenforced indexes, so the circular reference isn't order-sensitive in practice.

Full rationale and scope boundary: the "Stack Snapshot (StacksV1)" section of `docs/architecture/sync-stream-architecture.md`.

## Test plan

- `tests/unit/api/sync/test_sync_stream_stacks.py`: V1/V2 asset stackId + loose null, undecodable-stack_id degrade, stack converter field mapping; snapshot with pinned vs synthesized primary, zero-member skip + warning; **incremental** emission (only stacks after the cursor), **caught-up** checkpoint emits nothing but still pages and pays no member fetches, **id tiebreak** at equal `updated_at`, undecodable-id skip without aborting (bad stack sorted first), **graceful degrade** on a hydration `GumnutError` (asset loop still runs, `SyncCompleteV1` intact); StackV1-before-stacked-asset ordering, `PartnerStacksV1` silent no-op.
- Updated the two no-op invariant tests (`StacksV1` is no longer a no-op) and conftest defaults.
- Full suite green: 1679 passed; ruff, pyright, and docs lint clean.

Generated by an AI coding agent.