### PR TITLE
Send person_ids instead of the deprecated person_id alias on asset lists

### DIFF
--- a/routers/api/search.py
+++ b/routers/api/search.py
@@ -602,7 +602,7 @@ async def _fetch_month_assets_at_offsets(
     if album_id is not None:
         list_kwargs["album_id"] = album_id
     if person_id is not None:
-        list_kwargs["person_id"] = person_id
+        list_kwargs["person_ids"] = [person_id]
 
     picked: list[AssetResponse] = []
     index = 0

--- a/routers/api/timeline.py
+++ b/routers/api/timeline.py
@@ -205,7 +205,7 @@ async def get_time_bucket(
     if albumId:
         list_kwargs["album_id"] = uuid_to_gumnut_album_id(albumId)
     elif personId:
-        list_kwargs["person_id"] = uuid_to_gumnut_person_id(personId)
+        list_kwargs["person_ids"] = [uuid_to_gumnut_person_id(personId)]
 
     filtered_assets = [a async for a in client.assets.list(**list_kwargs)]
 

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -1557,9 +1557,9 @@ class TestSearchRandom:
             mock_client.assets.counts.call_args.kwargs["person_id"]
             == expected_person_id
         )
-        assert (
-            mock_client.assets.list.call_args.kwargs["person_id"] == expected_person_id
-        )
+        assert mock_client.assets.list.call_args.kwargs["person_ids"] == [
+            expected_person_id
+        ]
         assert len(result) == 1
 
     @pytest.mark.anyio

--- a/tests/unit/api/test_timeline.py
+++ b/tests/unit/api/test_timeline.py
@@ -684,7 +684,7 @@ class TestGetTimeBucket:
 
             assert len(result["id"]) == 1
             mock_client.assets.list.assert_called_once_with(
-                person_id=uuid_to_gumnut_person_id(sample_uuid),
+                person_ids=[uuid_to_gumnut_person_id(sample_uuid)],
                 extra_query=JANUARY_2024_DATE_RANGE,
             )
 
@@ -1631,7 +1631,7 @@ class TestTimeBucketStacks:
 
         bucket_read = client.assets.list.call_args_list[0]
         assert bucket_read.kwargs == {
-            "person_id": uuid_to_gumnut_person_id(person_id),
+            "person_ids": [uuid_to_gumnut_person_id(person_id)],
             "extra_query": JANUARY_2024_DATE_RANGE,
         }
 


### PR DESCRIPTION
## What

- Switch both `client.assets.list` call sites that filtered by person — the timeline bucket read and the random-sample month fetch — from the singular `person_id` alias to `person_ids=[...]`.
- Update the unit tests that pin those call kwargs.

## Why

The Gumnut API deprecated the singular `person_id` compatibility alias on its asset-list endpoint in favor of the plural `person_ids` filter, and the alias is being removed. Unknown query parameters are ignored rather than rejected, so continuing to send `person_id` after the removal would silently drop the person filter — person timelines would show the whole library. The current API and SDK already support `person_ids`, so this change is safe to deploy immediately and must be **deployed before** the API-side removal ships.

The `person_id` argument still sent to `assets.counts` is unchanged — on that endpoint it is a live filter, not an alias.

## Test plan

- `uv run pytest` (1661 passed)
- `uv run ruff format && uv run ruff check && uv run pyright` clean

Generated by an AI coding agent.