### PR TITLE
docs: prune historical adapter design records

### DIFF
--- a/docs/design-docs/auth-design.md
+++ b/docs/design-docs/auth-design.md
@@ -3,16 +3,17 @@ title: "Updated Authentication Design"
 status: deprecated
 superseded-by: ../architecture/adapter-architecture.md
 created: 2025-12-06
-last-updated: 2026-07-27
+last-updated: 2026-08-05
 ---
 
 # Updated Authentication Design Document
 
-> **Deprecated (2026-07-27):** This doc proposed the session-token authentication architecture, which shipped. The living description of how adapter auth works today is [`docs/architecture/adapter-architecture.md`](../architecture/adapter-architecture.md) § "Authentication and Session Management", with the Redis-side detail in [`docs/architecture/session-checkpoint-implementation.md`](../architecture/session-checkpoint-implementation.md); this doc is retained for the decision rationale and trade-offs considered. It is no longer updated as the system changes, and the body has already drifted: it names backend endpoints (`/auth/auth-url`, `/auth/exchange`) that do not match the real `/api/oauth/*` paths, knows only two session-token sources where the middleware accepts three (cookie, `Authorization: Bearer`, and `x-immich-user-token`), and omits three OAuth routes that exist today (`/link`, `/unlink`, `/mobile-redirect`).
->
-> Also pruned 2026-07-27: the "Adapter Architecture / Middleware-Based Token Handling" section (a file-path inventory and a generic benefits list — `adapter-architecture.md` owns the file map and request flow), "Flow 3: Token Refresh" (a restatement of Flow 2; its one novel line was folded into Flow 2's Key Points), and the Conclusion's "Key Benefits" list (a verbatim restatement of "Why Session Tokens").
->
-> Pruned 2026-07-27 to its decision record; implementation detail was removed as it is owned by the code. That pass also removed Flow 1's login response-body JSON dump, whose shape is owned by the generated Immich model; the one point it carried that the surrounding prose did not — that the client receives the session token and never the raw Gumnut JWT — was folded into the step above it.
+> **Deprecated —** This document records why the adapter introduced stable
+> session tokens in front of Gumnut JWTs. It was pruned on 2026-08-05 to the
+> constraints, architecture, rationale, and outcome; endpoint-by-endpoint flows
+> and component inventories are owned by the implementation. For current
+> behavior, see [`adapter-architecture.md`](../architecture/adapter-architecture.md)
+> and [`session-checkpoint-implementation.md`](../architecture/session-checkpoint-implementation.md).
 
 Date: 2025-12-05
 
@@ -78,50 +79,6 @@ The adapter now generates a stable UUID session token at login and returns that 
                                                       └──────────────┘
 ```
 
-### Component Responsibilities
-
-### 1. Web Client (Browser)
-
-- Initiates OAuth authentication flow
-- Stores session token in cookies (managed by adapter)
-- Sends requests with cookies
-- **Does not handle token refresh** - adapter manages cookies automatically
-
-### 2. Mobile Client (Mobile App)
-
-- Initiates OAuth authentication flow
-- Stores session token from OAuth response body
-- Sends requests with `Authorization: Bearer` header
-- Keeps the stable session token returned at login; backend JWT refresh stays internal to the adapter
-
-### 3. Immich Adapter (Session Manager with Middleware)
-
-- **Role**: Session management and request forwarding
-- **Session Generation**: Creates UUID session tokens at login
-- **JWT Storage**: Stores encrypted Gumnut JWTs in Redis, keyed by session token
-- **Auth Middleware**: Handles session token extraction and JWT lookup for both client types
-- **Client Type Detection**: Identifies web vs mobile clients by request format
-- **Token Refresh Handling**:
-  - Extracts session token from cookies (web) or Authorization header (mobile)
-  - Looks up stored JWT from Redis
-  - Forwards requests with JWT to backend
-  - If backend returns new JWT, updates stored JWT in Redis
-  - Session token remains stable across JWT refreshes
-- **OAuth endpoints**: Forwards to backend authentication endpoints
-- **No JWT validation**: Does not validate JWTs (backend responsibility)
-- Maintains Immich API compatibility
-
-### 4. Gumnut Backend (Authentication Server)
-
-- **Role**: All authentication logic and JWT management
-- Validates OAuth tokens with provider
-- Manages user creation/lookup in Clerk
-- Issues JWTs with appropriate expiration
-- Validates JWTs on every API request
-- Handles token refresh logic
-- Handles token revocation
-- Only component that communicates with OAuth Provider and Clerk
-
 ## Session Token Architecture
 
 ### Why Session Tokens (Not Raw JWTs)
@@ -149,158 +106,6 @@ For the complete Redis data model, including:
 - User session indexes
 
 See [`docs/references/session-checkpoint-reference.md`](../references/session-checkpoint-reference.md), which holds the field-level schema.
-
-## Authentication Flows
-
-### Flow 1: Initial Authentication & Token Exchange
-
-```
-User → Web Client → Adapter → Backend → OAuth Provider → Clerk
-```
-
-**Sequence:**
-
-1. **User initiates login**
-   - Web client calls adapter: `POST /api/oauth/authorize`
-   - Body: `{redirectUri: "http://localhost:3000/auth/callback"}`
-
-2. **Adapter forwards to backend**
-   - Adapter calls backend: `GET /auth/auth-url`
-   - Params: `redirect_uri`, optional PKCE params
-   - Backend creates CSRF state token
-   - Backend builds authorization URL for OAuth provider
-   - Backend returns authorization URL to adapter
-   - Adapter returns URL to web client
-
-3. **OAuth provider authentication**
-   - Web client redirects user to OAuth provider
-   - User sees consent dialog and approves
-   - OAuth provider redirects back with authorization code
-
-4. **Token exchange**
-   - Web client calls adapter: `POST /api/oauth/callback`
-   - Body: `{url: "callback_url_with_code_and_state"}`
-   - Adapter parses code, state, and error from callback URL
-   - Adapter forwards to backend: `POST /auth/exchange`
-   - Body: `{code: "code_from_provider", state: "state_from_provider", error: "error_if_any_from_provider"}`
-
-5. **Backend processes OAuth token**
-   - Backend validates CSRF state
-   - Backend exchanges code for access token with OAuth provider
-   - Backend validates ID token (if present)
-   - Backend fetches user info from userinfo endpoint
-   - Backend checks Clerk for existing user (by email)
-   - If user doesn't exist, creates user in Clerk
-   - Backend generates JWT containing Clerk user_id
-   - Backend returns JWT + user info to adapter
-
-6. **Adapter creates session and responds to client**
-   - Adapter generates UUID session token
-   - Adapter encrypts and stores Gumnut JWT in Redis, keyed by session token
-   - Adapter sets cookies:
-     - `immich_access_token=<session_token>` (httponly)
-     - `immich_auth_type=oauth` (httponly)
-     - `immich_is_authenticated=true`
-   - Adapter returns the session token as `accessToken` alongside the Immich login response's user fields (the generated Immich model owns the exact shape) — note the client receives the session token here, never the raw Gumnut JWT
-   - Client stores session token
-
-**Key Points:**
-
-- Backend determines JWT expiration policy
-- Adapter generates session token and stores encrypted JWT
-- Client stores and manages session token (not the raw JWT)
-- CSRF protection handled by backend
-- Stale or replayed callback exchanges surface the backend's 400 response so the client can restart the login flow
-
-### Flow 2: Subsequent API Requests (with Token Refresh)
-
-```
-User → Web/Mobile Client → Adapter Middleware → Backend → Gumnut API
-```
-
-> This flow describes the session-token clients (web/mobile). API-key clients skip session lookup and refresh entirely — see "API-key clients are the exception" under *Implemented Architecture*.
-
-**Sequence:**
-
-1. **User makes API request**
-   - **Web client**: Sends request with `immich_access_token` cookie (contains session token)
-   - **Mobile client**: Sends request with `Authorization: Bearer {session_token}` header
-   - Request goes to adapter API endpoint (e.g., `GET /api/albums`)
-
-2. **Adapter middleware processes request**
-   - Detects client type:
-     - If `Authorization` header present -> mobile client
-     - If `immich_access_token` cookie present -> web client
-   - Extracts session token from appropriate source
-   - Looks up session in Redis by session token
-   - Retrieves and decrypts stored Gumnut JWT
-   - Adds `Authorization: Bearer {jwt}` header for backend
-   - Request forwarded to endpoint handler
-
-3. **Adapter forwards to backend**
-   - Endpoint handler forwards request to backend
-   - Includes Gumnut JWT in `Authorization` header
-   - Same method, path, and body
-
-4. **Backend validates JWT and processes request**
-   - Backend verifies JWT signature
-   - Backend checks JWT expiration
-   - Backend extracts user_id from JWT claims
-   - Backend processes request for authenticated user
-   - **If JWT is close to expiration**: Backend generates new JWT
-
-5. **Backend response**
-   - Backend returns API response
-   - **If token refreshed**: Includes `X-New-Access-Token: {new_jwt}` header
-
-6. **Adapter middleware processes response**
-   - Checks for `X-New-Access-Token` header
-   - If present:
-     - Updates stored JWT in Redis (encrypted)
-     - **Session token remains unchanged**
-     - Removes `X-New-Access-Token` header from response (client doesn't need it)
-
-7. **Response to client**
-   - Adapter forwards response to client
-   - **Web client**: Unaware of JWT refresh (cookie unchanged, same session token)
-   - **Mobile client**: Unaware of JWT refresh (same session token)
-
-**Key Points:**
-
-- **Middleware handles all token logic** - endpoint code unchanged
-- Adapter performs **no JWT validation** (only session lookup)
-- All authorization logic in backend
-- **Token refresh is transparent to all clients** - session token is stable
-- Backend controls when to refresh tokens
-- No separate refresh endpoint needed - refresh happens during normal API requests
-
-### Flow 4: Logout (Session Deletion)
-
-```
-User → Client → Adapter
-```
-
-**Sequence:**
-
-1. **User initiates logout**
-   - Client calls adapter: `POST /api/auth/logout`
-
-2. **Adapter deletes session**
-   - Extracts session token from cookie or header
-   - Deletes session from Redis (including stored JWT)
-   - Clears authentication cookies
-   - Returns success response
-
-3. **Session cleanup**
-   - Session deletion also clears any associated checkpoints
-   - User session index is updated
-   - Next request with this session token will fail authentication
-
-**Key Points:**
-
-- Session deletion is immediate
-- Stored JWT is deleted from Redis
-- Client must re-authenticate to get a new session
 
 ## Conclusion
 

--- a/docs/design-docs/checksum-support.md
+++ b/docs/design-docs/checksum-support.md
@@ -3,12 +3,17 @@ title: "Checksum Support"
 status: deprecated
 superseded-by: ../references/code-practices.md
 created: 2025-11-25
-last-updated: 2026-07-27
+last-updated: 2026-08-05
 ---
 
 # Asset Checksum & Deduplication Analysis
 
-> **Deprecated (2026-07-27):** This doc analyzed Immich's checksum-based deduplication and proposed adding a SHA-1 checksum column to the Gumnut backend, which shipped. The living description of how the adapter handles checksums today — emitting base64 SHA-1 via `resolve_immich_checksum`, and the inbound `bulk_upload_check` dedup path — is [`docs/references/code-practices.md`](../references/code-practices.md) § "Outbound asset checksums". This doc is retained for the decision rationale and the alternatives weighed; it is no longer updated as the system changes. Pruned 2026-07-27 to its decision record; implementation detail was removed as it is owned by the code — specifically the "Schema Changes" section, a column-and-index definition that the backend's asset model owns and that had already drifted from it. Two things proposed below never became reality:
+> **Deprecated —** This document records the checksum-compatibility decision
+> that led to storing SHA-1 alongside Gumnut's SHA-256 checksum. It was pruned
+> on 2026-08-05 to the upstream protocol, chosen approach, and trade-offs; large
+> sample payloads and request walkthroughs are owned by the protocol and code.
+> Current adapter behavior lives in [`code-practices.md`](../references/code-practices.md)
+> under “Outbound asset checksums.” Two proposed details did not ship:
 >
 > - **The composite index did not ship.** This doc proposed indexing both `checksum_sha1` and `(library_id, checksum_sha1)`; the backend's asset model carries a single-column index on `checksum_sha1` only. The composite indexes that exist are on the SHA-256 `checksum` column (the `(library_id, checksum)` unique constraint and a live-rows partial index), not on `checksum_sha1`.
 > - **The Background section is a description of upstream Immich, not of the adapter.** Of the three endpoints it catalogs, only `POST /api/assets/bulk-upload-check` is implemented here. The adapter has no `POST /api/assets/exist` route, and it does not implement the upload-time `x-immich-checksum` duplicate-detection path — do not read that section as an adapter capability list.
@@ -21,105 +26,31 @@ Both the Immich web and mobile clients compute a base64-encoded SHA-1 hash of th
 
 ### Server-Side Deduplication Protocol
 
-The Immich server implements deduplication at multiple stages:
+The upstream Immich server uses checksum and device-identity checks at multiple
+stages:
 
 ### 1. Upload Endpoint (`POST /api/assets`)
 
-**Request Headers:**
-
-```
-x-immich-checksum: <base64-encoded-sha1-hash>
-```
-
-**Request Body (Form Data):**
-
-```
-deviceAssetId: <device-local-asset-id>
-deviceId: <device-identifier>
-fileCreatedAt: <iso8601-timestamp>
-fileModifiedAt: <iso8601-timestamp>
-isFavorite: <boolean>
-duration: <string>
-```
-
-**Deduplication Flow:**
-
-1. Client calculates SHA-1 hash of file before upload
-2. Client sends hash in `x-immich-checksum` header
-3. Server extracts ownerId from authenticated user: `ownerId = req.user.id`
-4. Server queries database: `SELECT * FROM assets WHERE ownerId = ? AND checksum = ?`
-5. If match found:
-   - Return HTTP 200 (not 201)
-   - Response: `{ status: "duplicate", id: "<existing-asset-id>" }`
-6. If no match:
-   - Accept upload
-   - Return HTTP 201
-   - Response: `{ status: "created", id: "<new-asset-id>" }`
+The client sends its base64 SHA-1 in `x-immich-checksum`. Upstream checks that
+checksum within the authenticated owner's assets before accepting the upload,
+returning the existing asset for a duplicate and creating a new asset otherwise.
 
 **Source**: `immich/server/src/middleware/asset-upload.interceptor.ts`
 
 ### 2. Bulk Upload Check Endpoint (`POST /api/assets/bulk-upload-check`)
 
-**Purpose**: Batch-check multiple assets before uploading
-
-**Request:**
-
-```json
-{
-  "assets": [
-    {
-      "id": "client-asset-id-1",
-      "checksum": "<base64-sha1>"
-    },
-    {
-      "id": "client-asset-id-2",
-      "checksum": "<base64-sha1>"
-    }
-  ]
-}
-```
-
-**Response:**
-
-```json
-{
-  "results": [
-    {
-      "id": "client-asset-id-1",
-      "action": "reject",
-      "reason": "duplicate",
-      "assetId": "<existing-server-asset-id>"
-    },
-    {
-      "id": "client-asset-id-2",
-      "action": "accept"
-    }
-  ]
-}
-```
+This endpoint batch-checks client asset IDs and base64 SHA-1 values before
+upload, returning an accept-or-reject decision and the existing server asset ID
+for duplicates. This is the checksum-based preflight surface implemented by the
+adapter.
 
 **Source**: `immich/server/src/services/asset-media.service.ts`
 
 ### 3. Existence Check Endpoint (`POST /api/assets/exist`)
 
-**Purpose**: Check if assets exist by device identifiers
-
-**Request:**
-
-```json
-{
-  "deviceId": "device-uuid",
-  "deviceAssetIds": ["device-asset-1", "device-asset-2"]
-}
-```
-
-**Response:**
-
-```json
-{
-  "existingIds": ["device-asset-1"]
-}
-```
+Upstream also supports checking device-local asset IDs for a device. This is a
+separate identity-based existence protocol, not a checksum lookup, and the
+adapter does not implement this route.
 
 **Source**: `immich/server/src/controllers/asset-media.controller.ts`
 

--- a/docs/design-docs/trash-soft-delete-adapter.md
+++ b/docs/design-docs/trash-soft-delete-adapter.md
@@ -3,16 +3,17 @@ title: "Trash: Soft-Delete with Retention (Adapter)"
 status: deprecated
 superseded-by: ../architecture/adapter-architecture.md
 created: 2026-04-20
-last-updated: 2026-07-27
+last-updated: 2026-08-05
 ---
 
 # Trash: Soft-Delete with Retention (Adapter)
 
-> **Deprecated (2026-07-27):** This doc proposed and recorded the adapter's trash/soft-delete flow, which shipped. The living description — `force` branching, the three trash routes, `trashDays`, trash-aware reads, sync/Socket.IO propagation, count semantics, the enumerate-before-mutate invariant, and the remaining limitations — is [`docs/architecture/adapter-architecture.md`](../architecture/adapter-architecture.md) § "Trash and Deletion Semantics". This doc is retained for the decision rationale and the backend capabilities the work depended on; it is no longer updated as the system changes. Its "Remaining limitations" list has already drifted: the typed SDK now *does* expose trash helpers (`assets.trash` / `assets.restore` / `assets.delete_list` / `assets.empty_trash`), and criterion-less `POST /api/search/metadata` now honors `withDeleted` and `trashedAfter`.
->
-> Also pruned 2026-07-27: the § Verification test-file inventory table, which restated what a directory listing already shows.
->
-> Pruned 2026-07-27 to its decision record; implementation detail was removed as it is owned by the code. A second pass the same day removed the remainder of § Verification — a two-line pointer at the test module and a grep suggestion for shipped work, which the suite itself answers more reliably.
+> **Deprecated —** This document records the adapter-side decisions behind
+> Immich-compatible trash and permanent deletion. It was pruned on 2026-08-05
+> to the context, cross-service contract, and evolution notes; endpoint,
+> filtering, event, and configuration inventories are owned by the code. For
+> current behavior, see [`adapter-architecture.md`](../architecture/adapter-architecture.md)
+> under “Trash and Deletion Semantics.”
 
 ## Context
 
@@ -20,61 +21,14 @@ The adapter now implements Immich's trash flow on top of the Gumnut API soft-del
 
 This work spans delete semantics, trash endpoints, timeline/statistics filters, sync `deletedAt` propagation, WebSocket events, and the `trashDays` value shown in the web app. This doc records the shipped adapter behavior and the remaining deliberate limitations.
 
-## Implemented behavior
+## Implemented outcome
 
-### Delete semantics
-
-`DELETE /api/assets` now branches on Immich's `force` flag:
-
-- `force=false` or omitted: soft-delete via `POST /api/assets/trash`
-- `force=true`: permanent delete via bulk `DELETE /api/assets`
-
-Both paths batch requests by `GUMNUT_API_MAX_BULK_IDS`. Soft-delete emits one `on_asset_trash` event per chunk carrying the full id array. Permanent delete emits one `on_asset_delete` event per id, matching Immich's wire shape for hard deletes.
-
-The backend trash and delete endpoints are idempotent for already-transitioned ids, so the adapter does not need the old per-id 404 swallowing loop.
-
-### Trash endpoints
-
-| Endpoint | Current behavior | Count semantics |
-|----------|------------------|-----------------|
-| `POST /api/trash/restore/assets` | Restores the requested ids in chunks via `POST /api/assets/restore` | Returns `len(request.ids)` because the upstream restore endpoint returns `204` with no per-row count |
-| `POST /api/trash/restore` | Enumerates the caller's `state="trashed"` assets, then restores them in chunks | Returns the upfront enumerated id count; concurrent changes can make the exact number of transitioned rows slightly smaller |
-| `POST /api/trash/empty` | Enumerates the caller's `state="trashed"` assets, then permanently deletes them in chunks | Returns the upfront enumerated id count; concurrent changes can make the exact number of transitioned rows slightly smaller |
-
-The restore-all and empty-trash flows collect the trashed id list before mutating anything so the pagination cursor stays stable while the `state="trashed"` result set shrinks.
-
-### Trash-aware read paths
-
-Trash state is now visible across the adapter's main read surfaces:
-
-- `GET /api/timeline/buckets?isTrashed=true` passes `state="trashed"` to the monthly counts query.
-- `GET /api/timeline/bucket?isTrashed=true` passes `state="trashed"` to asset listing and populates each response entry's `isTrashed` value from that asset's `trashed_at` field.
-- `GET /api/assets/statistics?isTrashed=true` passes `state="trashed"` through to the backend listing path.
-- `AssetResponseDto.isTrashed` and the upload-ready WebSocket payload's `asset.deletedAt` are sourced from `trashed_at`, not hardcoded placeholders.
-
-Live read paths continue to use the backend's default live-only filtering when `isTrashed` is absent or false.
-
-### Sync stream and WebSocket propagation
-
-Trash state now flows through both client update channels:
-
-- `SyncAssetV1.deletedAt` is populated from `trashed_at`.
-- Sync asset hydration uses `client.assets.list(state="all", ids=...)` so `asset_trashed` events can still hydrate after the asset leaves the live view.
-- `on_asset_trash` and `on_asset_restore` carry batched id arrays; `on_asset_delete` remains the permanent-delete event and carries one id per emission.
-
-This preserves the intended Immich behavior: trash/restore remain upserts in the sync stream, while permanent delete continues to use the delete path.
-
-### Server config
-
-`GET /api/server/config` now reads `trashDays` from `TRASH_RETENTION_DAYS` through `get_settings().trash_retention_days`. The web trash page therefore shows the deployed retention period instead of a hardcoded placeholder.
-
-The adapter and backend still need to agree on the same deploy-time `TRASH_RETENTION_DAYS` value; `.env.example` and the README document that contract.
-
-## Remaining limitations
-
-- The typed SDK still does not expose dedicated trash helpers, so the trash router uses `AsyncGumnut.post()` / `.delete()` directly for the restore and bulk-delete endpoints.
-- `search/metadata` and `search/large-assets` still do not surface trashed results through `withDeleted`, `trashedBefore`, or `trashedAfter`; that follow-up remains separate from the shipped trash flow.
-- `trashDays` is accurate at deploy time, but it is still a shared environment-variable contract rather than a backend-discovered runtime setting.
+The adapter preserved Immich's public trash contract while translating it onto
+the Gumnut API's soft-delete, restore, and permanent-delete primitives. The
+`force` flag distinguishes trash from permanent deletion; trash-aware reads and
+sync/realtime events keep client state coherent; and restore-all and empty-trash
+enumerate the target set before mutation so shrinking result sets do not break
+pagination. The adapter and API share the configured retention window.
 
 ## Dependencies
 


### PR DESCRIPTION
## Why

The three deprecated adapter design records still carried endpoint walkthroughs, payload examples, and component inventories that had drifted from the running system. Their durable value is the decision rationale and compatibility trade-offs; current behavior already has explicit architecture or reference owners.

## What changed

- reduced the authentication record to the constraints, session-token architecture, rationale, and outcome
- retained the checksum protocol research and rejected alternatives while removing sample request/response payloads and step-by-step flows
- reduced the trash record to its cross-service contract and evolution history
- refreshed retirement banners and current-document pointers

No document status changed in this PR; all three records were already deprecated.

## Validation

- `uv run scripts/lint_docs.py`
- `git diff --check`
