### PR TITLE
Event-driven Immich stack sync; retire the full-table snapshot

### DIFF
--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -73,56 +73,19 @@ delete from the album-user pass would duplicate `AlbumDeleteV1`. No
 
 ## Stack Snapshot (StacksV1)
 
-Stacks reach the mobile client two ways, both driven from the initial/full sync:
+Each sync asset carries its stack membership in `stackId`. Before streaming
+assets, `_stream_stacks` re-pages the stack table and emits rows after the
+client's checkpoint in `(updated_at, id)` order. This provides incremental
+upserts and resumes a truncated pass without a stack lifecycle event stream.
 
-1. **Asset membership.** Each sync asset row carries its `stackId` — the Gumnut
-   `stack_id` FK mapped to the Immich UUID (loose assets stay null). V2 inherits
-   it through the V1 delegation. This is what groups burst members under a stack
-   on the client.
-2. **Stack rows.** `StacksV1` streams `StackV1` rows, handled specially
-   (`_stream_stacks`) alongside the user types rather than via the events API —
-   the Gumnut backend emits no stack lifecycle events yet, so there is nothing to
-   feed the event stream. Each row's `primaryAssetId` is the **effective primary**
-   resolved by the shared `resolve_effective_primary`/`hydrate_stack` helpers (the
-   exact rule the REST `/stacks` surfaces use), so an auto-detected burst with no
-   pinned cover still gets a valid non-null primary. A member-less stack has no
-   honest primary and is skipped with a warning. `ownerId` is always the current
-   user (Gumnut is single-user; no stack sharing).
+Each row uses the same effective-primary resolution as the REST stack endpoints;
+member-less stacks are skipped because `primaryAssetId` is required. Incremental
+upserts prevent assets from referencing a missing stack, which would hide the
+burst in the mobile timeline.
 
-The stack rows are emitted **before** the phase-1 asset loop, so a stack row
-exists on the client before any asset naming it via `stackId` arrives. (The
-mobile client's `stackId` / `primaryAssetId` columns are unenforced indexes, not
-FKs, so the circular reference is not order-sensitive in practice — stacks-first
-is a deliberate, defensive choice for the asset→stack direction.)
-
-**Scope boundary — upserts only, no delete detection.** With no lifecycle event
-stream, `_stream_stacks` re-pages the whole stack table on **every** sync and
-emits the rows the client has not yet acked: it orders by `(updated_at, id)` and
-skips rows at or before the `StackV1` checkpoint cursor. This is upsert-only
-incremental delivery, and it exists for a concrete reason — asset rows carry
-`stackId` from current entity state unconditionally, so a burst created *after*
-the initial sync would otherwise leave its member assets pointing at a stack row
-the client never received. A dangling `stackId` is not benign: the mobile
-timeline join (`merged_asset.drift.dart`,
-`... AND (rae.stack_id IS NULL OR rae.id = se.primary_asset_id)`) hides **every
-frame** of a burst whose stack row is missing. Emitting the new stack keeps the
-burst visible and grouped.
-
-Ordering by the ack cursor also makes the pass **resumable**: if a snapshot
-truncates mid-stream, the checkpoint holds the last acked row's cursor and the
-next sync skips at-or-before it, so the un-streamed tail is not lost. This is
-also why a Gumnut API error while hydrating one stack is caught at the call site
-and ends the pass gracefully rather than propagating: the snapshot runs *before*
-the asset loop, so an unhandled error would suppress assets/albums/faces too —
-instead the already-streamed rows are acked, the asset loop still runs, and the
-remaining stacks resume next sync.
-
-**Delete detection stays out of scope**, tracked on a separate event-support
-track. A dissolved stack's row goes stale but is harmless: unstacking clears each
-member's `asset.stack_id` via asset events, and a stack row no asset references
-satisfies the `rae.stack_id IS NULL` branch of the join. `PartnerStacksV1` stays
-a no-op (partner sharing is unsupported), and `on_asset_stack_update` is **not**
-in the supported WebSocket table.
+Delete detection remains unsupported. A dissolved stack row is harmless once
+asset events clear its members' `stackId`. `PartnerStacksV1` remains a no-op
+because partner sharing is unsupported.
 
 ## Adding a New Sync Type Version
 
@@ -140,7 +103,10 @@ The invariant tests in `test_sync_v2.py` assert that every V2 type in `_SYNC_TYP
 
 Immich sync types that are accepted but have no Gumnut equivalent (e.g., `AssetEditsV1` — we don't support editing) go in `_NOOP_REQUEST_TYPES` in `stream.py`. This prevents "unsupported type" warnings while making the no-op explicit. Do not just add them to `_SUPPORTED_REQUEST_TYPES` without `_SYNC_TYPE_ORDER` — that silently drops them.
 
-The v3 mobile client requests a broad set of these on **every** sync (partner-*, `PartnerStacksV1`, memories-*, `AssetMetadataV1`, `AssetOcrV1`, `AlbumAssetExifsV1`, the V2 partner/album-asset variants) — all no-ops because the adapter has no sync-stream source for them, whether the underlying feature is absent (sharing, OCR) or reachable only through the REST surfaces (memories). They all belong in `_NOOP_REQUEST_TYPES` so the per-sync "unsupported types" warning stays quiet. Two requested types the adapter *does* handle are deliberately **not** no-ops, both handled specially alongside `UsersV1`/`AuthUsersV1` rather than via `_SYNC_TYPE_ORDER`: `UserMetadataV1` (synthesized preferences row — see "User Preferences" above) and `StacksV1` (current-state snapshot — see "Stack Snapshot" above). `PartnerStacksV1` remains a no-op regardless.
+The v3 mobile client requests these types on every sync, so keep unsupported
+ones in `_NOOP_REQUEST_TYPES` to avoid repeated warnings. `UserMetadataV1` and
+`StacksV1` are handled specially outside `_SYNC_TYPE_ORDER` and must not be
+listed as no-ops.
 
 ## Contract with the Gumnut API
 

--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -71,6 +71,42 @@ pass: an `album_deleted` event emits `AlbumDeleteV1`, and the client's
 delete from the album-user pass would duplicate `AlbumDeleteV1`. No
 `AlbumUserDeleteV1` is emitted (Gumnut has no unshare operation).
 
+## Stack Snapshot (StacksV1)
+
+Stacks reach the mobile client two ways, both driven from the initial/full sync:
+
+1. **Asset membership.** Each sync asset row carries its `stackId` — the Gumnut
+   `stack_id` FK mapped to the Immich UUID (loose assets stay null). V2 inherits
+   it through the V1 delegation. This is what groups burst members under a stack
+   on the client.
+2. **Stack rows.** `StacksV1` streams a **current-state snapshot** of `StackV1`
+   rows, handled specially (`_stream_stacks`) alongside the user types rather
+   than via the events API — the Gumnut backend emits no stack lifecycle events
+   yet, so there is nothing to feed the event stream. Each row's
+   `primaryAssetId` is the **effective primary** resolved by the shared
+   `resolve_effective_primary`/`hydrate_stack` helpers (the exact rule the REST
+   `/stacks` surfaces use), so an auto-detected burst with no pinned cover still
+   gets a valid non-null primary. A member-less stack has no honest primary and
+   is skipped with a warning. `ownerId` is always the current user (Gumnut is
+   single-user; no stack sharing).
+
+The snapshot is emitted **before** the phase-1 asset loop, so a stack row exists
+on the client before any asset naming it via `stackId` arrives. (The mobile
+client's `stackId` / `primaryAssetId` columns are unenforced indexes, not FKs,
+so the circular reference is not order-sensitive in practice — stacks-first is a
+deliberate, defensive choice for the asset→stack direction.)
+
+**Scope boundary — snapshot only.** The snapshot streams only on **reset / first
+sync** (no `StackV1` checkpoint). Once a client has acked, an existing `StackV1`
+checkpoint suppresses the pass entirely: no speculative updates are emitted.
+Incremental stack create/update/delete propagation is intentionally out of scope
+and tracked on a separate event-support track — re-emitting the full stack table
+on every delta is **not** a substitute, because it still cannot express deletes
+and wastes bandwidth. Per-row acks are `stack.updated_at` + id (pipe-free,
+stable), so a reset replays deterministically. `PartnerStacksV1` stays a no-op
+(partner sharing is unsupported), and `on_asset_stack_update` is **not** in the
+supported WebSocket table.
+
 ## Adding a New Sync Type Version
 
 When the same gumnut entity type maps to multiple Immich sync versions (e.g., AssetFacesV2 alongside V1), update these files in coordination:
@@ -87,7 +123,7 @@ The invariant tests in `test_sync_v2.py` assert that every V2 type in `_SYNC_TYP
 
 Immich sync types that are accepted but have no Gumnut equivalent (e.g., `AssetEditsV1` — we don't support editing) go in `_NOOP_REQUEST_TYPES` in `stream.py`. This prevents "unsupported type" warnings while making the no-op explicit. Do not just add them to `_SUPPORTED_REQUEST_TYPES` without `_SYNC_TYPE_ORDER` — that silently drops them.
 
-The v3 mobile client requests a broad set of these on **every** sync (partner-*, stacks-*, memories-*, `AssetMetadataV1`, `AssetOcrV1`, `AlbumAssetExifsV1`, the V2 partner/album-asset variants) — all no-ops because the adapter has no sync-stream source for them, whether the underlying feature is absent (sharing, OCR) or reachable only through the REST surfaces (stacks, memories). They all belong in `_NOOP_REQUEST_TYPES` so the per-sync "unsupported types" warning stays quiet. `UserMetadataV1` is the one requested type the adapter *does* synthesize (see "User Preferences" above), so it is deliberately **not** a no-op — it's handled specially alongside `UsersV1`/`AuthUsersV1`.
+The v3 mobile client requests a broad set of these on **every** sync (partner-*, `PartnerStacksV1`, memories-*, `AssetMetadataV1`, `AssetOcrV1`, `AlbumAssetExifsV1`, the V2 partner/album-asset variants) — all no-ops because the adapter has no sync-stream source for them, whether the underlying feature is absent (sharing, OCR) or reachable only through the REST surfaces (memories). They all belong in `_NOOP_REQUEST_TYPES` so the per-sync "unsupported types" warning stays quiet. Two requested types the adapter *does* handle are deliberately **not** no-ops, both handled specially alongside `UsersV1`/`AuthUsersV1` rather than via `_SYNC_TYPE_ORDER`: `UserMetadataV1` (synthesized preferences row — see "User Preferences" above) and `StacksV1` (current-state snapshot — see "Stack Snapshot" above). `PartnerStacksV1` remains a no-op regardless.
 
 ## Contract with the Gumnut API
 

--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -11,6 +11,8 @@ The sync stream (`routers/api/sync/stream.py`) consumes events from the Gumnut A
 
 The stream yields all upserts first (in FK dependency order per `_SYNC_TYPE_ORDER`), then all deletes (in reverse FK order per `_DELETE_TYPE_ORDER`). This prevents FK constraint violations in the mobile client — parents exist before children reference them, and children are cleaned up before parents are removed. See the [sync stream event ordering design doc](../design-docs/sync-stream-event-ordering.md) for the full design rationale and history.
 
+Failure is not isolated per pass: an unhandled fetch/hydration error propagates to `generate_sync_stream`'s top-level handler, which logs it and ends the generator — a truncated HTTP 200 with no `SyncCompleteV1` that silently drops every later pass. New pass code must catch per-item failures and skip them (see `_hydrate_stack_or_skip`); the earliest passes carry the widest blast radius.
+
 ## Event Classification
 
 Event types are classified into `_DELETE_EVENT_TYPES` (construct delete sync event from event data), `_SKIPPED_EVENT_TYPES` (ignored), and everything else is treated as an upsert (fetch full entity from the Gumnut API). Delete events are buffered during iteration and yielded in phase 2.

--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -11,7 +11,7 @@ The sync stream (`routers/api/sync/stream.py`) consumes events from the Gumnut A
 
 The stream yields all upserts first (in FK dependency order per `_SYNC_TYPE_ORDER`), then all deletes (in reverse FK order per `_DELETE_TYPE_ORDER`). This prevents FK constraint violations in the mobile client — parents exist before children reference them, and children are cleaned up before parents are removed. See the [sync stream event ordering design doc](../design-docs/sync-stream-event-ordering.md) for the full design rationale and history.
 
-Failure is not isolated per pass: an unhandled fetch/hydration error propagates to `generate_sync_stream`'s top-level handler, which logs it and ends the generator — a truncated HTTP 200 with no `SyncCompleteV1` that silently drops every later pass. New pass code must catch per-item failures and skip them (see `_hydrate_stack_or_skip`); the earliest passes carry the widest blast radius.
+Failure is not isolated per pass: an unhandled fetch/hydration error propagates to `generate_sync_stream`'s top-level handler, which logs it and ends the generator — a truncated HTTP 200 with no `SyncCompleteV1` that drops every later pass, so the earliest passes carry the widest blast radius. Skip a fetch failure to `missing_ids` **only** when the row is *permanently* non-emittable and skipping strands nothing downstream (a member-less or undecodable stack). A *retriable* failure must propagate instead: skipping advances the events cursor past the row while dependent rows still reference it, permanently losing it — for stacks, that hides the burst from the timeline (see `_hydrate_stack_for_sync`).
 
 ## Event Classification
 

--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Sync Stream Architecture"
-last-updated: 2026-07-30
+last-updated: 2026-08-03
 ---
 
 # Sync Stream Architecture
@@ -79,33 +79,50 @@ Stacks reach the mobile client two ways, both driven from the initial/full sync:
    `stack_id` FK mapped to the Immich UUID (loose assets stay null). V2 inherits
    it through the V1 delegation. This is what groups burst members under a stack
    on the client.
-2. **Stack rows.** `StacksV1` streams a **current-state snapshot** of `StackV1`
-   rows, handled specially (`_stream_stacks`) alongside the user types rather
-   than via the events API — the Gumnut backend emits no stack lifecycle events
-   yet, so there is nothing to feed the event stream. Each row's
-   `primaryAssetId` is the **effective primary** resolved by the shared
-   `resolve_effective_primary`/`hydrate_stack` helpers (the exact rule the REST
-   `/stacks` surfaces use), so an auto-detected burst with no pinned cover still
-   gets a valid non-null primary. A member-less stack has no honest primary and
-   is skipped with a warning. `ownerId` is always the current user (Gumnut is
-   single-user; no stack sharing).
+2. **Stack rows.** `StacksV1` streams `StackV1` rows, handled specially
+   (`_stream_stacks`) alongside the user types rather than via the events API —
+   the Gumnut backend emits no stack lifecycle events yet, so there is nothing to
+   feed the event stream. Each row's `primaryAssetId` is the **effective primary**
+   resolved by the shared `resolve_effective_primary`/`hydrate_stack` helpers (the
+   exact rule the REST `/stacks` surfaces use), so an auto-detected burst with no
+   pinned cover still gets a valid non-null primary. A member-less stack has no
+   honest primary and is skipped with a warning. `ownerId` is always the current
+   user (Gumnut is single-user; no stack sharing).
 
-The snapshot is emitted **before** the phase-1 asset loop, so a stack row exists
-on the client before any asset naming it via `stackId` arrives. (The mobile
-client's `stackId` / `primaryAssetId` columns are unenforced indexes, not FKs,
-so the circular reference is not order-sensitive in practice — stacks-first is a
-deliberate, defensive choice for the asset→stack direction.)
+The stack rows are emitted **before** the phase-1 asset loop, so a stack row
+exists on the client before any asset naming it via `stackId` arrives. (The
+mobile client's `stackId` / `primaryAssetId` columns are unenforced indexes, not
+FKs, so the circular reference is not order-sensitive in practice — stacks-first
+is a deliberate, defensive choice for the asset→stack direction.)
 
-**Scope boundary — snapshot only.** The snapshot streams only on **reset / first
-sync** (no `StackV1` checkpoint). Once a client has acked, an existing `StackV1`
-checkpoint suppresses the pass entirely: no speculative updates are emitted.
-Incremental stack create/update/delete propagation is intentionally out of scope
-and tracked on a separate event-support track — re-emitting the full stack table
-on every delta is **not** a substitute, because it still cannot express deletes
-and wastes bandwidth. Per-row acks are `stack.updated_at` + id (pipe-free,
-stable), so a reset replays deterministically. `PartnerStacksV1` stays a no-op
-(partner sharing is unsupported), and `on_asset_stack_update` is **not** in the
-supported WebSocket table.
+**Scope boundary — upserts only, no delete detection.** With no lifecycle event
+stream, `_stream_stacks` re-pages the whole stack table on **every** sync and
+emits the rows the client has not yet acked: it orders by `(updated_at, id)` and
+skips rows at or before the `StackV1` checkpoint cursor. This is upsert-only
+incremental delivery, and it exists for a concrete reason — asset rows carry
+`stackId` from current entity state unconditionally, so a burst created *after*
+the initial sync would otherwise leave its member assets pointing at a stack row
+the client never received. A dangling `stackId` is not benign: the mobile
+timeline join (`merged_asset.drift.dart`,
+`... AND (rae.stack_id IS NULL OR rae.id = se.primary_asset_id)`) hides **every
+frame** of a burst whose stack row is missing. Emitting the new stack keeps the
+burst visible and grouped.
+
+Ordering by the ack cursor also makes the pass **resumable**: if a snapshot
+truncates mid-stream, the checkpoint holds the last acked row's cursor and the
+next sync skips at-or-before it, so the un-streamed tail is not lost. This is
+also why a Gumnut API error while hydrating one stack is caught at the call site
+and ends the pass gracefully rather than propagating: the snapshot runs *before*
+the asset loop, so an unhandled error would suppress assets/albums/faces too —
+instead the already-streamed rows are acked, the asset loop still runs, and the
+remaining stacks resume next sync.
+
+**Delete detection stays out of scope**, tracked on a separate event-support
+track. A dissolved stack's row goes stale but is harmless: unstacking clears each
+member's `asset.stack_id` via asset events, and a stack row no asset references
+satisfies the `rae.stack_id IS NULL` branch of the join. `PartnerStacksV1` stays
+a no-op (partner sharing is unsupported), and `on_asset_stack_update` is **not**
+in the supported WebSocket table.
 
 ## Adding a New Sync Type Version
 

--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -11,7 +11,12 @@ The sync stream (`routers/api/sync/stream.py`) consumes events from the Gumnut A
 
 The stream yields all upserts first (in FK dependency order per `_SYNC_TYPE_ORDER`), then all deletes (in reverse FK order per `_DELETE_TYPE_ORDER`). This prevents FK constraint violations in the mobile client — parents exist before children reference them, and children are cleaned up before parents are removed. See the [sync stream event ordering design doc](../design-docs/sync-stream-event-ordering.md) for the full design rationale and history.
 
-Failure is not isolated per pass: an unhandled fetch/hydration error propagates to `generate_sync_stream`'s top-level handler, which logs it and ends the generator — a truncated HTTP 200 with no `SyncCompleteV1` that drops every later pass, so the earliest passes carry the widest blast radius. Skip a fetch failure to `missing_ids` **only** when the row is *permanently* non-emittable and skipping strands nothing downstream (a member-less or undecodable stack). A *retriable* failure must propagate instead: skipping advances the events cursor past the row while dependent rows still reference it, permanently losing it — for stacks, that hides the burst from the timeline (see `_hydrate_stack_for_sync`).
+Failure is not isolated per pass: an unhandled fetch error propagates to
+`generate_sync_stream`'s top-level handler and ends the generator without
+`SyncCompleteV1`, dropping every later pass. Degrade to `missing_ids` only when
+skipping cannot strand dependent rows; for stacks, that applies to an
+undecodable ID, not an empty member read. Retriable failures must propagate so
+the event cursor remains unacknowledged.
 
 ## Event Classification
 
@@ -75,35 +80,25 @@ delete from the album-user pass would duplicate `AlbumDeleteV1`. No
 
 ## Stacks (StacksV1)
 
-Stacks ride the same event-cursor path as every other entity type. `StacksV1`
-sits first in `_SYNC_TYPE_ORDER` — before assets — because the mobile timeline
-hides an asset whose `stackId` names a stack row the client doesn't hold (its
-`stack_id IS NULL OR id = primaryAssetId` visibility clause), so the stack must
-arrive before the member asset that points at it. The client enforces no stack
-foreign key in either direction; the ordering is about visibility, not insert
-constraints. A `stack_created` or `stack_updated` event hydrates the stack and
-emits `StackV1`; a `stack_deleted` event emits `StackDeleteV1`, placed after
-asset deletes in `_DELETE_TYPE_ORDER` (the inverse order). An already-synced
-client receives stack changes as deltas, not on reset.
+`StacksV1` uses the event cursor and sits before assets in `_SYNC_TYPE_ORDER`.
+The mobile timeline hides an asset whose `stackId` names an unknown stack, so a
+`stack_created` or `stack_updated` event must emit `StackV1` before its member
+assets. The client has no stack foreign key; this is a visibility constraint.
+Deletes use the inverse order, with `StackDeleteV1` after asset deletes.
 
-Hydration reuses the same effective-primary resolution as the REST stack
-endpoints — `StackV1.primaryAssetId` is required, so a member-less stack is
-dropped (`fetch_entities_map` reports it missing) rather than emitted with a
-manufactured cover. Resolving the primary needs the members, but
-`convert_entity_to_sync_event` is I/O-free, so `fetch_entities_map` hydrates each
-stack under a bounded concurrency fan-out and carries the resolved primary
-alongside the row in a `FetchedStack`.
+`StackV1.primaryAssetId` is required but an unpinned Gumnut stack has no primary
+on its row. Sync therefore reads members without heavy asset includes, applies
+the shared effective-primary rule, and carries only the resulting UUID into the
+converter. Reads are concurrency-bounded. An empty all-state member read is
+retryable even when `asset_count` is zero, because that count excludes trashed
+members; propagating the error truncates the stream before its cursor is acked.
 
-**Dissolve safety lives on the asset side, not in `FK_REFERENCES`.** An asset
-carries whatever `stackId` its `stack_id` decodes to, and that reference is
-deliberately absent from `FK_REFERENCES`, so nothing nulls it when the stack is
-deleted. Correctness relies instead on the Gumnut API emitting an `asset_updated`
-(clearing `stack_id`) for every frame freed from a dissolving stack, ahead of
-the `stack_deleted` — which it does, both when a user removes frames and when
-burst re-detection dissolves a run. Those member upserts stream in phase 1 and
-`StackDeleteV1` streams last in phase 2, so the client clears each member's
-`stackId` before it drops the stack row, and no frame is left pointing at a stack
-the client no longer holds.
+Stack references stay out of `FK_REFERENCES`. When a stack dissolves, the
+Gumnut API emits an `asset_updated` clearing each member's `stack_id` before
+`stack_deleted`. Those upserts run in phase 1 and the stack delete in phase 2,
+so members stop referencing the stack before the client removes it. Asset
+updates use the payload's event-time `stack_id`, preventing a later move outside
+the sync window from leaking into the current event.
 
 `PartnerStacksV1` remains a no-op because partner sharing is unsupported.
 

--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -74,20 +74,34 @@ delete from the album-user pass would duplicate `AlbumDeleteV1`. No
 ## Stacks (StacksV1)
 
 Stacks ride the same event-cursor path as every other entity type. `StacksV1`
-sits first in `_SYNC_TYPE_ORDER` — before assets — because `SyncAssetV1.stackId`
-is an asset→stack FK, so the parent stack must reach the client before the
-member asset that references it. A `stack_created` or `stack_updated` event
-hydrates the stack and emits `StackV1`; a `stack_deleted` event emits
-`StackDeleteV1`, placed after asset deletes in `_DELETE_TYPE_ORDER` (the inverse
-order) so the client removes a burst's members before their parent stack. An
-already-synced client receives stack changes as deltas, not on reset.
+sits first in `_SYNC_TYPE_ORDER` — before assets — because the mobile timeline
+hides an asset whose `stackId` names a stack row the client doesn't hold (its
+`stack_id IS NULL OR id = primaryAssetId` visibility clause), so the stack must
+arrive before the member asset that points at it. The client enforces no stack
+foreign key in either direction; the ordering is about visibility, not insert
+constraints. A `stack_created` or `stack_updated` event hydrates the stack and
+emits `StackV1`; a `stack_deleted` event emits `StackDeleteV1`, placed after
+asset deletes in `_DELETE_TYPE_ORDER` (the inverse order). An already-synced
+client receives stack changes as deltas, not on reset.
 
 Hydration reuses the same effective-primary resolution as the REST stack
 endpoints — `StackV1.primaryAssetId` is required, so a member-less stack is
 dropped (`fetch_entities_map` reports it missing) rather than emitted with a
 manufactured cover. Resolving the primary needs the members, but
-`convert_entity_to_sync_event` is I/O-free, so `fetch_entities_map` hydrates and
-carries the resolved primary alongside the row in a `FetchedStack`.
+`convert_entity_to_sync_event` is I/O-free, so `fetch_entities_map` hydrates each
+stack under a bounded concurrency fan-out and carries the resolved primary
+alongside the row in a `FetchedStack`.
+
+**Dissolve safety lives on the asset side, not in `FK_REFERENCES`.** An asset
+carries whatever `stackId` its `stack_id` decodes to, and that reference is
+deliberately absent from `FK_REFERENCES`, so nothing nulls it when the stack is
+deleted. Correctness relies instead on the Gumnut API emitting an `asset_updated`
+(clearing `stack_id`) for every frame freed from a dissolving stack, ahead of
+the `stack_deleted` — which it does, both when a user removes frames and when
+burst re-detection dissolves a run. Those member upserts stream in phase 1 and
+`StackDeleteV1` streams last in phase 2, so the client clears each member's
+`stackId` before it drops the stack row, and no frame is left pointing at a stack
+the client no longer holds.
 
 `PartnerStacksV1` remains a no-op because partner sharing is unsupported.
 

--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Sync Stream Architecture"
-last-updated: 2026-08-03
+last-updated: 2026-08-11
 ---
 
 # Sync Stream Architecture
@@ -71,21 +71,25 @@ pass: an `album_deleted` event emits `AlbumDeleteV1`, and the client's
 delete from the album-user pass would duplicate `AlbumDeleteV1`. No
 `AlbumUserDeleteV1` is emitted (Gumnut has no unshare operation).
 
-## Stack Snapshot (StacksV1)
+## Stacks (StacksV1)
 
-Each sync asset carries its stack membership in `stackId`. Before streaming
-assets, `_stream_stacks` re-pages the stack table and emits rows after the
-client's checkpoint in `(updated_at, id)` order. This provides incremental
-upserts and resumes a truncated pass without a stack lifecycle event stream.
+Stacks ride the same event-cursor path as every other entity type. `StacksV1`
+sits first in `_SYNC_TYPE_ORDER` — before assets — because `SyncAssetV1.stackId`
+is an asset→stack FK, so the parent stack must reach the client before the
+member asset that references it. A `stack_created` or `stack_updated` event
+hydrates the stack and emits `StackV1`; a `stack_deleted` event emits
+`StackDeleteV1`, placed after asset deletes in `_DELETE_TYPE_ORDER` (the inverse
+order) so the client removes a burst's members before their parent stack. An
+already-synced client receives stack changes as deltas, not on reset.
 
-Each row uses the same effective-primary resolution as the REST stack endpoints;
-member-less stacks are skipped because `primaryAssetId` is required. Incremental
-upserts prevent assets from referencing a missing stack, which would hide the
-burst in the mobile timeline.
+Hydration reuses the same effective-primary resolution as the REST stack
+endpoints — `StackV1.primaryAssetId` is required, so a member-less stack is
+dropped (`fetch_entities_map` reports it missing) rather than emitted with a
+manufactured cover. Resolving the primary needs the members, but
+`convert_entity_to_sync_event` is I/O-free, so `fetch_entities_map` hydrates and
+carries the resolved primary alongside the row in a `FetchedStack`.
 
-Delete detection remains unsupported. A dissolved stack row is harmless once
-asset events clear its members' `stackId`. `PartnerStacksV1` remains a no-op
-because partner sharing is unsupported.
+`PartnerStacksV1` remains a no-op because partner sharing is unsupported.
 
 ## Adding a New Sync Type Version
 
@@ -104,9 +108,8 @@ The invariant tests in `test_sync_v2.py` assert that every V2 type in `_SYNC_TYP
 Immich sync types that are accepted but have no Gumnut equivalent (e.g., `AssetEditsV1` — we don't support editing) go in `_NOOP_REQUEST_TYPES` in `stream.py`. This prevents "unsupported type" warnings while making the no-op explicit. Do not just add them to `_SUPPORTED_REQUEST_TYPES` without `_SYNC_TYPE_ORDER` — that silently drops them.
 
 The v3 mobile client requests these types on every sync, so keep unsupported
-ones in `_NOOP_REQUEST_TYPES` to avoid repeated warnings. `UserMetadataV1` and
-`StacksV1` are handled specially outside `_SYNC_TYPE_ORDER` and must not be
-listed as no-ops.
+ones in `_NOOP_REQUEST_TYPES` to avoid repeated warnings. `UserMetadataV1` is
+handled specially outside `_SYNC_TYPE_ORDER` and must not be listed as a no-op.
 
 ## Contract with the Gumnut API
 

--- a/docs/design-docs/immich-adapter-gap-analysis.md
+++ b/docs/design-docs/immich-adapter-gap-analysis.md
@@ -2,7 +2,7 @@
 title: "Immich Adapter Gap Analysis"
 status: active
 created: 2026-04-15
-last-updated: 2026-07-31
+last-updated: 2026-08-11
 ---
 
 # Immich Adapter Gap Analysis
@@ -144,17 +144,22 @@ Immich allows batch downloading multiple assets as a zip archive.
 
 Immich stacks group related photos (e.g., burst shots, HDR series, RAW+JPEG pairs) with a primary asset representing the group.
 
-**Current behavior**: **REST-complete.** All seven REST endpoints are real: list, detail, create, set-cover, delete, bulk-delete, and remove-asset. Asset detail also carries a nested stack summary, and timeline buckets collapse stacks into one badged tile. The one remaining gap is the sync path — the sync stream does not yet populate `SyncAssetV1.stackId`.
+**Current behavior**: **Closed.** All seven REST endpoints are real: list,
+detail, create, set-cover, delete, bulk-delete, and remove-asset. Asset detail
+carries a stack summary, timeline buckets collapse stacks, and the event-driven
+sync stream emits stack upserts/deletes plus each member asset's `stackId`.
 
-**User impact**: **Low** — Web can display stacks, create them, set covers, and dissolve or trim them from the timeline and duplicate-management surfaces. Mobile still cannot see stacks until the sync stream populates `SyncAssetV1.stackId`.
+**User impact**: **None for stack behavior** — web and mobile display stacks;
+users can create them, set covers, and dissolve or trim them.
 
-**Dependency**: **Adapter-only** — the backend grouping concept this gap was originally blocked on now exists. The Gumnut API's stack resource covers create, add/remove assets, list, retrieve, set cover, and delete, with `list_stacks` exposing an `origin` filter (auto-detected bursts vs. user-grouped) and `primary_asset_id`; members are reachable through the `stack_id` filter on the asset list.
+**Dependency**: **Closed across both systems** — the Gumnut API owns stack
+membership and emits member updates before a dissolve event; the adapter
+translates that resource and event ordering into Immich's REST and sync shapes.
 
 One piece of the timeline surface *is* backend-blocked: `GET /api/timeline/buckets` cannot collapse its counts, because `assets.counts` has no stack-aware filter. The effect is cosmetic and the fix is a backend one — see "Timeline stack collapse" in `docs/architecture/adapter-architecture.md`.
 
-**Effort**: **S remaining** — sync-stream stack resolution (`SyncAssetV1.stackId`); the REST surface is done.
-
-**Recommendation**: **Revisit later** — remaining work has low demand relative to Tier-1 and Tier-2 gaps.
+**Recommendation**: **Closed.** The cosmetic timeline-count limitation above can
+be revisited independently.
 
 ---
 
@@ -752,7 +757,6 @@ adapter code.
 | #1 Shared links | XL | Both | High value but major backend work |
 | #9 Partners | XL | Both | Family use case, deep auth changes |
 | #23 Album sharing | XL | Both | Blocked by sharing infrastructure |
-| #6 Stacks (sync path) | S | Adapter-only | Low user demand; REST surface complete, sync-stream `stackId` remains |
 | #20 API keys | M | Both | Developer feature |
 | #24 Custom metadata | M | Both | Integration feature |
 | #25 Asset edits | M | Both | Low user demand |

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -1,6 +1,6 @@
 ---
 title: "Code Practices"
-last-updated: 2026-08-03
+last-updated: 2026-08-11
 ---
 
 # Code Practices
@@ -265,8 +265,7 @@ authentication and setup errors before returning the response, and handle
 expected per-item failures inside the generator so they do not truncate the
 stream. Keep degradation guards narrow: `ValidationError` subclasses
 `ValueError`, so catch decoding failures around the decode call rather than
-around model construction. Catch transport errors at the call site when an
-early pass should not suppress later stream work.
+around model construction.
 
 ### Omit vs explicit-null in update-style DTOs — use `model_fields_set`
 

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -259,7 +259,14 @@ for asset_uuid in request.ids:
 
 Use `map_gumnut_error(e, context, extra=..., exc_info=True)` only when the call site needs to enrich the upstream log record with context the global handler can't see — most commonly the upload paths logging filename / device ids / tracebacks.
 
-**Exception — streaming responses swallow errors after the 200.** The "just let it bubble" rule holds only until a `StreamingResponse` commits its 200. After that a raised error no longer reaches the global handler: `generate_sync_stream`'s broad `except Exception` logs and returns, truncating the stream (no `SyncCompleteV1`, so the client re-fails identically every sync). Resolve auth/setup errors *before* streaming (the sync route pre-fetches the user for exactly this), and make per-item work inside the generator degrade rather than raise — e.g. `_immich_stack_id` falls back to a loose asset instead of letting a bad stack-prefix `ValueError` abort the whole sync. Scope such a degradation guard to the decode call itself, not the surrounding hydration: pydantic `ValidationError` subclasses `ValueError`, so an `except ValueError` wrapping model construction (an SDK member fetch, a DTO build) would swallow a real validation failure and mislabel it as the benign decode case. And when a per-item pass runs *before* other work in the same generator (the `StackV1` snapshot precedes the asset loop), catch its transport errors at the call site — an unhandled error there suppresses everything downstream, not just its own rows.
+**Streaming responses.** Once a `StreamingResponse` commits its headers,
+generator exceptions cannot reach the global error handler. Resolve
+authentication and setup errors before returning the response, and handle
+expected per-item failures inside the generator so they do not truncate the
+stream. Keep degradation guards narrow: `ValidationError` subclasses
+`ValueError`, so catch decoding failures around the decode call rather than
+around model construction. Catch transport errors at the call site when an
+early pass should not suppress later stream work.
 
 ### Omit vs explicit-null in update-style DTOs — use `model_fields_set`
 

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -259,6 +259,8 @@ for asset_uuid in request.ids:
 
 Use `map_gumnut_error(e, context, extra=..., exc_info=True)` only when the call site needs to enrich the upstream log record with context the global handler can't see — most commonly the upload paths logging filename / device ids / tracebacks.
 
+**Exception — streaming responses swallow errors after the 200.** The "just let it bubble" rule holds only until a `StreamingResponse` commits its 200. After that a raised error no longer reaches the global handler: `generate_sync_stream`'s broad `except Exception` logs and returns, truncating the stream (no `SyncCompleteV1`, so the client re-fails identically every sync). Resolve auth/setup errors *before* streaming (the sync route pre-fetches the user for exactly this), and make per-item work inside the generator degrade rather than raise — e.g. `_immich_stack_id` falls back to a loose asset instead of letting a bad stack-prefix `ValueError` abort the whole sync.
+
 ### Omit vs explicit-null in update-style DTOs — use `model_fields_set`
 
 Many generated Immich update DTOs declare each field as `T | None = None` (e.g., `UpdateAssetDto`'s `description`, `latitude`, `longitude`, `dateTimeOriginal`). On the wire, Immich clients distinguish two different intents:

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -1,6 +1,6 @@
 ---
 title: "Code Practices"
-last-updated: 2026-07-31
+last-updated: 2026-08-03
 ---
 
 # Code Practices
@@ -259,7 +259,7 @@ for asset_uuid in request.ids:
 
 Use `map_gumnut_error(e, context, extra=..., exc_info=True)` only when the call site needs to enrich the upstream log record with context the global handler can't see — most commonly the upload paths logging filename / device ids / tracebacks.
 
-**Exception — streaming responses swallow errors after the 200.** The "just let it bubble" rule holds only until a `StreamingResponse` commits its 200. After that a raised error no longer reaches the global handler: `generate_sync_stream`'s broad `except Exception` logs and returns, truncating the stream (no `SyncCompleteV1`, so the client re-fails identically every sync). Resolve auth/setup errors *before* streaming (the sync route pre-fetches the user for exactly this), and make per-item work inside the generator degrade rather than raise — e.g. `_immich_stack_id` falls back to a loose asset instead of letting a bad stack-prefix `ValueError` abort the whole sync.
+**Exception — streaming responses swallow errors after the 200.** The "just let it bubble" rule holds only until a `StreamingResponse` commits its 200. After that a raised error no longer reaches the global handler: `generate_sync_stream`'s broad `except Exception` logs and returns, truncating the stream (no `SyncCompleteV1`, so the client re-fails identically every sync). Resolve auth/setup errors *before* streaming (the sync route pre-fetches the user for exactly this), and make per-item work inside the generator degrade rather than raise — e.g. `_immich_stack_id` falls back to a loose asset instead of letting a bad stack-prefix `ValueError` abort the whole sync. Scope such a degradation guard to the decode call itself, not the surrounding hydration: pydantic `ValidationError` subclasses `ValueError`, so an `except ValueError` wrapping model construction (an SDK member fetch, a DTO build) would swallow a real validation failure and mislabel it as the benign decode case. And when a per-item pass runs *before* other work in the same generator (the `StackV1` snapshot precedes the asset loop), catch its transport errors at the call site — an unhandled error there suppresses everything downstream, not just its own rows.
 
 ### Omit vs explicit-null in update-style DTOs — use `model_fields_set`
 

--- a/docs/references/code-practices.md
+++ b/docs/references/code-practices.md
@@ -261,11 +261,11 @@ Use `map_gumnut_error(e, context, extra=..., exc_info=True)` only when the call 
 
 **Streaming responses.** Once a `StreamingResponse` commits its headers,
 generator exceptions cannot reach the global error handler. Resolve
-authentication and setup errors before returning the response, and handle
-expected per-item failures inside the generator so they do not truncate the
-stream. Keep degradation guards narrow: `ValidationError` subclasses
-`ValueError`, so catch decoding failures around the decode call rather than
-around model construction.
+authentication and setup errors before returning the response. Degrade a
+per-item failure only when skipping cannot advance a cursor past data that later
+items depend on; otherwise propagate it so the stream truncates and retries.
+Keep guards narrow: `ValidationError` subclasses `ValueError`, so catch decoding
+failures around the decode call rather than around model construction.
 
 ### Omit vs explicit-null in update-style DTOs — use `model_fields_set`
 

--- a/docs/references/immich-sync-communication.md
+++ b/docs/references/immich-sync-communication.md
@@ -218,14 +218,11 @@ Notes (discussed below):
 
 **Adapter behavior for `StacksV1`:** the table above is what the upstream client
 accepts. The adapter emits `StacksV1` as a **current-state snapshot** — `StackV1`
-upserts only, never `StackDeleteV1` — and only on reset / first sync (no
-`StackV1` checkpoint); an already-synced client receives nothing. Assets carry
-their `stackId` in the same sync so members group under the snapshot's stack
-rows. Incremental stack create/update/delete propagation is out of scope until a
-Gumnut stack event source lands, so a stack changed after a client's initial
-sync is not reflected until that client resets. `PartnerStacksV1` is a no-op
-(no partner sharing). See the "Stack Snapshot" section of
-`docs/architecture/sync-stream-architecture.md` for the full rationale.
+upserts only, never `StackDeleteV1`, and only on reset / first sync — with assets
+carrying their `stackId` in the same sync so members group under the snapshot's
+stack rows. `PartnerStacksV1` stays a no-op (no partner sharing). See the "Stack
+Snapshot" section of `docs/architecture/sync-stream-architecture.md` for the
+snapshot semantics and the incremental-support scope boundary.
 
 ## Special SyncEntityTypes
 

--- a/docs/references/immich-sync-communication.md
+++ b/docs/references/immich-sync-communication.md
@@ -217,12 +217,10 @@ Notes (discussed below):
 - `SyncAckV1`\*\* = Phase transition marker (before first CREATE, marks updates complete)
 
 **Adapter behavior for `StacksV1`:** the table above is what the upstream client
-accepts. The adapter emits `StacksV1` as a **current-state snapshot** — `StackV1`
-upserts only, never `StackDeleteV1`, and only on reset / first sync — with assets
-carrying their `stackId` in the same sync so members group under the snapshot's
-stack rows. `PartnerStacksV1` stays a no-op (no partner sharing). See the "Stack
-Snapshot" section of `docs/architecture/sync-stream-architecture.md` for the
-snapshot semantics and the incremental-support scope boundary.
+accepts; the adapter emits `StackV1` upserts only, never `StackDeleteV1`.
+`PartnerStacksV1` stays a no-op (no partner sharing). See the "Stack Snapshot
+(StacksV1)" section of `docs/architecture/sync-stream-architecture.md` for the
+delivery semantics and the delete-detection scope boundary.
 
 ## Special SyncEntityTypes
 

--- a/docs/references/immich-sync-communication.md
+++ b/docs/references/immich-sync-communication.md
@@ -1,6 +1,6 @@
 ---
 title: "Immich Client<>Server Sync Communication"
-last-updated: 2026-07-12
+last-updated: 2026-08-03
 ---
 
 # Immich Client<>Server Sync Communication
@@ -215,6 +215,17 @@ The 22 SyncRequestTypes generate 50 SyncEntityTypes in specific orders.
 Notes (discussed below):
 - `SyncAckV1`\* = Backfill completion marker (via `sendEntityBackfillCompleteAck()`, one per entity)
 - `SyncAckV1`\*\* = Phase transition marker (before first CREATE, marks updates complete)
+
+**Adapter behavior for `StacksV1`:** the table above is what the upstream client
+accepts. The adapter emits `StacksV1` as a **current-state snapshot** — `StackV1`
+upserts only, never `StackDeleteV1` — and only on reset / first sync (no
+`StackV1` checkpoint); an already-synced client receives nothing. Assets carry
+their `stackId` in the same sync so members group under the snapshot's stack
+rows. Incremental stack create/update/delete propagation is out of scope until a
+Gumnut stack event source lands, so a stack changed after a client's initial
+sync is not reflected until that client resets. `PartnerStacksV1` is a no-op
+(no partner sharing). See the "Stack Snapshot" section of
+`docs/architecture/sync-stream-architecture.md` for the full rationale.
 
 ## Special SyncEntityTypes
 

--- a/docs/references/immich-sync-communication.md
+++ b/docs/references/immich-sync-communication.md
@@ -216,11 +216,7 @@ Notes (discussed below):
 - `SyncAckV1`\* = Backfill completion marker (via `sendEntityBackfillCompleteAck()`, one per entity)
 - `SyncAckV1`\*\* = Phase transition marker (before first CREATE, marks updates complete)
 
-**Adapter behavior for `StacksV1`:** the table above is what the upstream client
-accepts; the adapter emits `StackV1` upserts only, never `StackDeleteV1`.
-`PartnerStacksV1` stays a no-op (no partner sharing). See the "Stack Snapshot
-(StacksV1)" section of `docs/architecture/sync-stream-architecture.md` for the
-delivery semantics and the delete-detection scope boundary.
+Adapter-specific behavior is documented in [Stack Snapshot](../architecture/sync-stream-architecture.md#stack-snapshot-stacksv1).
 
 ## Special SyncEntityTypes
 

--- a/docs/references/immich-sync-communication.md
+++ b/docs/references/immich-sync-communication.md
@@ -1,6 +1,6 @@
 ---
 title: "Immich Client<>Server Sync Communication"
-last-updated: 2026-08-03
+last-updated: 2026-08-11
 ---
 
 # Immich Client<>Server Sync Communication
@@ -216,7 +216,7 @@ Notes (discussed below):
 - `SyncAckV1`\* = Backfill completion marker (via `sendEntityBackfillCompleteAck()`, one per entity)
 - `SyncAckV1`\*\* = Phase transition marker (before first CREATE, marks updates complete)
 
-Adapter-specific behavior is documented in [Stack Snapshot](../architecture/sync-stream-architecture.md#stack-snapshot-stacksv1).
+Adapter-specific behavior is documented in [Stacks](../architecture/sync-stream-architecture.md#stacks-stacksv1).
 
 ## Special SyncEntityTypes
 

--- a/routers/api/sync/converters.py
+++ b/routers/api/sync/converters.py
@@ -65,28 +65,13 @@ logger = logging.getLogger(__name__)
 
 
 def _immich_stack_id(gumnut_stack_id: str | None) -> str | None:
-    """Map an asset's Gumnut stack FK to the Immich ``stackId``, or None.
-
-    Returns None for a loose (unstacked) asset, and — critically — also for a
-    stack_id that fails to decode rather than letting the ValueError abort the
-    whole sync stream. A stacked asset then syncs as loose (an inert
-    degradation), the same fallback ``resolve_timeline_stacks`` takes for this
-    prefix contract; the alternative is the streaming generator's broad handler
-    swallowing the error mid-stream, so the client never receives
-    ``SyncCompleteV1`` and every subsequent sync fails identically on the same
-    asset. The decode failure is logged at debug, not warning — see below.
-    """
+    """Map a stack FK, degrading invalid IDs to an unstacked asset."""
     if not gumnut_stack_id:
         return None
     try:
         return str(safe_uuid_from_stack_id(gumnut_stack_id))
     except ValueError:
-        # Logged at debug, not warning: the only cause is a backend change to the
-        # asset_stack_ prefix, which is systemic — it breaks every stacked asset
-        # at once, so a per-asset warning would flood a full-library sync with
-        # thousands of identical lines. That break already surfaces loudly and
-        # aggregated on the app's primary view via resolve_timeline_stacks; this
-        # path only needs to degrade quietly to a loose asset.
+        # Prefix drift affects every stack, so avoid one warning per asset.
         logger.debug(
             "Asset stack_id is not decodable to an Immich UUID; syncing the "
             "asset as loose (stackId=None)",
@@ -246,10 +231,6 @@ def gumnut_asset_to_sync_asset_v1(asset: AssetResponse, owner_id: UUID) -> SyncA
         height=asset.height if asset.height else None,
         libraryId=None,
         livePhotoVideoId=None,
-        # The asset's stack FK, so the client can group burst members under the
-        # stack row streamed by StacksV1. Loose (unstacked) assets stay null, as
-        # does an undecodable stack_id — see _immich_stack_id. V2 inherits this
-        # through the model_dump delegation below.
         stackId=_immich_stack_id(asset.stack_id),
         thumbhash=asset.thumbhash,
         width=asset.width if asset.width else None,
@@ -457,19 +438,7 @@ def gumnut_album_asset_to_sync_album_to_asset_v1(
 def gumnut_stack_to_sync_stack_v1(
     stack: StackListStacksResponse, primary_asset_id: UUID, owner_id: UUID
 ) -> SyncStackV1:
-    """Convert a Gumnut stack row to Immich SyncStackV1 format.
-
-    ``primary_asset_id`` is the *effective* cover resolved by the shared
-    ``resolve_effective_primary`` helper (via ``hydrate_stack``) — never the raw
-    Gumnut row's pinned cover, which is null for an auto-detected burst.
-    ``SyncStackV1.primaryAssetId`` is required and non-null, so callers must
-    resolve a cover before converting; a member-less stack has none and is
-    skipped upstream rather than reaching here.
-
-    Gumnut is single-user with no stack sharing, so ``ownerId`` is always the
-    current user — the row itself carries no owner. Member assets are not
-    embedded: each carries this stack's id in its own ``stackId`` field.
-    """
+    """Convert a stack using its resolved effective primary."""
     return SyncStackV1(
         id=safe_uuid_from_stack_id(stack.id),
         ownerId=owner_id,

--- a/routers/api/sync/converters.py
+++ b/routers/api/sync/converters.py
@@ -4,6 +4,7 @@ Converter functions mapping Gumnut SDK types to Immich sync models.
 Pure functions with no internal dependencies.
 """
 
+import logging
 from uuid import UUID
 
 from gumnut.types.album_asset_response import AlbumAssetResponse
@@ -58,6 +59,40 @@ from routers.utils.gumnut_id_conversion import (
     safe_uuid_from_stack_id,
     safe_uuid_from_user_id,
 )
+
+
+logger = logging.getLogger(__name__)
+
+
+def _immich_stack_id(gumnut_stack_id: str | None) -> str | None:
+    """Map an asset's Gumnut stack FK to the Immich ``stackId``, or None.
+
+    Returns None for a loose (unstacked) asset, and — critically — also for a
+    stack_id that fails to decode rather than letting the ValueError abort the
+    whole sync stream. A stacked asset then syncs as loose (an inert
+    degradation), the same fallback ``resolve_timeline_stacks`` takes for this
+    prefix contract; the alternative is the streaming generator's broad handler
+    swallowing the error mid-stream, so the client never receives
+    ``SyncCompleteV1`` and every subsequent sync fails identically on the same
+    asset. The decode failure is logged at debug, not warning — see below.
+    """
+    if not gumnut_stack_id:
+        return None
+    try:
+        return str(safe_uuid_from_stack_id(gumnut_stack_id))
+    except ValueError:
+        # Logged at debug, not warning: the only cause is a backend change to the
+        # asset_stack_ prefix, which is systemic — it breaks every stacked asset
+        # at once, so a per-asset warning would flood a full-library sync with
+        # thousands of identical lines. That break already surfaces loudly and
+        # aggregated on the app's primary view via resolve_timeline_stacks; this
+        # path only needs to degrade quietly to a loose asset.
+        logger.debug(
+            "Asset stack_id is not decodable to an Immich UUID; syncing the "
+            "asset as loose (stackId=None)",
+            extra={"stack_id": gumnut_stack_id},
+        )
+        return None
 
 
 def _format_exposure_time(exposure_time: float | None) -> str | None:
@@ -212,11 +247,10 @@ def gumnut_asset_to_sync_asset_v1(asset: AssetResponse, owner_id: UUID) -> SyncA
         libraryId=None,
         livePhotoVideoId=None,
         # The asset's stack FK, so the client can group burst members under the
-        # stack row streamed by StacksV1. Loose (unstacked) assets stay null.
-        # V2 inherits this through the model_dump delegation below.
-        stackId=(
-            str(safe_uuid_from_stack_id(asset.stack_id)) if asset.stack_id else None
-        ),
+        # stack row streamed by StacksV1. Loose (unstacked) assets stay null, as
+        # does an undecodable stack_id — see _immich_stack_id. V2 inherits this
+        # through the model_dump delegation below.
+        stackId=_immich_stack_id(asset.stack_id),
         thumbhash=asset.thumbhash,
         width=asset.width if asset.width else None,
     )

--- a/routers/api/sync/converters.py
+++ b/routers/api/sync/converters.py
@@ -11,6 +11,7 @@ from gumnut.types.album_response import AlbumResponse
 from gumnut.types.asset_response import AssetResponse
 from gumnut.types.face_response import FaceResponse
 from gumnut.types.person_response import PersonResponse
+from gumnut.types.stack_list_stacks_response import StackListStacksResponse
 from gumnut.types.user_response import UserResponse
 
 from routers.immich_models import (
@@ -28,6 +29,7 @@ from routers.immich_models import (
     SyncAssetV2,
     SyncAuthUserV1,
     SyncPersonV1,
+    SyncStackV1,
     SyncUserMetadataV1,
     SyncUserV1,
     UserMetadataKey,
@@ -53,6 +55,7 @@ from routers.utils.gumnut_id_conversion import (
     safe_uuid_from_asset_id,
     safe_uuid_from_face_id,
     safe_uuid_from_person_id,
+    safe_uuid_from_stack_id,
     safe_uuid_from_user_id,
 )
 
@@ -208,7 +211,12 @@ def gumnut_asset_to_sync_asset_v1(asset: AssetResponse, owner_id: UUID) -> SyncA
         height=asset.height if asset.height else None,
         libraryId=None,
         livePhotoVideoId=None,
-        stackId=None,
+        # The asset's stack FK, so the client can group burst members under the
+        # stack row streamed by StacksV1. Loose (unstacked) assets stay null.
+        # V2 inherits this through the model_dump delegation below.
+        stackId=(
+            str(safe_uuid_from_stack_id(asset.stack_id)) if asset.stack_id else None
+        ),
         thumbhash=asset.thumbhash,
         width=asset.width if asset.width else None,
     )
@@ -409,4 +417,29 @@ def gumnut_album_asset_to_sync_album_to_asset_v1(
     return SyncAlbumToAssetV1(
         albumId=safe_uuid_from_album_id(album_asset.album_id),
         assetId=safe_uuid_from_asset_id(album_asset.asset_id),
+    )
+
+
+def gumnut_stack_to_sync_stack_v1(
+    stack: StackListStacksResponse, primary_asset_id: UUID, owner_id: UUID
+) -> SyncStackV1:
+    """Convert a Gumnut stack row to Immich SyncStackV1 format.
+
+    ``primary_asset_id`` is the *effective* cover resolved by the shared
+    ``resolve_effective_primary`` helper (via ``hydrate_stack``) — never the raw
+    Gumnut row's pinned cover, which is null for an auto-detected burst.
+    ``SyncStackV1.primaryAssetId`` is required and non-null, so callers must
+    resolve a cover before converting; a member-less stack has none and is
+    skipped upstream rather than reaching here.
+
+    Gumnut is single-user with no stack sharing, so ``ownerId`` is always the
+    current user — the row itself carries no owner. Member assets are not
+    embedded: each carries this stack's id in its own ``stackId`` field.
+    """
+    return SyncStackV1(
+        id=safe_uuid_from_stack_id(stack.id),
+        ownerId=owner_id,
+        primaryAssetId=primary_asset_id,
+        createdAt=stack.created_at,
+        updatedAt=stack.updated_at,
     )

--- a/routers/api/sync/entity_fetch.py
+++ b/routers/api/sync/entity_fetch.py
@@ -9,6 +9,7 @@ from routers.api.constants import GUMNUT_API_MAX_BULK_IDS
 from routers.api.sync.types import EntityType, FetchedStack
 from routers.utils.asset_conversion import ASSET_INCLUDE_NO_PEOPLE
 from routers.utils.concurrency import gather_with_concurrency
+from routers.utils.gumnut_id_conversion import safe_uuid_from_stack_id
 from routers.utils.stack_conversion import HydratedStack, hydrate_stack
 
 logger = logging.getLogger(__name__)
@@ -22,15 +23,30 @@ def _batched(items: list[str], size: int) -> list[list[str]]:
 async def _hydrate_stack_or_skip(
     client: AsyncGumnut, stack_row: StackListStacksResponse
 ) -> HydratedStack | None:
-    """Hydrate one stack, degrading a member-read failure to a skip.
+    """Hydrate one stack, degrading a decode or member-read failure to a skip.
 
     StackV1 is the first pass in the sync stream, so an unhandled error here
-    truncates every later pass and `SyncCompleteV1`. `hydrate_stacks` aborts the
-    whole batch on one failure, so hydrate per stack behind this guard instead
-    (the same per-stack catch the timeline's `_live_members_or_error` uses): a
-    transient member read failing for one stack costs only its own `StackV1`,
-    routed to the inert `missing_ids` skip, not the sync.
+    escapes the whole `gather` batch (losing every sibling's `StackV1` too) and
+    truncates every later pass plus `SyncCompleteV1`. Two conditions are degraded
+    to the inert `missing_ids` skip instead — matching how the timeline and the
+    asset `stackId` converter already degrade them, rather than the delete path
+    that crashes:
+
+    - an undecodable stack id (prefix drift), guarded around the decode call
+      itself so a member `ValidationError` — also a `ValueError` — raised deeper
+      in hydration is not swallowed with it; and
+    - a transient member-read `GumnutError` (the per-stack catch `hydrate_stacks`'
+      docstring points callers to, since a batch-level failure drops siblings).
     """
+    try:
+        safe_uuid_from_stack_id(stack_row.id)
+    except ValueError:
+        logger.warning(
+            "Undecodable stack id during sync; skipping the stack row and "
+            "syncing its assets as loose",
+            extra={"stack_id": stack_row.id},
+        )
+        return None
     try:
         return await hydrate_stack(client, stack_row)
     except GumnutError:
@@ -152,7 +168,7 @@ async def fetch_entities_map(
             hydrated_stacks = await gather_with_concurrency(
                 [_hydrate_stack_or_skip(gumnut_client, row) for row in rows]
             )
-            for stack_row, hydrated in zip(rows, hydrated_stacks):
+            for stack_row, hydrated in zip(rows, hydrated_stacks, strict=True):
                 if hydrated is None:
                     missing_ids.add(stack_row.id)
                 else:

--- a/routers/api/sync/entity_fetch.py
+++ b/routers/api/sync/entity_fetch.py
@@ -1,16 +1,21 @@
 """Batch entity fetching from the Gumnut API."""
 
 import logging
+from typing import Literal
+from uuid import UUID
 
 from gumnut import AsyncGumnut
+from gumnut.types.asset_response import AssetResponse
 from gumnut.types.stack_list_stacks_response import StackListStacksResponse
 
 from routers.api.constants import GUMNUT_API_MAX_BULK_IDS
 from routers.api.sync.types import EntityType, FetchedStack
 from routers.utils.asset_conversion import ASSET_INCLUDE_NO_PEOPLE
 from routers.utils.concurrency import gather_with_concurrency
-from routers.utils.gumnut_id_conversion import safe_uuid_from_stack_id
-from routers.utils.stack_conversion import HydratedStack, hydrate_stack
+from routers.utils.gumnut_id_conversion import (
+    safe_uuid_from_asset_id,
+    safe_uuid_from_stack_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -21,43 +26,34 @@ def _batched(items: list[str], size: int) -> list[list[str]]:
 
 
 class StackMemberReadInconsistent(Exception):
-    """A stack row claims live members but its member read came back empty.
-
-    A transient contradiction (e.g. read replication lag), not a member-less
-    stack — surfaced so the sync truncates and retries rather than skipping the
-    stack and stranding its members as a hidden burst.
-    """
+    """A stack row was returned but its all-state member read was empty."""
 
 
-async def _hydrate_stack_for_sync(
+async def _first_stack_member(
+    client: AsyncGumnut,
+    stack_id: str,
+    *,
+    state: Literal["live", "all"],
+    asset_id: str | None = None,
+) -> AssetResponse | None:
+    """Return the first matching member without walking later cursor pages."""
+    if asset_id is None:
+        page = client.assets.list(stack_id=stack_id, state=state, order="asc", limit=1)
+    else:
+        page = client.assets.list(
+            stack_id=stack_id,
+            ids=[asset_id],
+            state=state,
+            order="asc",
+            limit=1,
+        )
+    return await anext(aiter(page), None)
+
+
+async def _resolve_stack_primary_for_sync(
     client: AsyncGumnut, stack_row: StackListStacksResponse
-) -> HydratedStack | None:
-    """Hydrate one stack, skipping only *permanent* non-emittable conditions.
-
-    Returns `None` — routed to the inert `missing_ids` skip — only when the stack
-    truly cannot be emitted and skipping strands no member: an undecodable id
-    (prefix drift; its members degrade to loose via `_immich_stack_id`), or a
-    genuinely member-less stack (`asset_count == 0` and `hydrate_stack` returns
-    `None`; no asset carries its `stackId`). The decode is guarded around the
-    call so a member `ValidationError` — also a `ValueError` — raised deeper in
-    hydration is not swallowed with it.
-
-    Two *retriable* failures are deliberately surfaced rather than skipped,
-    because skipping would let `_stream_entity_type` advance the events cursor
-    past the stack while the asset pass still stamps `stackId` on its members —
-    permanently hiding the whole burst, since the mobile timeline drops an asset
-    whose `stackId` names no stack row:
-
-    - a member-read `GumnutError` (propagated by not catching it); and
-    - an empty member read that contradicts a positive `asset_count`
-      (`StackMemberReadInconsistent`) — a transient inconsistency, since the
-      `state="all"` read would otherwise see even trashed members.
-
-    Either truncates the sync so the cursor is preserved and the stack retries
-    next cycle. A stack that fails *persistently* wedges the pass until it
-    recovers — loud in the logs, and the price of never stranding a member;
-    bounded per-stack retry is a possible future refinement.
-    """
+) -> UUID | None:
+    """Resolve a stack primary, skipping only an undecodable stack ID."""
     try:
         safe_uuid_from_stack_id(stack_row.id)
     except ValueError:
@@ -67,13 +63,27 @@ async def _hydrate_stack_for_sync(
             extra={"stack_id": stack_row.id},
         )
         return None
-    hydrated = await hydrate_stack(client, stack_row)
-    if hydrated is None and stack_row.asset_count > 0:
-        raise StackMemberReadInconsistent(
-            f"stack {stack_row.id} reports {stack_row.asset_count} member(s) but "
-            "its member read returned none"
+
+    primary = None
+    if stack_row.primary_asset_id is not None:
+        primary = await _first_stack_member(
+            client,
+            stack_row.id,
+            state="all",
+            asset_id=stack_row.primary_asset_id,
         )
-    return hydrated
+    if primary is None:
+        primary = await _first_stack_member(client, stack_row.id, state="live")
+    if primary is None:
+        primary = await _first_stack_member(client, stack_row.id, state="all")
+    if primary is None:
+        # asset_count excludes trashed members, so even zero cannot prove that
+        # an empty all-state read is permanent. Propagate to preserve the cursor.
+        raise StackMemberReadInconsistent(
+            f"stack {stack_row.id} member read returned none "
+            f"(row reports {stack_row.asset_count} live member(s))"
+        )
+    return safe_uuid_from_asset_id(primary.id)
 
 
 async def fetch_entities_map(
@@ -170,30 +180,22 @@ async def fetch_entities_map(
                     missing_ids.add(asset.id)
 
         elif gumnut_entity_type == "stack":
-            # hydrate_stack resolves the effective primary carried in
-            # FetchedStack (see its docstring for why the converter stays
-            # I/O-free). Each hydration is a per-stack member read, so run them
-            # under the shared concurrency bound rather than serially: a first
-            # sync replays every stack event and would otherwise open one
-            # blocking round-trip per stack. A permanently non-emittable stack
-            # (member-less, or undecodable id per _hydrate_stack_for_sync) yields
-            # None and goes to missing_ids — the same inert skip as an asset
-            # lacking metadata; a transient member-read failure propagates
-            # instead (see _hydrate_stack_for_sync for why skipping would hide
-            # the burst).
+            # Primary resolution costs one lean member read per stack, bounded
+            # here so a first sync does not fan out without limit.
             stack_page = await gumnut_client.stacks.list_stacks(
                 ids=chunk, limit=len(chunk)
             )
             rows = stack_page.data
-            hydrated_stacks = await gather_with_concurrency(
-                [_hydrate_stack_for_sync(gumnut_client, row) for row in rows]
+            primary_ids = await gather_with_concurrency(
+                [_resolve_stack_primary_for_sync(gumnut_client, row) for row in rows],
+                cancel_on_error=True,
             )
-            for stack_row, hydrated in zip(rows, hydrated_stacks, strict=True):
-                if hydrated is None:
+            for stack_row, primary_id in zip(rows, primary_ids, strict=True):
+                if primary_id is None:
                     missing_ids.add(stack_row.id)
                 else:
                     result[stack_row.id] = FetchedStack(
-                        row=stack_row, primary_asset_id=hydrated.primary_asset_id
+                        row=stack_row, primary_asset_id=primary_id
                     )
 
     return result, missing_ids

--- a/routers/api/sync/entity_fetch.py
+++ b/routers/api/sync/entity_fetch.py
@@ -2,12 +2,14 @@
 
 import logging
 
-from gumnut import AsyncGumnut
+from gumnut import AsyncGumnut, GumnutError
+from gumnut.types.stack_list_stacks_response import StackListStacksResponse
 
 from routers.api.constants import GUMNUT_API_MAX_BULK_IDS
 from routers.api.sync.types import EntityType, FetchedStack
 from routers.utils.asset_conversion import ASSET_INCLUDE_NO_PEOPLE
-from routers.utils.stack_conversion import hydrate_stack
+from routers.utils.concurrency import gather_with_concurrency
+from routers.utils.stack_conversion import HydratedStack, hydrate_stack
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +17,30 @@ logger = logging.getLogger(__name__)
 def _batched(items: list[str], size: int) -> list[list[str]]:
     """Split a list into chunks of the given size."""
     return [items[i : i + size] for i in range(0, len(items), size)]
+
+
+async def _hydrate_stack_or_skip(
+    client: AsyncGumnut, stack_row: StackListStacksResponse
+) -> HydratedStack | None:
+    """Hydrate one stack, degrading a member-read failure to a skip.
+
+    StackV1 is the first pass in the sync stream, so an unhandled error here
+    truncates every later pass and `SyncCompleteV1`. `hydrate_stacks` aborts the
+    whole batch on one failure, so hydrate per stack behind this guard instead
+    (the same per-stack catch the timeline's `_live_members_or_error` uses): a
+    transient member read failing for one stack costs only its own `StackV1`,
+    routed to the inert `missing_ids` skip, not the sync.
+    """
+    try:
+        return await hydrate_stack(client, stack_row)
+    except GumnutError:
+        logger.warning(
+            "Stack member read failed during sync; syncing its assets as loose "
+            "and skipping the stack row",
+            extra={"stack_id": stack_row.id},
+            exc_info=True,
+        )
+        return None
 
 
 async def fetch_entities_map(
@@ -111,23 +137,27 @@ async def fetch_entities_map(
                     missing_ids.add(asset.id)
 
         elif gumnut_entity_type == "stack":
-            # Stacks need a hop the other types don't: SyncStackV1 requires a
-            # primaryAssetId, and for an unpinned burst that cover is only known
-            # by reading the members. hydrate_stack resolves it (reusing the REST
-            # effective-primary rules) and the resolved id rides along in
-            # FetchedStack so convert_entity_to_sync_event stays I/O-free. A
-            # member-less stack has no honest primary, so it goes to missing_ids
-            # and is skipped — the same inert path as an asset lacking metadata.
+            # hydrate_stack resolves the effective primary carried in
+            # FetchedStack (see its docstring for why the converter stays
+            # I/O-free). Each hydration is a per-stack member read, so run them
+            # under the shared concurrency bound rather than serially: a first
+            # sync replays every stack event and would otherwise open one
+            # blocking round-trip per stack. A member-less stack (or one whose
+            # member read fails, per _hydrate_stack_or_skip) yields None and goes
+            # to missing_ids — the same inert skip as an asset lacking metadata.
             stack_page = await gumnut_client.stacks.list_stacks(
                 ids=chunk, limit=len(chunk)
             )
-            for stack_row in stack_page.data:
-                hydrated = await hydrate_stack(gumnut_client, stack_row)
+            rows = stack_page.data
+            hydrated_stacks = await gather_with_concurrency(
+                [_hydrate_stack_or_skip(gumnut_client, row) for row in rows]
+            )
+            for stack_row, hydrated in zip(rows, hydrated_stacks):
                 if hydrated is None:
                     missing_ids.add(stack_row.id)
-                    continue
-                result[stack_row.id] = FetchedStack(
-                    row=stack_row, primary_asset_id=hydrated.primary_asset_id
-                )
+                else:
+                    result[stack_row.id] = FetchedStack(
+                        row=stack_row, primary_asset_id=hydrated.primary_asset_id
+                    )
 
     return result, missing_ids

--- a/routers/api/sync/entity_fetch.py
+++ b/routers/api/sync/entity_fetch.py
@@ -5,8 +5,9 @@ import logging
 from gumnut import AsyncGumnut
 
 from routers.api.constants import GUMNUT_API_MAX_BULK_IDS
-from routers.api.sync.types import EntityType
+from routers.api.sync.types import EntityType, FetchedStack
 from routers.utils.asset_conversion import ASSET_INCLUDE_NO_PEOPLE
+from routers.utils.stack_conversion import hydrate_stack
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,15 @@ async def fetch_entities_map(
         Tuple of (entity_id -> entity object mapping, set of IDs that were
         explicitly missing — e.g., assets fetched but lacking metadata)
     """
-    _SUPPORTED_TYPES = {"asset", "album", "person", "face", "album_asset", "metadata"}
+    _SUPPORTED_TYPES = {
+        "asset",
+        "album",
+        "person",
+        "face",
+        "album_asset",
+        "metadata",
+        "stack",
+    }
     if gumnut_entity_type not in _SUPPORTED_TYPES:
         raise ValueError(
             f"Unsupported entity type in fetch_entities_map: {gumnut_entity_type}"
@@ -100,5 +109,25 @@ async def fetch_entities_map(
                         extra={"asset_id": asset.id},
                     )
                     missing_ids.add(asset.id)
+
+        elif gumnut_entity_type == "stack":
+            # Stacks need a hop the other types don't: SyncStackV1 requires a
+            # primaryAssetId, and for an unpinned burst that cover is only known
+            # by reading the members. hydrate_stack resolves it (reusing the REST
+            # effective-primary rules) and the resolved id rides along in
+            # FetchedStack so convert_entity_to_sync_event stays I/O-free. A
+            # member-less stack has no honest primary, so it goes to missing_ids
+            # and is skipped — the same inert path as an asset lacking metadata.
+            stack_page = await gumnut_client.stacks.list_stacks(
+                ids=chunk, limit=len(chunk)
+            )
+            for stack_row in stack_page.data:
+                hydrated = await hydrate_stack(gumnut_client, stack_row)
+                if hydrated is None:
+                    missing_ids.add(stack_row.id)
+                    continue
+                result[stack_row.id] = FetchedStack(
+                    row=stack_row, primary_asset_id=hydrated.primary_asset_id
+                )
 
     return result, missing_ids

--- a/routers/api/sync/entity_fetch.py
+++ b/routers/api/sync/entity_fetch.py
@@ -20,28 +20,43 @@ def _batched(items: list[str], size: int) -> list[list[str]]:
     return [items[i : i + size] for i in range(0, len(items), size)]
 
 
+class StackMemberReadInconsistent(Exception):
+    """A stack row claims live members but its member read came back empty.
+
+    A transient contradiction (e.g. read replication lag), not a member-less
+    stack — surfaced so the sync truncates and retries rather than skipping the
+    stack and stranding its members as a hidden burst.
+    """
+
+
 async def _hydrate_stack_for_sync(
     client: AsyncGumnut, stack_row: StackListStacksResponse
 ) -> HydratedStack | None:
     """Hydrate one stack, skipping only *permanent* non-emittable conditions.
 
     Returns `None` — routed to the inert `missing_ids` skip — only when the stack
-    can never be emitted and skipping strands no member: an undecodable id
+    truly cannot be emitted and skipping strands no member: an undecodable id
     (prefix drift; its members degrade to loose via `_immich_stack_id`), or a
-    member-less stack (`hydrate_stack` returns `None`; no asset carries its
-    `stackId`). The decode is guarded around the call so a member
-    `ValidationError` — also a `ValueError` — raised deeper in hydration is not
-    swallowed with it.
+    genuinely member-less stack (`asset_count == 0` and `hydrate_stack` returns
+    `None`; no asset carries its `stackId`). The decode is guarded around the
+    call so a member `ValidationError` — also a `ValueError` — raised deeper in
+    hydration is not swallowed with it.
 
-    A transient `GumnutError` from the member read is deliberately **not** caught.
-    It is retriable, and skipping it would let `_stream_entity_type` advance the
-    events cursor past the stack while the asset pass still stamps `stackId` on
-    its members — permanently hiding the whole burst, since the mobile timeline
-    drops an asset whose `stackId` names no stack row. Propagating truncates this
-    sync so the cursor is preserved and the stack retries next cycle. A stack
-    that fails *persistently* wedges the pass until it recovers — loud in the
-    logs, and the price of never stranding a member; bounded per-stack retry is a
-    possible future refinement.
+    Two *retriable* failures are deliberately surfaced rather than skipped,
+    because skipping would let `_stream_entity_type` advance the events cursor
+    past the stack while the asset pass still stamps `stackId` on its members —
+    permanently hiding the whole burst, since the mobile timeline drops an asset
+    whose `stackId` names no stack row:
+
+    - a member-read `GumnutError` (propagated by not catching it); and
+    - an empty member read that contradicts a positive `asset_count`
+      (`StackMemberReadInconsistent`) — a transient inconsistency, since the
+      `state="all"` read would otherwise see even trashed members.
+
+    Either truncates the sync so the cursor is preserved and the stack retries
+    next cycle. A stack that fails *persistently* wedges the pass until it
+    recovers — loud in the logs, and the price of never stranding a member;
+    bounded per-stack retry is a possible future refinement.
     """
     try:
         safe_uuid_from_stack_id(stack_row.id)
@@ -52,7 +67,13 @@ async def _hydrate_stack_for_sync(
             extra={"stack_id": stack_row.id},
         )
         return None
-    return await hydrate_stack(client, stack_row)
+    hydrated = await hydrate_stack(client, stack_row)
+    if hydrated is None and stack_row.asset_count > 0:
+        raise StackMemberReadInconsistent(
+            f"stack {stack_row.id} reports {stack_row.asset_count} member(s) but "
+            "its member read returned none"
+        )
+    return hydrated
 
 
 async def fetch_entities_map(

--- a/routers/api/sync/entity_fetch.py
+++ b/routers/api/sync/entity_fetch.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from gumnut import AsyncGumnut, GumnutError
+from gumnut import AsyncGumnut
 from gumnut.types.stack_list_stacks_response import StackListStacksResponse
 
 from routers.api.constants import GUMNUT_API_MAX_BULK_IDS
@@ -20,23 +20,28 @@ def _batched(items: list[str], size: int) -> list[list[str]]:
     return [items[i : i + size] for i in range(0, len(items), size)]
 
 
-async def _hydrate_stack_or_skip(
+async def _hydrate_stack_for_sync(
     client: AsyncGumnut, stack_row: StackListStacksResponse
 ) -> HydratedStack | None:
-    """Hydrate one stack, degrading a decode or member-read failure to a skip.
+    """Hydrate one stack, skipping only *permanent* non-emittable conditions.
 
-    StackV1 is the first pass in the sync stream, so an unhandled error here
-    escapes the whole `gather` batch (losing every sibling's `StackV1` too) and
-    truncates every later pass plus `SyncCompleteV1`. Two conditions are degraded
-    to the inert `missing_ids` skip instead — matching how the timeline and the
-    asset `stackId` converter already degrade them, rather than the delete path
-    that crashes:
+    Returns `None` — routed to the inert `missing_ids` skip — only when the stack
+    can never be emitted and skipping strands no member: an undecodable id
+    (prefix drift; its members degrade to loose via `_immich_stack_id`), or a
+    member-less stack (`hydrate_stack` returns `None`; no asset carries its
+    `stackId`). The decode is guarded around the call so a member
+    `ValidationError` — also a `ValueError` — raised deeper in hydration is not
+    swallowed with it.
 
-    - an undecodable stack id (prefix drift), guarded around the decode call
-      itself so a member `ValidationError` — also a `ValueError` — raised deeper
-      in hydration is not swallowed with it; and
-    - a transient member-read `GumnutError` (the per-stack catch `hydrate_stacks`'
-      docstring points callers to, since a batch-level failure drops siblings).
+    A transient `GumnutError` from the member read is deliberately **not** caught.
+    It is retriable, and skipping it would let `_stream_entity_type` advance the
+    events cursor past the stack while the asset pass still stamps `stackId` on
+    its members — permanently hiding the whole burst, since the mobile timeline
+    drops an asset whose `stackId` names no stack row. Propagating truncates this
+    sync so the cursor is preserved and the stack retries next cycle. A stack
+    that fails *persistently* wedges the pass until it recovers — loud in the
+    logs, and the price of never stranding a member; bounded per-stack retry is a
+    possible future refinement.
     """
     try:
         safe_uuid_from_stack_id(stack_row.id)
@@ -47,16 +52,7 @@ async def _hydrate_stack_or_skip(
             extra={"stack_id": stack_row.id},
         )
         return None
-    try:
-        return await hydrate_stack(client, stack_row)
-    except GumnutError:
-        logger.warning(
-            "Stack member read failed during sync; syncing its assets as loose "
-            "and skipping the stack row",
-            extra={"stack_id": stack_row.id},
-            exc_info=True,
-        )
-        return None
+    return await hydrate_stack(client, stack_row)
 
 
 async def fetch_entities_map(
@@ -158,15 +154,18 @@ async def fetch_entities_map(
             # I/O-free). Each hydration is a per-stack member read, so run them
             # under the shared concurrency bound rather than serially: a first
             # sync replays every stack event and would otherwise open one
-            # blocking round-trip per stack. A member-less stack (or one whose
-            # member read fails, per _hydrate_stack_or_skip) yields None and goes
-            # to missing_ids — the same inert skip as an asset lacking metadata.
+            # blocking round-trip per stack. A permanently non-emittable stack
+            # (member-less, or undecodable id per _hydrate_stack_for_sync) yields
+            # None and goes to missing_ids — the same inert skip as an asset
+            # lacking metadata; a transient member-read failure propagates
+            # instead (see _hydrate_stack_for_sync for why skipping would hide
+            # the burst).
             stack_page = await gumnut_client.stacks.list_stacks(
                 ids=chunk, limit=len(chunk)
             )
             rows = stack_page.data
             hydrated_stacks = await gather_with_concurrency(
-                [_hydrate_stack_or_skip(gumnut_client, row) for row in rows]
+                [_hydrate_stack_for_sync(gumnut_client, row) for row in rows]
             )
             for stack_row, hydrated in zip(rows, hydrated_stacks, strict=True):
                 if hydrated is None:

--- a/routers/api/sync/events.py
+++ b/routers/api/sync/events.py
@@ -193,7 +193,18 @@ def make_delete_sync_event(
         )
 
     elif event.event_type == "stack_deleted":
-        data = SyncStackDeleteV1(stackId=safe_uuid_from_stack_id(event.entity_id))
+        # Stacks are the first sync pass, so an unguarded decode here would
+        # truncate the whole sync on prefix drift. Skip instead, degrading like
+        # the other stack surfaces rather than the sibling delete types.
+        try:
+            stack_uuid = safe_uuid_from_stack_id(event.entity_id)
+        except ValueError:
+            logger.warning(
+                "Undecodable stack id in stack_deleted event, skipping",
+                extra={"entity_id": event.entity_id, "cursor": event.cursor},
+            )
+            return None
+        data = SyncStackDeleteV1(stackId=stack_uuid)
         return (
             make_sync_event(
                 SyncEntityType.StackDeleteV1,

--- a/routers/api/sync/events.py
+++ b/routers/api/sync/events.py
@@ -19,12 +19,14 @@ from routers.immich_models import (
     SyncAssetFaceDeleteV1,
     SyncEntityType,
     SyncPersonDeleteV1,
+    SyncStackDeleteV1,
 )
 from routers.utils.gumnut_id_conversion import (
     safe_uuid_from_album_id,
     safe_uuid_from_asset_id,
     safe_uuid_from_face_id,
     safe_uuid_from_person_id,
+    safe_uuid_from_stack_id,
 )
 
 from routers.api.sync.converters import (
@@ -38,8 +40,9 @@ from routers.api.sync.converters import (
     gumnut_face_to_sync_face_v2,
     gumnut_metadata_to_sync_exif_v1,
     gumnut_person_to_sync_person_v1,
+    gumnut_stack_to_sync_stack_v1,
 )
-from routers.api.sync.types import EntityType
+from routers.api.sync.types import EntityType, FetchedStack
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +53,7 @@ _DELETE_EVENT_ENTITY_TYPES: dict[str, str] = {
     "person_deleted": "person",
     "face_deleted": "face",
     "album_asset_removed": "album_asset",
+    "stack_deleted": "stack",
 }
 
 
@@ -188,6 +192,17 @@ def make_delete_sync_event(
             SyncEntityType.AssetFaceDeleteV1,
         )
 
+    elif event.event_type == "stack_deleted":
+        data = SyncStackDeleteV1(stackId=safe_uuid_from_stack_id(event.entity_id))
+        return (
+            make_sync_event(
+                SyncEntityType.StackDeleteV1,
+                data.model_dump(mode="json"),
+                event.cursor,
+            ),
+            SyncEntityType.StackDeleteV1,
+        )
+
     elif event.event_type == "album_asset_removed":
         if not isinstance(event.payload, dict):
             logger.warning(
@@ -318,6 +333,13 @@ def convert_entity_to_sync_event(
             sync_model = gumnut_face_to_sync_face_v1(cast(FaceResponse, entity))
     elif gumnut_entity_type == "metadata":
         sync_model = gumnut_metadata_to_sync_exif_v1(cast(AssetResponse, entity))
+    elif gumnut_entity_type == "stack":
+        # fetch_entities_map hydrated the members and resolved the effective
+        # primary into FetchedStack, so the converter stays I/O-free.
+        fetched = cast(FetchedStack, entity)
+        sync_model = gumnut_stack_to_sync_stack_v1(
+            fetched.row, fetched.primary_asset_id, owner_id
+        )
     else:
         raise ValueError(f"Unsupported entity type: {gumnut_entity_type}")
 

--- a/routers/api/sync/fk_integrity.py
+++ b/routers/api/sync/fk_integrity.py
@@ -5,6 +5,8 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any, NamedTuple
 
+from pydantic import BaseModel
+
 from gumnut.types.events_response import Data as EventData
 
 from routers.immich_models import SyncEntityType
@@ -79,6 +81,7 @@ _GUMNUT_TYPE_TO_SYNC_TYPES: dict[str, list[SyncEntityType]] = {
     "metadata": [SyncEntityType.AssetExifV1],
     "person": [SyncEntityType.PersonV1],
     "face": [SyncEntityType.AssetFaceV1, SyncEntityType.AssetFaceV2],
+    "stack": [SyncEntityType.StackV1],
 }
 
 
@@ -211,7 +214,11 @@ def null_deleted_fk_references(
             )
             updates[attr_name] = None
 
-    if updates:
+    if updates and isinstance(entity, BaseModel):
+        # Only FK-bearing pydantic entities reach here — FetchedStack has no
+        # FK_REFERENCES entry, so `refs` was empty and we returned above. The
+        # isinstance narrows the EntityType union (which now includes the
+        # non-pydantic FetchedStack) for the type checker.
         entity = entity.model_copy(update=updates)
 
     return entity

--- a/routers/api/sync/routes.py
+++ b/routers/api/sync/routes.py
@@ -5,7 +5,7 @@ This module implements the Immich sync protocol via streaming sync. The legacy
 full/delta sync endpoints were removed in Immich v3 — Sync v2 supersedes them
 over the existing /sync/stream.
 
-The streaming sync uses the Gumnut API v2 events endpoint (/api/v2/events) to
+The streaming sync uses the Gumnut API events endpoint (/api/events) to
 fetch lightweight event records, then batch-fetches full entities as needed.
 Events are processed in priority order (assets before exif, etc.).
 """

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -532,6 +532,23 @@ async def _stream_stacks(
     The per-row ack cursor is ``stack.updated_at`` + id: pipe-free and stable, so
     a reset replays deterministically and the last row's ack becomes the StackV1
     checkpoint that suppresses future snapshots.
+
+    Two accepted trade-offs, both cheap because this pass is reset-only:
+
+    - Each stack is hydrated through the shared ``hydrate_stack`` — the same
+      helper REST ``/stacks`` uses, so the effective primary matches exactly
+      (including the trashed-pin rule) — which fetches every member with
+      ``ASSET_INCLUDE`` even though only the resolved primary id is used here.
+      Reusing the single source of truth is worth the unused member payload on a
+      reset; a lean member read is a later optimization if a large, burst-heavy
+      library ever makes reset latency matter.
+    - A client with no stacks (or only member-less ones) emits no StackV1 row, so
+      never acks one, so never stores a checkpoint — it re-pages ``list_stacks``
+      (one empty page) on every sync until it has a real stack to checkpoint.
+      A consequence: the first stack a stackless client gains after its initial
+      sync does propagate on the next delta (there is no checkpoint yet to
+      suppress it) — strictly more than the "snapshot only on reset" guarantee,
+      never less, so it is harmless.
     """
     if checkpoint is not None:
         # An existing checkpoint means the client already holds the snapshot;
@@ -676,11 +693,8 @@ async def generate_sync_stream(
         event_counts: dict[str, int] = {}
         total_events = 0
 
-        # Stream the stack snapshot before the asset loop (StacksV1). Stacks are
-        # a current-state snapshot rather than events, emitted first so every
-        # asset's stackId names a stack row the client already holds. Only a
-        # reset / first sync produces rows — see _stream_stacks for the
-        # checkpoint semantics and the incremental-support scope boundary.
+        # Stream the StackV1 snapshot before the asset loop (so each asset's
+        # stackId names a stack the client already holds). See _stream_stacks.
         if SyncRequestType.StacksV1 in requested_types:
             stack_checkpoint = checkpoint_map.get(SyncEntityType.StackV1)
             async for stack_line in _stream_stacks(

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -13,7 +13,7 @@ from collections.abc import Iterator
 from typing import Any, AsyncGenerator
 from uuid import UUID
 
-from gumnut import AsyncGumnut, GumnutError
+from gumnut import AsyncGumnut
 from gumnut.types.album_response import AlbumResponse
 from gumnut.types.face_response import FaceResponse
 from gumnut.types.user_response import UserResponse
@@ -23,16 +23,11 @@ from routers.immich_models import (
     SyncRequestType,
     SyncStreamDto,
 )
-from routers.utils.datetime_utils import to_actual_utc
-from routers.utils.gumnut_id_conversion import (
-    safe_uuid_from_stack_id,
-    safe_uuid_from_user_id,
-)
+from routers.utils.gumnut_id_conversion import safe_uuid_from_user_id
 from services.checkpoint_store import Checkpoint
 
 from routers.api.constants import GUMNUT_API_MAX_PAGE_SIZE
 from routers.api.sync.converters import (
-    gumnut_stack_to_sync_stack_v1,
     gumnut_user_to_sync_auth_user_v1,
     gumnut_user_to_sync_user_metadata_v1,
     gumnut_user_to_sync_user_v1,
@@ -51,7 +46,6 @@ from routers.api.sync.fk_integrity import (
     null_deleted_fk_references,
     payload_override,
 )
-from routers.utils.stack_conversion import hydrate_stack
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +60,7 @@ _DELETE_EVENT_TYPES = frozenset(
         "person_deleted",
         "face_deleted",
         "album_asset_removed",
+        "stack_deleted",
     }
 )
 
@@ -78,6 +73,9 @@ _SKIPPED_EVENT_TYPES: frozenset[str] = frozenset()
 # Order matters - assets before metadata, albums before album_assets, etc.
 # This ordering ensures FK parents are streamed before children during upserts.
 _SYNC_TYPE_ORDER: list[tuple[SyncRequestType, str, SyncEntityType]] = [
+    # Stacks stream before assets: SyncAssetV1.stackId is an asset->stack FK, so
+    # the stack (parent) must land before the asset (child) that references it.
+    (SyncRequestType.StacksV1, "stack", SyncEntityType.StackV1),
     (SyncRequestType.AssetsV1, "asset", SyncEntityType.AssetV1),
     (SyncRequestType.AssetsV2, "asset", SyncEntityType.AssetV2),
     (SyncRequestType.AlbumsV1, "album", SyncEntityType.AlbumV1),
@@ -128,6 +126,9 @@ _DELETE_TYPE_ORDER: list[SyncEntityType] = [
     SyncEntityType.PersonDeleteV1,
     SyncEntityType.AlbumDeleteV1,
     SyncEntityType.AssetDeleteV1,
+    # After asset deletes: a stack is the FK parent of its member assets, so the
+    # children (assets) must be removed on the client before the parent (stack).
+    SyncEntityType.StackDeleteV1,
 ]
 
 # Request types that are accepted but have no Gumnut equivalent, so nothing is
@@ -150,7 +151,7 @@ _DELETE_TYPE_ORDER: list[SyncEntityType] = [
 #                          EXIF arrives via AssetExifsV1.
 #   - MemoriesV1 /
 #     MemoryToAssetsV1:    Gumnut has no memories feature; the tab renders empty.
-# StacksV1 is emitted by _stream_stacks; PartnerStacksV1 remains a no-op.
+# StacksV1 is event-driven via _SYNC_TYPE_ORDER; PartnerStacksV1 remains a no-op.
 # UserMetadataV1 is deliberately NOT here — it is emitted (a synthesized
 # preferences row); see gumnut_user_to_sync_user_metadata_v1.
 _NOOP_REQUEST_TYPES: dict[SyncRequestType, SyncEntityType] = {
@@ -167,14 +168,13 @@ _NOOP_REQUEST_TYPES: dict[SyncRequestType, SyncEntityType] = {
     SyncRequestType.MemoryToAssetsV1: SyncEntityType.MemoryToAssetV1,
 }
 
-# User and stack types below are handled outside _SYNC_TYPE_ORDER.
+# User types below are handled outside _SYNC_TYPE_ORDER.
 _SUPPORTED_REQUEST_TYPES: frozenset[SyncRequestType] = frozenset(
     {request_type for request_type, _, _ in _SYNC_TYPE_ORDER}
     | {
         SyncRequestType.AuthUsersV1,
         SyncRequestType.UsersV1,
         SyncRequestType.UserMetadataV1,
-        SyncRequestType.StacksV1,
     }
     | _NOOP_REQUEST_TYPES.keys()
 )
@@ -502,65 +502,6 @@ def _yield_buffered_deletes(
             yield json_line, delete_type
 
 
-async def _stream_stacks(
-    gumnut_client: AsyncGumnut,
-    owner_id: UUID,
-    checkpoint: Checkpoint | None,
-) -> AsyncGenerator[str, None]:
-    """Stream incremental StackV1 upserts in stable checkpoint order.
-
-    The pass re-pages the stack table because the Gumnut API has no stack
-    lifecycle events. Hydration reuses the REST effective-primary rules;
-    undecodable IDs and member-less stacks are skipped.
-    """
-    # Stable UTC ordering makes checkpoint comparison and resume deterministic.
-    stacks = [
-        stack
-        async for stack in gumnut_client.stacks.list_stacks(
-            limit=GUMNUT_API_MAX_PAGE_SIZE
-        )
-    ]
-    stacks.sort(key=lambda s: (to_actual_utc(s.updated_at), s.id))
-
-    checkpoint_cursor = checkpoint.cursor if checkpoint is not None else None
-    undecodable_ids: list[str] = []
-
-    for stack in stacks:
-        cursor = f"{to_actual_utc(stack.updated_at).isoformat()}_{stack.id}"
-        if checkpoint_cursor is not None and cursor <= checkpoint_cursor:
-            continue
-
-        # Keep the ValueError guard separate from hydration failures.
-        try:
-            safe_uuid_from_stack_id(stack.id)
-        except ValueError:
-            undecodable_ids.append(stack.id)
-            continue
-
-        hydrated = await hydrate_stack(gumnut_client, stack)
-        if hydrated is None:
-            continue
-        sync_stack = gumnut_stack_to_sync_stack_v1(
-            stack, hydrated.primary_asset_id, owner_id
-        )
-        yield make_sync_event(
-            SyncEntityType.StackV1,
-            sync_stack.model_dump(mode="json"),
-            cursor,
-        )
-
-    if undecodable_ids:
-        logger.warning(
-            "Skipped %d stack(s) with undecodable ids in the StackV1 snapshot; "
-            "syncing their assets as loose",
-            len(undecodable_ids),
-            extra={
-                "undecodable_stack_count": len(undecodable_ids),
-                "sample_stack_ids": undecodable_ids[:10],
-            },
-        )
-
-
 async def generate_sync_stream(
     gumnut_client: AsyncGumnut,
     request: SyncStreamDto,
@@ -680,26 +621,6 @@ async def generate_sync_stream(
         # Counters for logging
         event_counts: dict[str, int] = {}
         total_events = 0
-
-        # Emit stacks before assets; hydration errors must not suppress later types.
-        if SyncRequestType.StacksV1 in requested_types:
-            stack_checkpoint = checkpoint_map.get(SyncEntityType.StackV1)
-            try:
-                async for stack_line in _stream_stacks(
-                    gumnut_client, owner_uuid, stack_checkpoint
-                ):
-                    yield stack_line
-                    event_counts[SyncEntityType.StackV1.value] = (
-                        event_counts.get(SyncEntityType.StackV1.value, 0) + 1
-                    )
-                    total_events += 1
-            except GumnutError:
-                logger.warning(
-                    "StackV1 snapshot cut short by a Gumnut API error; already "
-                    "streamed rows are acked and the rest resume next sync",
-                    extra={"user_id": owner_id},
-                    exc_info=True,
-                )
 
         # Phase 1: Stream upserts for all entity types in FK dependency order,
         # buffering delete events for phase 2.

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -28,6 +28,7 @@ from services.checkpoint_store import Checkpoint
 
 from routers.api.constants import GUMNUT_API_MAX_PAGE_SIZE
 from routers.api.sync.converters import (
+    gumnut_stack_to_sync_stack_v1,
     gumnut_user_to_sync_auth_user_v1,
     gumnut_user_to_sync_user_metadata_v1,
     gumnut_user_to_sync_user_v1,
@@ -46,6 +47,7 @@ from routers.api.sync.fk_integrity import (
     null_deleted_fk_references,
     payload_override,
 )
+from routers.utils.stack_conversion import hydrate_stack
 
 logger = logging.getLogger(__name__)
 
@@ -144,11 +146,9 @@ _DELETE_TYPE_ORDER: list[SyncEntityType] = [
 #                          EXIF arrives via AssetExifsV1.
 #   - MemoriesV1 /
 #     MemoryToAssetsV1:    Gumnut has no memories feature; the tab renders empty.
-#   - StacksV1:            stacks exist and are readable over REST (`/api/stacks`),
-#                          but nothing feeds them into the sync stream, and the
-#                          sync asset converters still emit stackId=None — so a
-#                          stack row here would name a grouping no synced asset
-#                          claims membership in.
+# StacksV1 is deliberately NOT here — it is emitted as a current-state snapshot
+# (see _stream_stacks), alongside the special user types below rather than via
+# the events API. PartnerStacksV1 stays a no-op: partner sharing is unsupported.
 # UserMetadataV1 is deliberately NOT here — it is emitted (a synthesized
 # preferences row); see gumnut_user_to_sync_user_metadata_v1.
 _NOOP_REQUEST_TYPES: dict[SyncRequestType, SyncEntityType] = {
@@ -163,19 +163,20 @@ _NOOP_REQUEST_TYPES: dict[SyncRequestType, SyncEntityType] = {
     SyncRequestType.AlbumAssetExifsV1: SyncEntityType.AlbumAssetExifCreateV1,
     SyncRequestType.MemoriesV1: SyncEntityType.MemoryV1,
     SyncRequestType.MemoryToAssetsV1: SyncEntityType.MemoryToAssetV1,
-    SyncRequestType.StacksV1: SyncEntityType.StackV1,
 }
 
 # Supported SyncRequestTypes (used to detect unsupported types requested by
-# client). AuthUsersV1/UsersV1/UserMetadataV1 are handled specially (not via
-# _SYNC_TYPE_ORDER): the first two stream the user record, and UserMetadataV1
-# streams a synthesized preferences row (see gumnut_user_to_sync_user_metadata_v1).
+# client). AuthUsersV1/UsersV1/UserMetadataV1/StacksV1 are handled specially (not
+# via _SYNC_TYPE_ORDER): the first two stream the user record, UserMetadataV1
+# streams a synthesized preferences row (see gumnut_user_to_sync_user_metadata_v1),
+# and StacksV1 streams a current-state snapshot (see _stream_stacks).
 _SUPPORTED_REQUEST_TYPES: frozenset[SyncRequestType] = frozenset(
     {request_type for request_type, _, _ in _SYNC_TYPE_ORDER}
     | {
         SyncRequestType.AuthUsersV1,
         SyncRequestType.UsersV1,
         SyncRequestType.UserMetadataV1,
+        SyncRequestType.StacksV1,
     }
     | _NOOP_REQUEST_TYPES.keys()
 )
@@ -503,6 +504,58 @@ def _yield_buffered_deletes(
             yield json_line, delete_type
 
 
+async def _stream_stacks(
+    gumnut_client: AsyncGumnut,
+    owner_id: UUID,
+    checkpoint: Checkpoint | None,
+) -> AsyncGenerator[str, None]:
+    """Stream StackV1 rows as a current-state snapshot.
+
+    Stacks are not sourced from the events API — the Gumnut backend emits no
+    stack lifecycle events yet — so this is a point-in-time snapshot, not a
+    delta. Incremental create/update/delete support is intentionally out of
+    scope (tracked on a separate event-support track):
+
+    - **Checkpoint present** → emit nothing. An already-synced client keeps the
+      stacks it has until that track lands; re-emitting the whole table every
+      delta cannot express deletes and only wastes bandwidth.
+    - **Checkpoint absent** (reset / first sync) → page every stack, resolve its
+      effective cover, and emit a StackV1 row.
+
+    The caller emits this before the phase-1 asset loop, so a stack row exists on
+    the client before any asset naming it via ``stackId`` arrives.
+
+    A member-less stack has no honest ``primaryAssetId`` (``SyncStackV1`` requires
+    a non-null one), so ``hydrate_stack`` returns ``None`` — logging a warning —
+    and it is skipped here.
+
+    The per-row ack cursor is ``stack.updated_at`` + id: pipe-free and stable, so
+    a reset replays deterministically and the last row's ack becomes the StackV1
+    checkpoint that suppresses future snapshots.
+    """
+    if checkpoint is not None:
+        # An existing checkpoint means the client already holds the snapshot;
+        # emit no speculative updates. See the docstring's scope boundary.
+        return
+
+    async for stack in gumnut_client.stacks.list_stacks(limit=GUMNUT_API_MAX_PAGE_SIZE):
+        hydrated = await hydrate_stack(gumnut_client, stack)
+        if hydrated is None:
+            # Member-less stack — hydrate_stack already logged a warning. Skipped
+            # rather than emitting an invalid required primary.
+            continue
+
+        sync_stack = gumnut_stack_to_sync_stack_v1(
+            stack, hydrated.primary_asset_id, owner_id
+        )
+        cursor = f"{stack.updated_at.isoformat()}_{stack.id}"
+        yield make_sync_event(
+            SyncEntityType.StackV1,
+            sync_stack.model_dump(mode="json"),
+            cursor,
+        )
+
+
 async def generate_sync_stream(
     gumnut_client: AsyncGumnut,
     request: SyncStreamDto,
@@ -622,6 +675,22 @@ async def generate_sync_stream(
         # Counters for logging
         event_counts: dict[str, int] = {}
         total_events = 0
+
+        # Stream the stack snapshot before the asset loop (StacksV1). Stacks are
+        # a current-state snapshot rather than events, emitted first so every
+        # asset's stackId names a stack row the client already holds. Only a
+        # reset / first sync produces rows — see _stream_stacks for the
+        # checkpoint semantics and the incremental-support scope boundary.
+        if SyncRequestType.StacksV1 in requested_types:
+            stack_checkpoint = checkpoint_map.get(SyncEntityType.StackV1)
+            async for stack_line in _stream_stacks(
+                gumnut_client, owner_uuid, stack_checkpoint
+            ):
+                yield stack_line
+                event_counts[SyncEntityType.StackV1.value] = (
+                    event_counts.get(SyncEntityType.StackV1.value, 0) + 1
+                )
+                total_events += 1
 
         # Phase 1: Stream upserts for all entity types in FK dependency order,
         # buffering delete events for phase 2.

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -73,8 +73,10 @@ _SKIPPED_EVENT_TYPES: frozenset[str] = frozenset()
 # Order matters - assets before metadata, albums before album_assets, etc.
 # This ordering ensures FK parents are streamed before children during upserts.
 _SYNC_TYPE_ORDER: list[tuple[SyncRequestType, str, SyncEntityType]] = [
-    # Stacks stream before assets: SyncAssetV1.stackId is an asset->stack FK, so
-    # the stack (parent) must land before the asset (child) that references it.
+    # Stacks stream before assets: the mobile timeline hides an asset whose
+    # stackId names a stack row the client doesn't have, so the stack must land
+    # before the member asset pointing at it. (The client enforces no FK
+    # constraint either way — this is about visibility, not insert order.)
     (SyncRequestType.StacksV1, "stack", SyncEntityType.StackV1),
     (SyncRequestType.AssetsV1, "asset", SyncEntityType.AssetV1),
     (SyncRequestType.AssetsV2, "asset", SyncEntityType.AssetV2),

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -13,7 +13,7 @@ from collections.abc import Iterator
 from typing import Any, AsyncGenerator
 from uuid import UUID
 
-from gumnut import AsyncGumnut
+from gumnut import AsyncGumnut, GumnutError
 from gumnut.types.album_response import AlbumResponse
 from gumnut.types.face_response import FaceResponse
 from gumnut.types.user_response import UserResponse
@@ -23,7 +23,11 @@ from routers.immich_models import (
     SyncRequestType,
     SyncStreamDto,
 )
-from routers.utils.gumnut_id_conversion import safe_uuid_from_user_id
+from routers.utils.datetime_utils import to_actual_utc
+from routers.utils.gumnut_id_conversion import (
+    safe_uuid_from_stack_id,
+    safe_uuid_from_user_id,
+)
 from services.checkpoint_store import Checkpoint
 
 from routers.api.constants import GUMNUT_API_MAX_PAGE_SIZE
@@ -509,67 +513,84 @@ async def _stream_stacks(
     owner_id: UUID,
     checkpoint: Checkpoint | None,
 ) -> AsyncGenerator[str, None]:
-    """Stream StackV1 rows as a current-state snapshot.
+    """Stream StackV1 rows for the StacksV1 sync type.
 
-    Stacks are not sourced from the events API — the Gumnut backend emits no
-    stack lifecycle events yet — so this is a point-in-time snapshot, not a
-    delta. Incremental create/update/delete support is intentionally out of
-    scope (tracked on a separate event-support track):
+    Every sync re-pages the whole stack table (the Gumnut backend emits no stack
+    lifecycle events yet) and emits rows in ``(updated_at, id)`` order, filtered
+    strictly after the checkpoint cursor — which gives incremental upsert and
+    mid-stream resume, with delete detection out of scope. The "Stack Snapshot
+    (StacksV1)" section of ``docs/architecture/sync-stream-architecture.md`` owns
+    why each of those matters and what stays out of scope.
 
-    - **Checkpoint present** → emit nothing. An already-synced client keeps the
-      stacks it has until that track lands; re-emitting the whole table every
-      delta cannot express deletes and only wastes bandwidth.
-    - **Checkpoint absent** (reset / first sync) → page every stack, resolve its
-      effective cover, and emit a StackV1 row.
+    Two code-local details:
 
-    The caller emits this before the phase-1 asset loop, so a stack row exists on
-    the client before any asset naming it via ``stackId`` arrives.
+    - Each surviving stack is hydrated through the shared ``hydrate_stack`` — the
+      same helper REST ``/stacks`` uses, so the effective primary matches exactly
+      — which fetches every member even though only the resolved primary id is
+      used here. Reusing the single source of truth is worth the unused member
+      payload; a lean member read is a later optimization if reset latency ever
+      matters.
+    - Only an undecodable ``stack.id`` (a systemic ``asset_stack_`` prefix change)
+      is degraded to a skip, and it is decoded *up front* so the guard cannot also
+      swallow a ``ValidationError`` or ``GumnutError`` raised during member
+      hydration — those are real failures that must surface, not be mislabeled.
 
     A member-less stack has no honest ``primaryAssetId`` (``SyncStackV1`` requires
     a non-null one), so ``hydrate_stack`` returns ``None`` — logging a warning —
     and it is skipped here.
-
-    The per-row ack cursor is ``stack.updated_at`` + id: pipe-free and stable, so
-    a reset replays deterministically and the last row's ack becomes the StackV1
-    checkpoint that suppresses future snapshots.
-
-    Two accepted trade-offs, both cheap because this pass is reset-only:
-
-    - Each stack is hydrated through the shared ``hydrate_stack`` — the same
-      helper REST ``/stacks`` uses, so the effective primary matches exactly
-      (including the trashed-pin rule) — which fetches every member with
-      ``ASSET_INCLUDE`` even though only the resolved primary id is used here.
-      Reusing the single source of truth is worth the unused member payload on a
-      reset; a lean member read is a later optimization if a large, burst-heavy
-      library ever makes reset latency matter.
-    - A client with no stacks (or only member-less ones) emits no StackV1 row, so
-      never acks one, so never stores a checkpoint — it re-pages ``list_stacks``
-      (one empty page) on every sync until it has a real stack to checkpoint.
-      A consequence: the first stack a stackless client gains after its initial
-      sync does propagate on the next delta (there is no checkpoint yet to
-      suppress it) — strictly more than the "snapshot only on reset" guarantee,
-      never less, so it is harmless.
     """
-    if checkpoint is not None:
-        # An existing checkpoint means the client already holds the snapshot;
-        # emit no speculative updates. See the docstring's scope boundary.
-        return
+    # Collect so the rows can be emitted in a stable (updated_at, id) order — a
+    # plain async-for can't reorder. Normalize to UTC so a naive/aware mix can't
+    # crash the sort or invert the cursor comparison below (same normalization
+    # stack_conversion applies to its member sort).
+    stacks = [
+        stack
+        async for stack in gumnut_client.stacks.list_stacks(
+            limit=GUMNUT_API_MAX_PAGE_SIZE
+        )
+    ]
+    stacks.sort(key=lambda s: (to_actual_utc(s.updated_at), s.id))
 
-    async for stack in gumnut_client.stacks.list_stacks(limit=GUMNUT_API_MAX_PAGE_SIZE):
-        hydrated = await hydrate_stack(gumnut_client, stack)
-        if hydrated is None:
-            # Member-less stack — hydrate_stack already logged a warning. Skipped
-            # rather than emitting an invalid required primary.
+    checkpoint_cursor = checkpoint.cursor if checkpoint is not None else None
+    undecodable_ids: list[str] = []
+
+    for stack in stacks:
+        cursor = f"{to_actual_utc(stack.updated_at).isoformat()}_{stack.id}"
+        if checkpoint_cursor is not None and cursor <= checkpoint_cursor:
             continue
 
+        # Decode the id first: it is the only ValueError this pass degrades on.
+        # Keeping it out of the hydrate call below means a member ValidationError
+        # (pydantic subclasses ValueError) or GumnutError truncates loudly instead
+        # of being mislabeled as an undecodable stack id and silently dropped.
+        try:
+            safe_uuid_from_stack_id(stack.id)
+        except ValueError:
+            undecodable_ids.append(stack.id)
+            continue
+
+        hydrated = await hydrate_stack(gumnut_client, stack)
+        if hydrated is None:
+            # Member-less stack — hydrate_stack already logged a warning.
+            continue
         sync_stack = gumnut_stack_to_sync_stack_v1(
             stack, hydrated.primary_asset_id, owner_id
         )
-        cursor = f"{stack.updated_at.isoformat()}_{stack.id}"
         yield make_sync_event(
             SyncEntityType.StackV1,
             sync_stack.model_dump(mode="json"),
             cursor,
+        )
+
+    if undecodable_ids:
+        logger.warning(
+            "Skipped %d stack(s) with undecodable ids in the StackV1 snapshot; "
+            "syncing their assets as loose",
+            len(undecodable_ids),
+            extra={
+                "undecodable_stack_count": len(undecodable_ids),
+                "sample_stack_ids": undecodable_ids[:10],
+            },
         )
 
 
@@ -695,16 +716,29 @@ async def generate_sync_stream(
 
         # Stream the StackV1 snapshot before the asset loop (so each asset's
         # stackId names a stack the client already holds). See _stream_stacks.
+        # A GumnutError while hydrating one stack ends the pass gracefully rather
+        # than truncating the whole sync: because this runs first, an unhandled
+        # error would suppress assets/albums/faces too. Rows already yielded are
+        # acked, so the remaining stacks resume from the checkpoint next sync,
+        # and the asset loop below still runs this cycle.
         if SyncRequestType.StacksV1 in requested_types:
             stack_checkpoint = checkpoint_map.get(SyncEntityType.StackV1)
-            async for stack_line in _stream_stacks(
-                gumnut_client, owner_uuid, stack_checkpoint
-            ):
-                yield stack_line
-                event_counts[SyncEntityType.StackV1.value] = (
-                    event_counts.get(SyncEntityType.StackV1.value, 0) + 1
+            try:
+                async for stack_line in _stream_stacks(
+                    gumnut_client, owner_uuid, stack_checkpoint
+                ):
+                    yield stack_line
+                    event_counts[SyncEntityType.StackV1.value] = (
+                        event_counts.get(SyncEntityType.StackV1.value, 0) + 1
+                    )
+                    total_events += 1
+            except GumnutError:
+                logger.warning(
+                    "StackV1 snapshot cut short by a Gumnut API error; already "
+                    "streamed rows are acked and the rest resume next sync",
+                    extra={"user_id": owner_id},
+                    exc_info=True,
                 )
-                total_events += 1
 
         # Phase 1: Stream upserts for all entity types in FK dependency order,
         # buffering delete events for phase 2.

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -15,6 +15,7 @@ from uuid import UUID
 
 from gumnut import AsyncGumnut
 from gumnut.types.album_response import AlbumResponse
+from gumnut.types.asset_response import AssetResponse
 from gumnut.types.face_response import FaceResponse
 from gumnut.types.user_response import UserResponse
 
@@ -128,8 +129,7 @@ _DELETE_TYPE_ORDER: list[SyncEntityType] = [
     SyncEntityType.PersonDeleteV1,
     SyncEntityType.AlbumDeleteV1,
     SyncEntityType.AssetDeleteV1,
-    # After asset deletes: a stack is the FK parent of its member assets, so the
-    # children (assets) must be removed on the client before the parent (stack).
+    # Delete member assets before their stack; dissolve updates ran in phase 1.
     SyncEntityType.StackDeleteV1,
 ]
 
@@ -396,6 +396,18 @@ async def _stream_entity_type(
                     )
                     if should_apply and entity.person_id != person_id:
                         entity = entity.model_copy(update={"person_id": person_id})
+
+                # Preserve event-time stack membership when hydration observes
+                # a later move whose stack event is outside this sync window.
+                if (
+                    sync_entity_type in (SyncEntityType.AssetV1, SyncEntityType.AssetV2)
+                    and event.event_type == "asset_updated"
+                    and isinstance(entity, AssetResponse)
+                    and isinstance(event.payload, dict)
+                ):
+                    should_apply, stack_id = payload_override(event.payload, "stack_id")
+                    if should_apply and entity.stack_id != stack_id:
+                        entity = entity.model_copy(update={"stack_id": stack_id})
 
                 # album_updated events carry the causally-consistent
                 # album_cover_asset_id in the event payload. Use it

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -150,9 +150,7 @@ _DELETE_TYPE_ORDER: list[SyncEntityType] = [
 #                          EXIF arrives via AssetExifsV1.
 #   - MemoriesV1 /
 #     MemoryToAssetsV1:    Gumnut has no memories feature; the tab renders empty.
-# StacksV1 is deliberately NOT here — it is emitted as a current-state snapshot
-# (see _stream_stacks), alongside the special user types below rather than via
-# the events API. PartnerStacksV1 stays a no-op: partner sharing is unsupported.
+# StacksV1 is emitted by _stream_stacks; PartnerStacksV1 remains a no-op.
 # UserMetadataV1 is deliberately NOT here — it is emitted (a synthesized
 # preferences row); see gumnut_user_to_sync_user_metadata_v1.
 _NOOP_REQUEST_TYPES: dict[SyncRequestType, SyncEntityType] = {
@@ -169,11 +167,7 @@ _NOOP_REQUEST_TYPES: dict[SyncRequestType, SyncEntityType] = {
     SyncRequestType.MemoryToAssetsV1: SyncEntityType.MemoryToAssetV1,
 }
 
-# Supported SyncRequestTypes (used to detect unsupported types requested by
-# client). AuthUsersV1/UsersV1/UserMetadataV1/StacksV1 are handled specially (not
-# via _SYNC_TYPE_ORDER): the first two stream the user record, UserMetadataV1
-# streams a synthesized preferences row (see gumnut_user_to_sync_user_metadata_v1),
-# and StacksV1 streams a current-state snapshot (see _stream_stacks).
+# User and stack types below are handled outside _SYNC_TYPE_ORDER.
 _SUPPORTED_REQUEST_TYPES: frozenset[SyncRequestType] = frozenset(
     {request_type for request_type, _, _ in _SYNC_TYPE_ORDER}
     | {
@@ -513,36 +507,13 @@ async def _stream_stacks(
     owner_id: UUID,
     checkpoint: Checkpoint | None,
 ) -> AsyncGenerator[str, None]:
-    """Stream StackV1 rows for the StacksV1 sync type.
+    """Stream incremental StackV1 upserts in stable checkpoint order.
 
-    Every sync re-pages the whole stack table (the Gumnut backend emits no stack
-    lifecycle events yet) and emits rows in ``(updated_at, id)`` order, filtered
-    strictly after the checkpoint cursor — which gives incremental upsert and
-    mid-stream resume, with delete detection out of scope. The "Stack Snapshot
-    (StacksV1)" section of ``docs/architecture/sync-stream-architecture.md`` owns
-    why each of those matters and what stays out of scope.
-
-    Two code-local details:
-
-    - Each surviving stack is hydrated through the shared ``hydrate_stack`` — the
-      same helper REST ``/stacks`` uses, so the effective primary matches exactly
-      — which fetches every member even though only the resolved primary id is
-      used here. Reusing the single source of truth is worth the unused member
-      payload; a lean member read is a later optimization if reset latency ever
-      matters.
-    - Only an undecodable ``stack.id`` (a systemic ``asset_stack_`` prefix change)
-      is degraded to a skip, and it is decoded *up front* so the guard cannot also
-      swallow a ``ValidationError`` or ``GumnutError`` raised during member
-      hydration — those are real failures that must surface, not be mislabeled.
-
-    A member-less stack has no honest ``primaryAssetId`` (``SyncStackV1`` requires
-    a non-null one), so ``hydrate_stack`` returns ``None`` — logging a warning —
-    and it is skipped here.
+    The pass re-pages the stack table because the Gumnut API has no stack
+    lifecycle events. Hydration reuses the REST effective-primary rules;
+    undecodable IDs and member-less stacks are skipped.
     """
-    # Collect so the rows can be emitted in a stable (updated_at, id) order — a
-    # plain async-for can't reorder. Normalize to UTC so a naive/aware mix can't
-    # crash the sort or invert the cursor comparison below (same normalization
-    # stack_conversion applies to its member sort).
+    # Stable UTC ordering makes checkpoint comparison and resume deterministic.
     stacks = [
         stack
         async for stack in gumnut_client.stacks.list_stacks(
@@ -559,10 +530,7 @@ async def _stream_stacks(
         if checkpoint_cursor is not None and cursor <= checkpoint_cursor:
             continue
 
-        # Decode the id first: it is the only ValueError this pass degrades on.
-        # Keeping it out of the hydrate call below means a member ValidationError
-        # (pydantic subclasses ValueError) or GumnutError truncates loudly instead
-        # of being mislabeled as an undecodable stack id and silently dropped.
+        # Keep the ValueError guard separate from hydration failures.
         try:
             safe_uuid_from_stack_id(stack.id)
         except ValueError:
@@ -571,7 +539,6 @@ async def _stream_stacks(
 
         hydrated = await hydrate_stack(gumnut_client, stack)
         if hydrated is None:
-            # Member-less stack — hydrate_stack already logged a warning.
             continue
         sync_stack = gumnut_stack_to_sync_stack_v1(
             stack, hydrated.primary_asset_id, owner_id
@@ -714,13 +681,7 @@ async def generate_sync_stream(
         event_counts: dict[str, int] = {}
         total_events = 0
 
-        # Stream the StackV1 snapshot before the asset loop (so each asset's
-        # stackId names a stack the client already holds). See _stream_stacks.
-        # A GumnutError while hydrating one stack ends the pass gracefully rather
-        # than truncating the whole sync: because this runs first, an unhandled
-        # error would suppress assets/albums/faces too. Rows already yielded are
-        # acked, so the remaining stacks resume from the checkpoint next sync,
-        # and the asset loop below still runs this cycle.
+        # Emit stacks before assets; hydration errors must not suppress later types.
         if SyncRequestType.StacksV1 in requested_types:
             stack_checkpoint = checkpoint_map.get(SyncEntityType.StackV1)
             try:

--- a/routers/api/sync/types.py
+++ b/routers/api/sync/types.py
@@ -14,23 +14,14 @@ from gumnut.types.stack_list_stacks_response import StackListStacksResponse
 
 @dataclass(frozen=True)
 class FetchedStack:
-    """A stack row paired with its resolved effective primary.
-
-    Stacks are the one fetched entity whose sync conversion needs a value that
-    isn't on the row: SyncStackV1 requires a non-null primaryAssetId, and an
-    unpinned burst's cover is only knowable by reading its members. Resolving it
-    is an async round-trip, but convert_entity_to_sync_event is deliberately
-    I/O-free — so fetch_entities_map hydrates the members and carries the
-    resolved primary here, keeping the converter pure.
-    """
+    """A stack row paired with the member-derived primary required by sync."""
 
     row: StackListStacksResponse
     primary_asset_id: UUID
 
     @property
     def id(self) -> str:
-        """The Gumnut stack id, so the generic stream loop can track it like any
-        other fetched entity (see stats.streamed_ids)."""
+        """Return the Gumnut stack ID used by the generic stream loop."""
         return self.row.id
 
 

--- a/routers/api/sync/types.py
+++ b/routers/api/sync/types.py
@@ -1,13 +1,44 @@
 """Shared type aliases for the sync package."""
 
+from dataclasses import dataclass
 from typing import TypeAlias
+from uuid import UUID
 
 from gumnut.types.album_asset_response import AlbumAssetResponse
 from gumnut.types.album_response import AlbumResponse
 from gumnut.types.asset_response import AssetResponse
 from gumnut.types.face_response import FaceResponse
 from gumnut.types.person_response import PersonResponse
+from gumnut.types.stack_list_stacks_response import StackListStacksResponse
+
+
+@dataclass(frozen=True)
+class FetchedStack:
+    """A stack row paired with its resolved effective primary.
+
+    Stacks are the one fetched entity whose sync conversion needs a value that
+    isn't on the row: SyncStackV1 requires a non-null primaryAssetId, and an
+    unpinned burst's cover is only knowable by reading its members. Resolving it
+    is an async round-trip, but convert_entity_to_sync_event is deliberately
+    I/O-free — so fetch_entities_map hydrates the members and carries the
+    resolved primary here, keeping the converter pure.
+    """
+
+    row: StackListStacksResponse
+    primary_asset_id: UUID
+
+    @property
+    def id(self) -> str:
+        """The Gumnut stack id, so the generic stream loop can track it like any
+        other fetched entity (see stats.streamed_ids)."""
+        return self.row.id
+
 
 EntityType: TypeAlias = (
-    AssetResponse | AlbumResponse | AlbumAssetResponse | PersonResponse | FaceResponse
+    AssetResponse
+    | AlbumResponse
+    | AlbumAssetResponse
+    | PersonResponse
+    | FaceResponse
+    | FetchedStack
 )

--- a/routers/utils/concurrency.py
+++ b/routers/utils/concurrency.py
@@ -24,6 +24,7 @@ async def gather_with_concurrency[T](
     coros: Sequence[Coroutine[Any, Any, T]],
     *,
     limit: int = BULK_FANOUT_CONCURRENCY_LIMIT,
+    cancel_on_error: bool = False,
 ) -> list[T]:
     """Run coroutines in parallel under a bounded semaphore.
 
@@ -31,14 +32,10 @@ async def gather_with_concurrency[T](
     callers that walk the results in input order (e.g. sticky-first-error
     semantics, or zipping back to the input id list).
 
-    If any coroutine raises, the exception propagates and the partial results
-    are discarded. The siblings are **not** cancelled — ``asyncio.gather``
-    without ``return_exceptions`` lets already-scheduled awaitables run to
-    completion, and this helper's ``finally`` release lets queued ones acquire
-    the semaphore and start — so an aborted batch still costs its full fan-out
-    upstream. Callers that need per-item errors must catch inside the coroutine
-    and return a result object; callers that need the work to actually *stop*
-    need a different primitive (e.g. a TaskGroup), not this one.
+    If any coroutine raises, the exception propagates and partial results are
+    discarded. By default siblings continue; set ``cancel_on_error`` when their
+    results become useless after the first failure. Callers that need per-item
+    errors must catch inside the coroutine and return a result object.
 
     Only the first exception **to occur** is ever visible — completion order,
     not input order, so which of several failures a caller sees is not
@@ -50,6 +47,7 @@ async def gather_with_concurrency[T](
     the coroutine.
     """
     semaphore = asyncio.Semaphore(limit)
+    failed = asyncio.Event()
 
     async def _run(coro: Coroutine[Any, Any, T]) -> T:
         # Inputs are already-constructed coroutines, so any coro whose `_run`
@@ -61,9 +59,25 @@ async def gather_with_concurrency[T](
         except BaseException:
             coro.close()
             raise
+        if cancel_on_error and failed.is_set():
+            coro.close()
+            semaphore.release()
+            raise asyncio.CancelledError
         try:
             return await coro
+        except BaseException:
+            if cancel_on_error:
+                failed.set()
+            raise
         finally:
             semaphore.release()
 
-    return await asyncio.gather(*(_run(coro) for coro in coros))
+    tasks = [asyncio.create_task(_run(coro)) for coro in coros]
+    try:
+        return await asyncio.gather(*tasks)
+    except BaseException:
+        if cancel_on_error:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+        raise

--- a/tests/unit/api/sync/conftest.py
+++ b/tests/unit/api/sync/conftest.py
@@ -72,10 +72,6 @@ def create_mock_gumnut_client(user: Mock) -> Mock:
     client.album_assets.list.return_value = empty_page
     client.people.list.return_value = empty_page
     client.faces.list.return_value = empty_page
-    # Default: no stacks. The StacksV1 snapshot pages this on reset/first sync;
-    # a bare Mock would not be async-iterable and break any test that requests
-    # StacksV1 without setting up its own stacks. Tests that model stacks
-    # override this.
     client.stacks.list_stacks.return_value = empty_page
     return client
 
@@ -173,10 +169,7 @@ def create_mock_asset_data(updated_at: datetime) -> Mock:
     asset.file_data.file_size_bytes = 1059218
     asset.metadata = None
     asset.trashed_at = None
-    # Loose (unstacked) by default. Set explicitly because the sync asset
-    # converter now reads stack_id — a bare Mock attribute would be truthy and
-    # feed a Mock into safe_uuid_from_stack_id. Tests that model a stacked asset
-    # override this with an asset_stack_-prefixed Gumnut ID.
+    # Avoid a truthy auto-created Mock for unstacked assets.
     asset.stack_id = None
     return asset
 

--- a/tests/unit/api/sync/conftest.py
+++ b/tests/unit/api/sync/conftest.py
@@ -72,6 +72,11 @@ def create_mock_gumnut_client(user: Mock) -> Mock:
     client.album_assets.list.return_value = empty_page
     client.people.list.return_value = empty_page
     client.faces.list.return_value = empty_page
+    # Default: no stacks. The StacksV1 snapshot pages this on reset/first sync;
+    # a bare Mock would not be async-iterable and break any test that requests
+    # StacksV1 without setting up its own stacks. Tests that model stacks
+    # override this.
+    client.stacks.list_stacks.return_value = empty_page
     return client
 
 
@@ -168,6 +173,11 @@ def create_mock_asset_data(updated_at: datetime) -> Mock:
     asset.file_data.file_size_bytes = 1059218
     asset.metadata = None
     asset.trashed_at = None
+    # Loose (unstacked) by default. Set explicitly because the sync asset
+    # converter now reads stack_id — a bare Mock attribute would be truthy and
+    # feed a Mock into safe_uuid_from_stack_id. Tests that model a stacked asset
+    # override this with an asset_stack_-prefixed Gumnut ID.
+    asset.stack_id = None
     return asset
 
 

--- a/tests/unit/api/sync/test_datetime_conversion.py
+++ b/tests/unit/api/sync/test_datetime_conversion.py
@@ -297,8 +297,7 @@ class TestGumnutAssetToSyncAssetV1DateHandling:
         # an explicit None the unset Mock attribute would silently produce a
         # truthy Mock and walk the wrong branch.
         asset.metadata = None
-        # Loose by default — the sync asset converter reads stack_id, and an
-        # unset Mock attribute is truthy (see conftest's create_mock_asset_data).
+        # Avoid a truthy auto-created Mock for an unstacked asset.
         asset.stack_id = None
         return asset
 

--- a/tests/unit/api/sync/test_datetime_conversion.py
+++ b/tests/unit/api/sync/test_datetime_conversion.py
@@ -297,6 +297,9 @@ class TestGumnutAssetToSyncAssetV1DateHandling:
         # an explicit None the unset Mock attribute would silently produce a
         # truthy Mock and walk the wrong branch.
         asset.metadata = None
+        # Loose by default — the sync asset converter reads stack_id, and an
+        # unset Mock attribute is truthy (see conftest's create_mock_asset_data).
+        asset.stack_id = None
         return asset
 
     def test_file_created_at_uses_local_datetime_not_file_created_at(self):

--- a/tests/unit/api/sync/test_sync_stream.py
+++ b/tests/unit/api/sync/test_sync_stream.py
@@ -674,9 +674,6 @@ class TestGenerateSyncStream:
         request = SyncStreamDto(
             types=[
                 SyncRequestType.MemoriesV1,
-                # StacksV1 is no longer a no-op — it streams a current-state
-                # snapshot (covered in test_sync_stream_stacks.py). PartnerStacksV1
-                # stays a no-op and stands in for the stack family here.
                 SyncRequestType.PartnerStacksV1,
                 SyncRequestType.PartnersV1,
                 SyncRequestType.AssetMetadataV1,

--- a/tests/unit/api/sync/test_sync_stream.py
+++ b/tests/unit/api/sync/test_sync_stream.py
@@ -674,7 +674,10 @@ class TestGenerateSyncStream:
         request = SyncStreamDto(
             types=[
                 SyncRequestType.MemoriesV1,
-                SyncRequestType.StacksV1,
+                # StacksV1 is no longer a no-op — it streams a current-state
+                # snapshot (covered in test_sync_stream_stacks.py). PartnerStacksV1
+                # stays a no-op and stands in for the stack family here.
+                SyncRequestType.PartnerStacksV1,
                 SyncRequestType.PartnersV1,
                 SyncRequestType.AssetMetadataV1,
             ]

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -209,10 +209,11 @@ class TestStackEntityFetch:
         assert fetched_b.primary_asset_id == safe_uuid_from_asset_id(members_b[2].id)
 
     @pytest.mark.anyio
-    async def test_one_stack_member_read_failure_skips_only_that_stack(self, caplog):
-        # StackV1 is the first sync pass, so one stack's member-read failure must
-        # not abort the batch (or truncate the whole sync). The bad stack skips
-        # to missing_ids; its sibling still resolves.
+    async def test_transient_member_read_failure_propagates_not_skipped(self):
+        # A transient member-read failure must NOT degrade to a skip: skipping
+        # would advance the events cursor past the stack while its members still
+        # carry stackId, permanently hiding the burst. It propagates so the sync
+        # truncates and the stack retries next cycle.
         good, good_members = make_gumnut_stack_with_members(count=2)
         good.primary_asset_id = good_members[0].id
         bad, _bad_members = make_gumnut_stack_with_members(count=2)
@@ -228,19 +229,8 @@ class TestStackEntityFetch:
 
         client.assets.list = Mock(side_effect=_list)
 
-        with caplog.at_level("WARNING"):
-            result, missing = await fetch_entities_map(
-                client, "stack", [good.id, bad.id]
-            )
-
-        assert isinstance(result.get(good.id), FetchedStack)
-        assert bad.id in missing
-        assert bad.id not in result
-        assert any(
-            "member read failed" in record.message.lower()
-            or "stack member read failed" in record.message.lower()
-            for record in caplog.records
-        )
+        with pytest.raises(GumnutError):
+            await fetch_entities_map(client, "stack", [good.id, bad.id])
 
     @pytest.mark.anyio
     async def test_undecodable_stack_id_skips_only_that_stack(self, caplog):

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from gumnut import GumnutError
 
 from routers.api.sync.converters import (
     gumnut_asset_to_sync_asset_v1,
@@ -178,6 +179,68 @@ class TestStackEntityFetch:
         assert stack.id not in result
         assert stack.id in missing
         assert any("no members" in record.message for record in caplog.records)
+
+    @pytest.mark.anyio
+    async def test_two_stacks_in_one_fetch_each_keep_their_own_primary(self):
+        # A page can carry several stacks, and mock_list_stacks returns rows
+        # reversed vs. the requested order — so a consumer that zipped response
+        # order to request order (instead of keying by row.id) would cross the
+        # covers. Each stack must resolve to its own.
+        stack_a, members_a = make_gumnut_stack_with_members(count=2)
+        stack_a.primary_asset_id = members_a[0].id
+        stack_b, members_b = make_gumnut_stack_with_members(count=3)
+        stack_b.primary_asset_id = members_b[2].id
+        client = Mock()
+        client.stacks.list_stacks = mock_list_stacks([stack_a, stack_b])
+        client.assets.list = _assets_list(
+            members_by_stack={stack_a.id: members_a, stack_b.id: members_b}
+        )
+
+        result, missing = await fetch_entities_map(
+            client, "stack", [stack_a.id, stack_b.id]
+        )
+
+        assert missing == set()
+        fetched_a = result[stack_a.id]
+        fetched_b = result[stack_b.id]
+        assert isinstance(fetched_a, FetchedStack)
+        assert isinstance(fetched_b, FetchedStack)
+        assert fetched_a.primary_asset_id == safe_uuid_from_asset_id(members_a[0].id)
+        assert fetched_b.primary_asset_id == safe_uuid_from_asset_id(members_b[2].id)
+
+    @pytest.mark.anyio
+    async def test_one_stack_member_read_failure_skips_only_that_stack(self, caplog):
+        # StackV1 is the first sync pass, so one stack's member-read failure must
+        # not abort the batch (or truncate the whole sync). The bad stack skips
+        # to missing_ids; its sibling still resolves.
+        good, good_members = make_gumnut_stack_with_members(count=2)
+        good.primary_asset_id = good_members[0].id
+        bad, _bad_members = make_gumnut_stack_with_members(count=2)
+        client = Mock()
+        client.stacks.list_stacks = mock_list_stacks([good, bad])
+
+        def _list(**kwargs):
+            if kwargs.get("stack_id") == bad.id:
+                raise GumnutError("member read failed")
+            return MockSyncCursorPage(
+                {good.id: good_members}.get(kwargs.get("stack_id"), [])
+            )
+
+        client.assets.list = Mock(side_effect=_list)
+
+        with caplog.at_level("WARNING"):
+            result, missing = await fetch_entities_map(
+                client, "stack", [good.id, bad.id]
+            )
+
+        assert isinstance(result.get(good.id), FetchedStack)
+        assert bad.id in missing
+        assert bad.id not in result
+        assert any(
+            "member read failed" in record.message.lower()
+            or "stack member read failed" in record.message.lower()
+            for record in caplog.records
+        )
 
 
 class TestEventDrivenStacks:

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -1,18 +1,12 @@
-"""Tests for stacks in the event-driven sync stream.
-
-Stacks ride the same event-cursor path as every other entity type: a
-``stack_created`` / ``stack_updated`` event hydrates and emits ``StackV1``, a
-``stack_deleted`` event emits ``StackDeleteV1``, and a caught-up client that
-sends no new events gets nothing (no full-table sweep). The asset ``stackId``
-mapping and the ``gumnut_stack_to_sync_stack_v1`` converter are exercised here
-too, since both feed the stack rows the stream emits.
-"""
+"""Tests for stacks in the event-driven sync stream."""
 
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 from gumnut import GumnutError
+from gumnut.types.asset_response import AssetResponse
+from gumnut.types.file_data_response import FileDataResponse
 
 from routers.api.sync.converters import (
     gumnut_asset_to_sync_asset_v1,
@@ -26,6 +20,7 @@ from routers.api.sync.entity_fetch import (
 from routers.api.sync.stream import generate_sync_stream
 from routers.api.sync.types import FetchedStack
 from routers.immich_models import SyncRequestType, SyncStreamDto
+from routers.utils.concurrency import BULK_FANOUT_CONCURRENCY_LIMIT
 from routers.utils.gumnut_id_conversion import (
     safe_uuid_from_asset_id,
     safe_uuid_from_stack_id,
@@ -50,12 +45,7 @@ UPDATED_AT = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
 
 
 def _events_by_type(mapping):
-    """An ``events.get`` mock keyed on each pass's ``entity_types`` filter.
-
-    Each entity-type pass queries ``/api/events`` for its own type, so a shared
-    ``return_value`` would leak one pass's events into another. This returns the
-    events registered for the requested ``entity_types`` only.
-    """
+    """Return events keyed by each sync pass's entity-type filter."""
     return AsyncMock(
         side_effect=lambda **kwargs: create_mock_events_response(
             mapping.get(kwargs.get("entity_types"), [])
@@ -64,17 +54,18 @@ def _events_by_type(mapping):
 
 
 def _assets_list(*, members_by_stack=None, assets_by_id=None):
-    """One ``assets.list`` mock serving both stack hydration and entity fetch.
-
-    Stack hydration reads members with ``stack_id=``; the asset pass fetches by
-    ``ids=``. Dispatch on which kwarg is present so a single test can drive both.
-    """
+    """Serve stack-member and by-ID asset reads from one mock."""
     members_by_stack = members_by_stack or {}
     assets_by_id = assets_by_id or {}
 
     def _list(**kwargs):
         if "stack_id" in kwargs:
-            return MockSyncCursorPage(members_by_stack.get(kwargs["stack_id"], []))
+            members = members_by_stack.get(kwargs["stack_id"], [])
+            if kwargs.get("state") == "live":
+                members = [member for member in members if member.trashed_at is None]
+            if ids := kwargs.get("ids"):
+                members = [member for member in members if member.id in ids]
+            return MockSyncCursorPage(members)
         ids = kwargs.get("ids") or []
         return MockSyncCursorPage([assets_by_id[i] for i in ids if i in assets_by_id])
 
@@ -82,31 +73,24 @@ def _assets_list(*, members_by_stack=None, assets_by_id=None):
 
 
 class TestAssetStackIdConversion:
-    def test_v1_maps_stack_id_to_uuid_string(self):
+    @pytest.mark.parametrize(
+        "converter", [gumnut_asset_to_sync_asset_v1, gumnut_asset_to_sync_asset_v2]
+    )
+    def test_maps_stack_id_to_uuid_string(self, converter):
         stack = make_gumnut_stack()
         asset = make_gumnut_asset(stack_id=stack.id)
 
-        sync = gumnut_asset_to_sync_asset_v1(asset, TEST_UUID)
+        sync = converter(asset, TEST_UUID)
 
         assert sync.stackId == str(safe_uuid_from_stack_id(stack.id))
 
-    def test_v1_loose_asset_is_null(self):
+    @pytest.mark.parametrize(
+        "converter", [gumnut_asset_to_sync_asset_v1, gumnut_asset_to_sync_asset_v2]
+    )
+    def test_loose_asset_is_null(self, converter):
         asset = make_gumnut_asset(stack_id=None)
 
-        assert gumnut_asset_to_sync_asset_v1(asset, TEST_UUID).stackId is None
-
-    def test_v2_inherits_stack_id(self):
-        stack = make_gumnut_stack()
-        asset = make_gumnut_asset(stack_id=stack.id)
-
-        sync = gumnut_asset_to_sync_asset_v2(asset, TEST_UUID)
-
-        assert sync.stackId == str(safe_uuid_from_stack_id(stack.id))
-
-    def test_v2_loose_asset_is_null(self):
-        asset = make_gumnut_asset(stack_id=None)
-
-        assert gumnut_asset_to_sync_asset_v2(asset, TEST_UUID).stackId is None
+        assert converter(asset, TEST_UUID).stackId is None
 
     def test_undecodable_stack_id_degrades_to_loose_without_raising(self, caplog):
         asset = make_gumnut_asset(stack_id="not_a_valid_stack_prefix")
@@ -141,7 +125,7 @@ class TestStackEntityFetch:
 
     @pytest.mark.anyio
     async def test_resolves_pinned_primary(self):
-        stack, members = make_gumnut_stack_with_members(count=3)
+        stack, members = make_gumnut_stack_with_members(count=3, trashed={2})
         stack.primary_asset_id = members[2].id
         client = Mock()
         client.stacks.list_stacks = mock_list_stacks([stack])
@@ -153,6 +137,40 @@ class TestStackEntityFetch:
         assert isinstance(fetched, FetchedStack)
         assert fetched.primary_asset_id == safe_uuid_from_asset_id(members[2].id)
         assert missing == set()
+        assert client.assets.list.call_args_list == [
+            call(
+                stack_id=stack.id,
+                ids=[members[2].id],
+                state="all",
+                order="asc",
+                limit=1,
+            )
+        ]
+
+    @pytest.mark.anyio
+    async def test_missing_pin_falls_back_to_first_live_member(self):
+        stack, members = make_gumnut_stack_with_members(count=2)
+        missing_pin = make_gumnut_asset().id
+        stack.primary_asset_id = missing_pin
+        client = Mock()
+        client.stacks.list_stacks = mock_list_stacks([stack])
+        client.assets.list = _assets_list(members_by_stack={stack.id: members})
+
+        result, _ = await fetch_entities_map(client, "stack", [stack.id])
+
+        fetched = result[stack.id]
+        assert isinstance(fetched, FetchedStack)
+        assert fetched.primary_asset_id == safe_uuid_from_asset_id(members[0].id)
+        assert client.assets.list.call_args_list == [
+            call(
+                stack_id=stack.id,
+                ids=[missing_pin],
+                state="all",
+                order="asc",
+                limit=1,
+            ),
+            call(stack_id=stack.id, state="live", order="asc", limit=1),
+        ]
 
     @pytest.mark.anyio
     async def test_synthesizes_primary_for_unpinned_burst(self):
@@ -166,22 +184,52 @@ class TestStackEntityFetch:
 
         fetched = result[stack.id]
         assert isinstance(fetched, FetchedStack)
-        # The earliest-captured member stands in for an unpinned burst.
         assert fetched.primary_asset_id == safe_uuid_from_asset_id(members[0].id)
 
     @pytest.mark.anyio
-    async def test_member_less_stack_is_reported_missing(self, caplog):
-        stack = make_gumnut_stack(asset_count=0)
+    async def test_all_trashed_stack_still_resolves_primary(self):
+        stack, members = make_gumnut_stack_with_members(count=2, trashed={0, 1})
+        assert stack.asset_count == 0
         client = Mock()
         client.stacks.list_stacks = mock_list_stacks([stack])
-        client.assets.list = _assets_list(members_by_stack={stack.id: []})
+        client.assets.list = _assets_list(members_by_stack={stack.id: members})
 
-        with caplog.at_level("WARNING"):
-            result, missing = await fetch_entities_map(client, "stack", [stack.id])
+        result, missing = await fetch_entities_map(client, "stack", [stack.id])
 
-        assert stack.id not in result
-        assert stack.id in missing
-        assert any("no members" in record.message for record in caplog.records)
+        fetched = result[stack.id]
+        assert isinstance(fetched, FetchedStack)
+        assert fetched.primary_asset_id == safe_uuid_from_asset_id(members[0].id)
+        assert missing == set()
+        assert client.assets.list.call_args.kwargs["state"] == "all"
+        assert "include" not in client.assets.list.call_args.kwargs
+        assert client.assets.list.call_args_list == [
+            call(stack_id=stack.id, state="live", order="asc", limit=1),
+            call(stack_id=stack.id, state="all", order="asc", limit=1),
+        ]
+
+    @pytest.mark.anyio
+    async def test_primary_resolution_stops_after_first_sufficient_member(self):
+        stack, members = make_gumnut_stack_with_members(count=2)
+        consumed = []
+
+        async def member_page():
+            for member in members:
+                consumed.append(member.id)
+                yield member
+
+        client = Mock()
+        client.stacks.list_stacks = mock_list_stacks([stack])
+        client.assets.list = Mock(return_value=member_page())
+
+        result, _ = await fetch_entities_map(client, "stack", [stack.id])
+
+        fetched = result[stack.id]
+        assert isinstance(fetched, FetchedStack)
+        assert fetched.primary_asset_id == safe_uuid_from_asset_id(members[0].id)
+        assert consumed == [members[0].id]
+        assert client.assets.list.call_args_list == [
+            call(stack_id=stack.id, state="live", order="asc", limit=1)
+        ]
 
     @pytest.mark.anyio
     async def test_two_stacks_in_one_fetch_each_keep_their_own_primary(self):
@@ -213,10 +261,6 @@ class TestStackEntityFetch:
 
     @pytest.mark.anyio
     async def test_transient_member_read_failure_propagates_not_skipped(self):
-        # A transient member-read failure must NOT degrade to a skip: skipping
-        # would advance the events cursor past the stack while its members still
-        # carry stackId, permanently hiding the burst. It propagates so the sync
-        # truncates and the stack retries next cycle.
         good, good_members = make_gumnut_stack_with_members(count=2)
         good.primary_asset_id = good_members[0].id
         bad, _bad_members = make_gumnut_stack_with_members(count=2)
@@ -236,12 +280,38 @@ class TestStackEntityFetch:
             await fetch_entities_map(client, "stack", [good.id, bad.id])
 
     @pytest.mark.anyio
-    async def test_empty_read_contradicting_asset_count_propagates(self):
-        # The row claims members but the state="all" read comes back empty — a
-        # transient contradiction, not a member-less stack (a member-less stack
-        # reports asset_count 0). It must propagate to retry, not skip, or the
-        # stack's members strand as a hidden burst.
-        stack = make_gumnut_stack(asset_count=2)
+    async def test_member_failure_cancels_queued_stack_reads(self):
+        stacks_and_members = [
+            make_gumnut_stack_with_members(count=1)
+            for _ in range(BULK_FANOUT_CONCURRENCY_LIMIT + 2)
+        ]
+        stacks = [stack for stack, _ in stacks_and_members]
+        members_by_stack = {stack.id: members for stack, members in stacks_and_members}
+        bad = stacks[0]
+        started = []
+        client = Mock()
+        client.stacks.list_stacks = Mock(return_value=MockSyncCursorPage(stacks))
+
+        def _list(**kwargs):
+            stack_id = kwargs["stack_id"]
+            started.append(stack_id)
+            if stack_id == bad.id:
+                raise GumnutError("member read failed")
+            return MockSyncCursorPage(members_by_stack[stack_id])
+
+        client.assets.list = Mock(side_effect=_list)
+
+        with pytest.raises(GumnutError):
+            await fetch_entities_map(client, "stack", [stack.id for stack in stacks])
+
+        assert not set(started) & {
+            stack.id for stack in stacks[BULK_FANOUT_CONCURRENCY_LIMIT:]
+        }
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("asset_count", [0, 2])
+    async def test_empty_member_read_propagates(self, asset_count):
+        stack = make_gumnut_stack(asset_count=asset_count)
         client = Mock()
         client.stacks.list_stacks = mock_list_stacks([stack])
         client.assets.list = _assets_list(members_by_stack={stack.id: []})
@@ -307,7 +377,6 @@ class TestEventDrivenStacks:
         assert stack_events[0]["data"]["primaryAssetId"] == str(
             safe_uuid_from_asset_id(members[0].id)
         )
-        # The ack is the raw event cursor, not a synthetic snapshot cursor.
         assert stack_events[0]["ack"] == "StackV1|cur_s1|"
         assert events[-1]["type"] == "SyncCompleteV1"
 
@@ -357,7 +426,6 @@ class TestEventDrivenStacks:
         assert delete_events[0]["data"]["stackId"] == str(
             safe_uuid_from_stack_id(stack.id)
         )
-        # A delete needs no entity hydration — the stack table is never read.
         client.stacks.list_stacks.assert_not_called()
 
     @pytest.mark.anyio
@@ -400,6 +468,70 @@ class TestEventDrivenStacks:
         assert events[-1]["type"] == "SyncCompleteV1"
 
     @pytest.mark.anyio
+    async def test_asset_uses_event_time_stack_membership(self):
+        user = create_mock_user(UPDATED_AT)
+        client = create_mock_gumnut_client(user)
+        event_stack, event_stack_members = make_gumnut_stack_with_members(count=1)
+        later_stack = make_gumnut_stack()
+        asset_id = make_gumnut_asset().id
+        asset = AssetResponse(
+            id=asset_id,
+            created_at=UPDATED_AT,
+            local_datetime=UPDATED_AT,
+            mime_type="image/jpeg",
+            original_file_name="moved.jpg",
+            updated_at=UPDATED_AT,
+            file_data=FileDataResponse(
+                checksum="sha256",
+                checksum_sha1="PaDX6+c+Lhjpm5/ciXUROL1ryaU=",
+                device_asset_id="device-asset",
+                device_id="device",
+                file_created_at=UPDATED_AT,
+                file_modified_at=UPDATED_AT,
+                file_size_bytes=1,
+            ),
+            stack_id=later_stack.id,
+        )
+        client.events.get = _events_by_type(
+            {
+                "stack": [
+                    create_mock_event(
+                        "stack",
+                        event_stack.id,
+                        "stack_created",
+                        UPDATED_AT,
+                        "cur_s",
+                    )
+                ],
+                "asset": [
+                    create_mock_event(
+                        "asset",
+                        asset.id,
+                        "asset_updated",
+                        UPDATED_AT,
+                        "cur_a",
+                        payload={"stack_id": event_stack.id},
+                    )
+                ],
+            }
+        )
+        client.stacks.list_stacks = mock_list_stacks([event_stack])
+        client.assets.list = _assets_list(
+            members_by_stack={event_stack.id: event_stack_members},
+            assets_by_id={asset.id: asset},
+        )
+
+        request = SyncStreamDto(
+            types=[SyncRequestType.StacksV1, SyncRequestType.AssetsV2]
+        )
+        events = await collect_stream(generate_sync_stream(client, request, {}, user))
+
+        asset_event = next(event for event in events if event["type"] == "AssetV2")
+        assert asset_event["data"]["stackId"] == str(
+            safe_uuid_from_stack_id(event_stack.id)
+        )
+
+    @pytest.mark.anyio
     async def test_stack_delete_streams_after_asset_delete(self):
         user = create_mock_user(UPDATED_AT)
         client = create_mock_gumnut_client(user)
@@ -426,13 +558,10 @@ class TestEventDrivenStacks:
         events = await collect_stream(generate_sync_stream(client, request, {}, user))
 
         types = [e["type"] for e in events]
-        # Children (assets) are removed before their parent stack.
         assert types.index("AssetDeleteV1") < types.index("StackDeleteV1")
 
     @pytest.mark.anyio
     async def test_caught_up_client_gets_no_stacks_and_no_sweep(self):
-        # No events for any type: a caught-up client. The event path emits
-        # nothing and never sweeps the stack table (the snapshot path would).
         user = create_mock_user(UPDATED_AT)
         client = create_mock_gumnut_client(user)
 
@@ -443,30 +572,46 @@ class TestEventDrivenStacks:
         client.stacks.list_stacks.assert_not_called()
 
     @pytest.mark.anyio
-    async def test_stack_created_for_member_less_stack_is_skipped(self, caplog):
+    async def test_stack_hydration_failure_truncates_before_asset_pass(self, caplog):
         user = create_mock_user(UPDATED_AT)
         client = create_mock_gumnut_client(user)
         stack = make_gumnut_stack(asset_count=0)
-        client.events.get.return_value = create_mock_events_response(
-            [create_mock_event("stack", stack.id, "stack_created", UPDATED_AT, "cur_m")]
+        asset = make_gumnut_asset(stack_id=stack.id)
+        client.events.get = _events_by_type(
+            {
+                "stack": [
+                    create_mock_event(
+                        "stack", stack.id, "stack_created", UPDATED_AT, "cur_s"
+                    )
+                ],
+                "asset": [
+                    create_mock_event(
+                        "asset", asset.id, "asset_created", UPDATED_AT, "cur_a"
+                    )
+                ],
+            }
         )
         client.stacks.list_stacks = mock_list_stacks([stack])
-        client.assets.list = _assets_list(members_by_stack={stack.id: []})
+        client.assets.list = _assets_list(
+            members_by_stack={stack.id: []}, assets_by_id={asset.id: asset}
+        )
 
-        request = SyncStreamDto(types=[SyncRequestType.StacksV1])
-        with caplog.at_level("WARNING"):
+        request = SyncStreamDto(
+            types=[SyncRequestType.StacksV1, SyncRequestType.AssetsV2]
+        )
+        with caplog.at_level("ERROR"):
             events = await collect_stream(
                 generate_sync_stream(client, request, {}, user)
             )
 
-        assert not any(e["type"] == "StackV1" for e in events)
-        assert events[-1]["type"] == "SyncCompleteV1"
-        assert any("no members" in record.message for record in caplog.records)
+        assert not any(e["type"] in {"StackV1", "AssetV2"} for e in events)
+        assert not any(e["type"] == "SyncCompleteV1" for e in events)
+        assert not any(
+            call.kwargs.get("ids") for call in client.assets.list.call_args_list
+        )
 
     @pytest.mark.anyio
     async def test_stack_vanished_between_event_and_fetch_is_skipped(self, caplog):
-        # The stack event arrives, but the stack is gone by the time we fetch it.
-        # It must be skipped, not crash the stream (the not-returned path).
         user = create_mock_user(UPDATED_AT)
         client = create_mock_gumnut_client(user)
         stack = make_gumnut_stack()
@@ -503,9 +648,7 @@ class TestEventDrivenStacks:
 
     @pytest.mark.anyio
     async def test_undecodable_stack_deleted_event_is_skipped(self, caplog):
-        # A stack_deleted with an undecodable id must skip, not truncate the
-        # sync (stacks are the first pass, so an unguarded decode would take
-        # every later pass and SyncCompleteV1 with it).
+        # Stacks run first, so an unguarded decode would drop every later pass.
         user = create_mock_user(UPDATED_AT)
         client = create_mock_gumnut_client(user)
         client.events.get.return_value = create_mock_events_response(

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -1,29 +1,37 @@
-"""Tests for stack membership and incremental StackV1 upserts."""
+"""Tests for stacks in the event-driven sync stream.
 
-import json
+Stacks ride the same event-cursor path as every other entity type: a
+``stack_created`` / ``stack_updated`` event hydrates and emits ``StackV1``, a
+``stack_deleted`` event emits ``StackDeleteV1``, and a caught-up client that
+sends no new events gets nothing (no full-table sweep). The asset ``stackId``
+mapping and the ``gumnut_stack_to_sync_stack_v1`` converter are exercised here
+too, since both feed the stack rows the stream emits.
+"""
+
 from datetime import datetime, timezone
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
-from gumnut import GumnutError
 
 from routers.api.sync.converters import (
     gumnut_asset_to_sync_asset_v1,
     gumnut_asset_to_sync_asset_v2,
     gumnut_stack_to_sync_stack_v1,
 )
-from routers.api.sync.stream import _stream_stacks, generate_sync_stream
-from routers.immich_models import SyncEntityType, SyncRequestType, SyncStreamDto
+from routers.api.sync.entity_fetch import fetch_entities_map
+from routers.api.sync.stream import generate_sync_stream
+from routers.api.sync.types import FetchedStack
+from routers.immich_models import SyncRequestType, SyncStreamDto
 from routers.utils.gumnut_id_conversion import (
     safe_uuid_from_asset_id,
     safe_uuid_from_stack_id,
 )
-from services.checkpoint_store import Checkpoint
 from tests.conftest import (
     MockSyncCursorPage,
     make_gumnut_asset,
     make_gumnut_stack,
     make_gumnut_stack_with_members,
+    mock_list_stacks,
 )
 from tests.unit.api.sync.conftest import (
     TEST_UUID,
@@ -34,19 +42,39 @@ from tests.unit.api.sync.conftest import (
     create_mock_user,
 )
 
-
-def _stacks_page(*stacks):
-    """Return the given stacks for any list_stacks call."""
-    return Mock(return_value=MockSyncCursorPage(list(stacks)))
+UPDATED_AT = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
 
 
-def _members_by_stack(mapping):
-    """Return members by stack_id."""
-    return Mock(
-        side_effect=lambda **kwargs: MockSyncCursorPage(
-            mapping.get(kwargs.get("stack_id"), [])
+def _events_by_type(mapping):
+    """An ``events.get`` mock keyed on each pass's ``entity_types`` filter.
+
+    Each entity-type pass queries ``/api/events`` for its own type, so a shared
+    ``return_value`` would leak one pass's events into another. This returns the
+    events registered for the requested ``entity_types`` only.
+    """
+    return AsyncMock(
+        side_effect=lambda **kwargs: create_mock_events_response(
+            mapping.get(kwargs.get("entity_types"), [])
         )
     )
+
+
+def _assets_list(*, members_by_stack=None, assets_by_id=None):
+    """One ``assets.list`` mock serving both stack hydration and entity fetch.
+
+    Stack hydration reads members with ``stack_id=``; the asset pass fetches by
+    ``ids=``. Dispatch on which kwarg is present so a single test can drive both.
+    """
+    members_by_stack = members_by_stack or {}
+    assets_by_id = assets_by_id or {}
+
+    def _list(**kwargs):
+        if "stack_id" in kwargs:
+            return MockSyncCursorPage(members_by_stack.get(kwargs["stack_id"], []))
+        ids = kwargs.get("ids") or []
+        return MockSyncCursorPage([assets_by_id[i] for i in ids if i in assets_by_id])
+
+    return Mock(side_effect=_list)
 
 
 class TestAssetStackIdConversion:
@@ -104,197 +132,160 @@ class TestStackConverter:
         assert sync.updatedAt == updated
 
 
-def _stack_cursor(stack):
-    """Return the checkpoint cursor for a stack."""
-    return f"{stack.updated_at.isoformat()}_{stack.id}"
-
-
-class TestStreamStacks:
-    @pytest.mark.anyio
-    async def test_checkpoint_at_or_after_all_stacks_emits_nothing(self):
-        stack, members = make_gumnut_stack_with_members(count=2)
-        client = Mock()
-        client.stacks.list_stacks = _stacks_page(stack)
-        client.assets.list = _members_by_stack({stack.id: members})
-        checkpoint = Checkpoint(
-            entity_type=SyncEntityType.StackV1,
-            updated_at=stack.updated_at,
-            cursor=_stack_cursor(stack),
-        )
-
-        lines = await collect_stream(_stream_stacks(client, TEST_UUID, checkpoint))
-
-        assert lines == []
-        client.stacks.list_stacks.assert_called_once()
-        client.assets.list.assert_not_called()
+class TestStackEntityFetch:
+    """fetch_entities_map hydrates a stack and resolves its effective primary."""
 
     @pytest.mark.anyio
-    async def test_checkpoint_emits_only_stacks_after_its_cursor(self):
-        stack_a, members_a = make_gumnut_stack_with_members(count=2)
-        stack_a.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
-        stack_b, members_b = make_gumnut_stack_with_members(count=2)
-        stack_b.updated_at = datetime(2025, 2, 2, tzinfo=timezone.utc)
-        client = Mock()
-        client.stacks.list_stacks = _stacks_page(stack_a, stack_b)
-        client.assets.list = _members_by_stack(
-            {stack_a.id: members_a, stack_b.id: members_b}
-        )
-        checkpoint = Checkpoint(
-            entity_type=SyncEntityType.StackV1,
-            updated_at=stack_a.updated_at,
-            cursor=_stack_cursor(stack_a),
-        )
-
-        lines = await collect_stream(_stream_stacks(client, TEST_UUID, checkpoint))
-
-        assert [line["data"]["id"] for line in lines] == [
-            str(safe_uuid_from_stack_id(stack_b.id))
-        ]
-
-    @pytest.mark.anyio
-    async def test_undecodable_stack_id_skipped_without_aborting(self, caplog):
-        good, good_members = make_gumnut_stack_with_members(count=2)
-        good.updated_at = datetime(2025, 2, 2, tzinfo=timezone.utc)
-        bad, bad_members = make_gumnut_stack_with_members(
-            count=2, stack_id="not_a_valid_stack_prefix"
-        )
-        bad.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
-        client = Mock()
-        client.stacks.list_stacks = _stacks_page(good, bad)
-        client.assets.list = _members_by_stack(
-            {good.id: good_members, bad.id: bad_members}
-        )
-
-        with caplog.at_level("WARNING"):
-            lines = await collect_stream(_stream_stacks(client, TEST_UUID, None))
-
-        assert [line["data"]["id"] for line in lines] == [
-            str(safe_uuid_from_stack_id(good.id))
-        ]
-        assert any("undecodable" in record.message for record in caplog.records)
-
-    @pytest.mark.anyio
-    async def test_no_checkpoint_uses_pinned_primary(self):
+    async def test_resolves_pinned_primary(self):
         stack, members = make_gumnut_stack_with_members(count=3)
         stack.primary_asset_id = members[2].id
         client = Mock()
-        client.stacks.list_stacks = _stacks_page(stack)
-        client.assets.list = _members_by_stack({stack.id: members})
+        client.stacks.list_stacks = mock_list_stacks([stack])
+        client.assets.list = _assets_list(members_by_stack={stack.id: members})
 
-        lines = await collect_stream(_stream_stacks(client, TEST_UUID, None))
+        result, missing = await fetch_entities_map(client, "stack", [stack.id])
 
-        assert len(lines) == 1
-        assert lines[0]["type"] == "StackV1"
-        assert lines[0]["data"]["primaryAssetId"] == str(
-            safe_uuid_from_asset_id(members[2].id)
-        )
-        assert lines[0]["data"]["id"] == str(safe_uuid_from_stack_id(stack.id))
+        fetched = result[stack.id]
+        assert isinstance(fetched, FetchedStack)
+        assert fetched.primary_asset_id == safe_uuid_from_asset_id(members[2].id)
+        assert missing == set()
 
     @pytest.mark.anyio
-    async def test_no_checkpoint_synthesizes_primary_for_unpinned_burst(self):
+    async def test_synthesizes_primary_for_unpinned_burst(self):
         stack, members = make_gumnut_stack_with_members(count=3)
         assert stack.primary_asset_id is None
         client = Mock()
-        client.stacks.list_stacks = _stacks_page(stack)
-        client.assets.list = _members_by_stack({stack.id: members})
+        client.stacks.list_stacks = mock_list_stacks([stack])
+        client.assets.list = _assets_list(members_by_stack={stack.id: members})
 
-        lines = await collect_stream(_stream_stacks(client, TEST_UUID, None))
+        result, _ = await fetch_entities_map(client, "stack", [stack.id])
 
-        assert lines[0]["data"]["primaryAssetId"] == str(
-            safe_uuid_from_asset_id(members[0].id)
-        )
+        fetched = result[stack.id]
+        assert isinstance(fetched, FetchedStack)
+        # The earliest-captured member stands in for an unpinned burst.
+        assert fetched.primary_asset_id == safe_uuid_from_asset_id(members[0].id)
 
     @pytest.mark.anyio
-    async def test_zero_member_stack_skipped_with_warning(self, caplog):
+    async def test_member_less_stack_is_reported_missing(self, caplog):
         stack = make_gumnut_stack(asset_count=0)
         client = Mock()
-        client.stacks.list_stacks = _stacks_page(stack)
-        client.assets.list = _members_by_stack({stack.id: []})
+        client.stacks.list_stacks = mock_list_stacks([stack])
+        client.assets.list = _assets_list(members_by_stack={stack.id: []})
 
         with caplog.at_level("WARNING"):
-            lines = await collect_stream(_stream_stacks(client, TEST_UUID, None))
+            result, missing = await fetch_entities_map(client, "stack", [stack.id])
 
-        assert lines == []
+        assert stack.id not in result
+        assert stack.id in missing
         assert any("no members" in record.message for record in caplog.records)
 
-    @pytest.mark.anyio
-    async def test_multiple_stacks_stream_in_order_with_deterministic_acks(self):
-        stack_a, members_a = make_gumnut_stack_with_members(count=2)
-        stack_a.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
-        stack_b, members_b = make_gumnut_stack_with_members(count=2)
-        stack_b.updated_at = datetime(2025, 2, 2, tzinfo=timezone.utc)
 
-        client = Mock()
-        client.stacks.list_stacks = _stacks_page(stack_b, stack_a)
-        client.assets.list = _members_by_stack(
-            {stack_a.id: members_a, stack_b.id: members_b}
-        )
-
-        lines = [
-            (json.loads(line), line)
-            async for line in _stream_stacks(client, TEST_UUID, None)
-        ]
-
-        assert [data["data"]["id"] for data, _ in lines] == [
-            str(safe_uuid_from_stack_id(stack_a.id)),
-            str(safe_uuid_from_stack_id(stack_b.id)),
-        ]
-        assert lines[0][0]["ack"] == (
-            f"StackV1|{stack_a.updated_at.isoformat()}_{stack_a.id}|"
-        )
-        assert lines[1][0]["ack"] == (
-            f"StackV1|{stack_b.updated_at.isoformat()}_{stack_b.id}|"
-        )
+class TestEventDrivenStacks:
+    """Stacks flow through generate_sync_stream on the shared event-cursor path."""
 
     @pytest.mark.anyio
-    async def test_checkpoint_tiebreak_on_id_at_equal_updated_at(self):
-        shared = datetime(2025, 3, 3, tzinfo=timezone.utc)
-        s1, m1 = make_gumnut_stack_with_members(count=2)
-        s2, m2 = make_gumnut_stack_with_members(count=2)
-        s1.updated_at = s2.updated_at = shared
-        low, high = sorted([s1, s2], key=lambda s: s.id)
-        client = Mock()
-        client.stacks.list_stacks = _stacks_page(high, low)
-        client.assets.list = _members_by_stack({s1.id: m1, s2.id: m2})
-        checkpoint = Checkpoint(
-            entity_type=SyncEntityType.StackV1,
-            updated_at=shared,
-            cursor=_stack_cursor(low),
-        )
-
-        lines = await collect_stream(_stream_stacks(client, TEST_UUID, checkpoint))
-
-        assert [line["data"]["id"] for line in lines] == [
-            str(safe_uuid_from_stack_id(high.id))
-        ]
-
-
-class TestSnapshotOrdering:
-    @pytest.mark.anyio
-    async def test_stack_streamed_before_its_stacked_asset(self):
-        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
-        user = create_mock_user(updated_at)
+    async def test_stack_created_emits_stack_v1_from_event_cursor(self):
+        user = create_mock_user(UPDATED_AT)
         client = create_mock_gumnut_client(user)
-
-        stack, members = make_gumnut_stack_with_members(count=1)
-        asset = members[0]
-
+        stack, members = make_gumnut_stack_with_members(count=2)
+        stack.primary_asset_id = members[0].id
         client.events.get.return_value = create_mock_events_response(
             [
                 create_mock_event(
-                    entity_type="asset",
-                    entity_id=asset.id,
-                    event_type="asset_created",
-                    created_at=updated_at,
-                    cursor="cursor_asset_1",
+                    "stack", stack.id, "stack_created", UPDATED_AT, "cur_s1"
                 )
             ]
         )
-        # Serve both the entity fetch (ids=) and stack hydration (stack_id=).
-        client.assets.list = Mock(
-            side_effect=lambda **kwargs: MockSyncCursorPage([asset])
+        client.stacks.list_stacks = mock_list_stacks([stack])
+        client.assets.list = _assets_list(members_by_stack={stack.id: members})
+
+        request = SyncStreamDto(types=[SyncRequestType.StacksV1])
+        events = await collect_stream(generate_sync_stream(client, request, {}, user))
+
+        stack_events = [e for e in events if e["type"] == "StackV1"]
+        assert len(stack_events) == 1
+        assert stack_events[0]["data"]["id"] == str(safe_uuid_from_stack_id(stack.id))
+        assert stack_events[0]["data"]["primaryAssetId"] == str(
+            safe_uuid_from_asset_id(members[0].id)
         )
-        client.stacks.list_stacks = _stacks_page(stack)
+        # The ack is the raw event cursor, not a synthetic snapshot cursor.
+        assert stack_events[0]["ack"] == "StackV1|cur_s1|"
+        assert events[-1]["type"] == "SyncCompleteV1"
+
+    @pytest.mark.anyio
+    async def test_stack_updated_reemits_with_current_primary(self):
+        user = create_mock_user(UPDATED_AT)
+        client = create_mock_gumnut_client(user)
+        stack, members = make_gumnut_stack_with_members(count=3)
+        stack.primary_asset_id = members[1].id
+        client.events.get.return_value = create_mock_events_response(
+            [
+                create_mock_event(
+                    "stack", stack.id, "stack_updated", UPDATED_AT, "cur_s2"
+                )
+            ]
+        )
+        client.stacks.list_stacks = mock_list_stacks([stack])
+        client.assets.list = _assets_list(members_by_stack={stack.id: members})
+
+        request = SyncStreamDto(types=[SyncRequestType.StacksV1])
+        events = await collect_stream(generate_sync_stream(client, request, {}, user))
+
+        stack_events = [e for e in events if e["type"] == "StackV1"]
+        assert len(stack_events) == 1
+        assert stack_events[0]["data"]["primaryAssetId"] == str(
+            safe_uuid_from_asset_id(members[1].id)
+        )
+
+    @pytest.mark.anyio
+    async def test_stack_deleted_emits_delete_without_fetching(self):
+        user = create_mock_user(UPDATED_AT)
+        client = create_mock_gumnut_client(user)
+        stack = make_gumnut_stack()
+        client.events.get.return_value = create_mock_events_response(
+            [
+                create_mock_event(
+                    "stack", stack.id, "stack_deleted", UPDATED_AT, "cur_d1"
+                )
+            ]
+        )
+
+        request = SyncStreamDto(types=[SyncRequestType.StacksV1])
+        events = await collect_stream(generate_sync_stream(client, request, {}, user))
+
+        delete_events = [e for e in events if e["type"] == "StackDeleteV1"]
+        assert len(delete_events) == 1
+        assert delete_events[0]["data"]["stackId"] == str(
+            safe_uuid_from_stack_id(stack.id)
+        )
+        # A delete needs no entity hydration — the stack table is never read.
+        client.stacks.list_stacks.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_stack_streams_before_its_stacked_asset(self):
+        user = create_mock_user(UPDATED_AT)
+        client = create_mock_gumnut_client(user)
+        stack, members = make_gumnut_stack_with_members(count=1)
+        stack.primary_asset_id = members[0].id
+        asset = members[0]
+        client.events.get = _events_by_type(
+            {
+                "stack": [
+                    create_mock_event(
+                        "stack", stack.id, "stack_created", UPDATED_AT, "cur_s"
+                    )
+                ],
+                "asset": [
+                    create_mock_event(
+                        "asset", asset.id, "asset_created", UPDATED_AT, "cur_a"
+                    )
+                ],
+            }
+        )
+        client.stacks.list_stacks = mock_list_stacks([stack])
+        client.assets.list = _assets_list(
+            members_by_stack={stack.id: members}, assets_by_id={asset.id: asset}
+        )
 
         request = SyncStreamDto(
             types=[SyncRequestType.StacksV1, SyncRequestType.AssetsV2]
@@ -303,89 +294,103 @@ class TestSnapshotOrdering:
 
         types = [e["type"] for e in events]
         assert types.index("StackV1") < types.index("AssetV2")
-
         stack_event = next(e for e in events if e["type"] == "StackV1")
         asset_event = next(e for e in events if e["type"] == "AssetV2")
-        assert asset_event["data"]["stackId"] == str(safe_uuid_from_stack_id(stack.id))
         assert asset_event["data"]["stackId"] == stack_event["data"]["id"]
+        assert asset_event["data"]["stackId"] == str(safe_uuid_from_stack_id(stack.id))
         assert events[-1]["type"] == "SyncCompleteV1"
 
     @pytest.mark.anyio
-    async def test_caught_up_stack_checkpoint_streams_no_stacks(self):
-        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
-        user = create_mock_user(updated_at)
+    async def test_stack_delete_streams_after_asset_delete(self):
+        user = create_mock_user(UPDATED_AT)
         client = create_mock_gumnut_client(user)
         stack = make_gumnut_stack()
-        client.stacks.list_stacks = _stacks_page(stack)
-
-        checkpoint_map = {
-            SyncEntityType.StackV1: Checkpoint(
-                entity_type=SyncEntityType.StackV1,
-                updated_at=stack.updated_at,
-                cursor=_stack_cursor(stack),
-            )
-        }
-        request = SyncStreamDto(types=[SyncRequestType.StacksV1])
-
-        events = await collect_stream(
-            generate_sync_stream(client, request, checkpoint_map, user)
+        gone_asset_id = make_gumnut_asset().id
+        client.events.get = _events_by_type(
+            {
+                "stack": [
+                    create_mock_event(
+                        "stack", stack.id, "stack_deleted", UPDATED_AT, "cur_sd"
+                    )
+                ],
+                "asset": [
+                    create_mock_event(
+                        "asset", gone_asset_id, "asset_deleted", UPDATED_AT, "cur_ad"
+                    )
+                ],
+            }
         )
-
-        assert [e["type"] for e in events] == ["SyncCompleteV1"]
-        client.stacks.list_stacks.assert_called_once()
-
-    @pytest.mark.anyio
-    async def test_stack_hydration_error_does_not_truncate_sync(self, caplog):
-        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
-        user = create_mock_user(updated_at)
-        client = create_mock_gumnut_client(user)
-        stack, members = make_gumnut_stack_with_members(count=1)
-        asset = members[0]
-
-        client.events.get.return_value = create_mock_events_response(
-            [
-                create_mock_event(
-                    entity_type="asset",
-                    entity_id=asset.id,
-                    event_type="asset_created",
-                    created_at=updated_at,
-                    cursor="cursor_asset_1",
-                )
-            ]
-        )
-        client.stacks.list_stacks = _stacks_page(stack)
-
-        def assets_list(**kwargs):
-            # Fail stack hydration but allow the later asset fetch.
-            if "stack_id" in kwargs:
-                raise GumnutError("stack member fetch failed")
-            return MockSyncCursorPage([asset])
-
-        client.assets.list = Mock(side_effect=assets_list)
 
         request = SyncStreamDto(
-            types=[SyncRequestType.StacksV1, SyncRequestType.AssetsV2]
+            types=[SyncRequestType.AssetsV2, SyncRequestType.StacksV1]
         )
+        events = await collect_stream(generate_sync_stream(client, request, {}, user))
+
+        types = [e["type"] for e in events]
+        # Children (assets) are removed before their parent stack.
+        assert types.index("AssetDeleteV1") < types.index("StackDeleteV1")
+
+    @pytest.mark.anyio
+    async def test_caught_up_client_gets_no_stacks_and_no_sweep(self):
+        # No events for any type: a caught-up client. The event path emits
+        # nothing and never sweeps the stack table (the snapshot path would).
+        user = create_mock_user(UPDATED_AT)
+        client = create_mock_gumnut_client(user)
+
+        request = SyncStreamDto(types=[SyncRequestType.StacksV1])
+        events = await collect_stream(generate_sync_stream(client, request, {}, user))
+
+        assert [e["type"] for e in events] == ["SyncCompleteV1"]
+        client.stacks.list_stacks.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_stack_created_for_member_less_stack_is_skipped(self, caplog):
+        user = create_mock_user(UPDATED_AT)
+        client = create_mock_gumnut_client(user)
+        stack = make_gumnut_stack(asset_count=0)
+        client.events.get.return_value = create_mock_events_response(
+            [create_mock_event("stack", stack.id, "stack_created", UPDATED_AT, "cur_m")]
+        )
+        client.stacks.list_stacks = mock_list_stacks([stack])
+        client.assets.list = _assets_list(members_by_stack={stack.id: []})
+
+        request = SyncStreamDto(types=[SyncRequestType.StacksV1])
         with caplog.at_level("WARNING"):
             events = await collect_stream(
                 generate_sync_stream(client, request, {}, user)
             )
 
-        types = [e["type"] for e in events]
-        assert "StackV1" not in types
-        assert "AssetV2" in types
+        assert not any(e["type"] == "StackV1" for e in events)
         assert events[-1]["type"] == "SyncCompleteV1"
-        assert any("cut short" in record.message for record in caplog.records)
+        assert any("no members" in record.message for record in caplog.records)
+
+    @pytest.mark.anyio
+    async def test_stack_vanished_between_event_and_fetch_is_skipped(self, caplog):
+        # The stack event arrives, but the stack is gone by the time we fetch it.
+        # It must be skipped, not crash the stream (the not-returned path).
+        user = create_mock_user(UPDATED_AT)
+        client = create_mock_gumnut_client(user)
+        stack = make_gumnut_stack()
+        client.events.get.return_value = create_mock_events_response(
+            [create_mock_event("stack", stack.id, "stack_created", UPDATED_AT, "cur_v")]
+        )
+        client.stacks.list_stacks = mock_list_stacks([])  # nothing comes back
+
+        request = SyncStreamDto(types=[SyncRequestType.StacksV1])
+        with caplog.at_level("WARNING"):
+            events = await collect_stream(
+                generate_sync_stream(client, request, {}, user)
+            )
+
+        assert not any(e["type"] == "StackV1" for e in events)
+        assert events[-1]["type"] == "SyncCompleteV1"
 
     @pytest.mark.anyio
     async def test_partner_stacks_v1_is_silent_noop(self, caplog):
-        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
-        user = create_mock_user(updated_at)
+        user = create_mock_user(UPDATED_AT)
         client = create_mock_gumnut_client(user)
-        client.stacks.list_stacks = _stacks_page(make_gumnut_stack())
 
         request = SyncStreamDto(types=[SyncRequestType.PartnerStacksV1])
-
         with caplog.at_level("INFO", logger="routers.api.sync.stream"):
             events = await collect_stream(
                 generate_sync_stream(client, request, {}, user)
@@ -393,6 +398,6 @@ class TestSnapshotOrdering:
 
         assert [e["type"] for e in events] == ["SyncCompleteV1"]
         assert not any(
-            "unsupported sync types" in record.message for record in caplog.records
+            "unsupported" in record.message.lower() for record in caplog.records
         )
         client.stacks.list_stacks.assert_not_called()

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -101,6 +101,18 @@ class TestAssetStackIdConversion:
 
         assert gumnut_asset_to_sync_asset_v2(asset, TEST_UUID).stackId is None
 
+    def test_undecodable_stack_id_degrades_to_loose_without_raising(self, caplog):
+        """A malformed stack_id (e.g. a backend prefix change) must not abort the
+        sync stream — the asset syncs as loose, with only a debug log (a prefix
+        break is systemic; a per-asset warning would flood the sync)."""
+        asset = make_gumnut_asset(stack_id="not_a_valid_stack_prefix")
+
+        with caplog.at_level("DEBUG"):
+            sync = gumnut_asset_to_sync_asset_v1(asset, TEST_UUID)
+
+        assert sync.stackId is None
+        assert any("not decodable" in record.message for record in caplog.records)
+
 
 # --- Stack converter -----------------------------------------------------------
 

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -1,0 +1,324 @@
+"""Tests for Immich mobile stack-snapshot sync.
+
+Two behaviors ship together here:
+
+- The sync asset converters carry each asset's ``stackId`` (V1 and V2), so a
+  stacked asset names the stack row it belongs to; loose assets stay null.
+- ``StacksV1`` streams a *current-state snapshot* of ``StackV1`` rows on reset /
+  first sync only. There is no Gumnut stack event source yet, so an
+  already-synced client (checkpoint present) receives nothing — incremental
+  create/update/delete support is intentionally out of scope.
+"""
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import Mock
+
+import pytest
+
+from routers.api.sync.converters import (
+    gumnut_asset_to_sync_asset_v1,
+    gumnut_asset_to_sync_asset_v2,
+    gumnut_stack_to_sync_stack_v1,
+)
+from routers.api.sync.stream import _stream_stacks, generate_sync_stream
+from routers.immich_models import SyncEntityType, SyncRequestType, SyncStreamDto
+from routers.utils.gumnut_id_conversion import (
+    safe_uuid_from_asset_id,
+    safe_uuid_from_stack_id,
+)
+from services.checkpoint_store import Checkpoint
+from tests.conftest import (
+    MockSyncCursorPage,
+    make_gumnut_asset,
+    make_gumnut_stack,
+    make_gumnut_stack_with_members,
+)
+from tests.unit.api.sync.conftest import (
+    TEST_UUID,
+    collect_stream,
+    create_mock_event,
+    create_mock_events_response,
+    create_mock_gumnut_client,
+    create_mock_user,
+)
+
+
+def _stacks_page(*stacks):
+    """A ``client.stacks.list_stacks`` mock returning ``stacks`` on any call.
+
+    The snapshot pages with ``limit=`` and no ``ids`` filter, so — unlike the
+    REST ``mock_list_stacks`` helper — this ignores kwargs and replays the full
+    page in the order given, which is the order the snapshot must preserve.
+    """
+    return Mock(return_value=MockSyncCursorPage(list(stacks)))
+
+
+def _members_by_stack(mapping):
+    """A ``client.assets.list`` mock keyed by the ``stack_id`` hydrate_stack asks for."""
+    return Mock(
+        side_effect=lambda **kwargs: MockSyncCursorPage(
+            mapping.get(kwargs.get("stack_id"), [])
+        )
+    )
+
+
+async def _collect(gen):
+    """Collect an async generator of JSON lines into parsed dicts."""
+    return [json.loads(line) async for line in gen]
+
+
+# --- Asset stackId conversion --------------------------------------------------
+
+
+class TestAssetStackIdConversion:
+    """The sync asset converters map the Gumnut stack FK to Immich's stackId."""
+
+    def test_v1_maps_stack_id_to_uuid_string(self):
+        stack = make_gumnut_stack()
+        asset = make_gumnut_asset(stack_id=stack.id)
+
+        sync = gumnut_asset_to_sync_asset_v1(asset, TEST_UUID)
+
+        assert sync.stackId == str(safe_uuid_from_stack_id(stack.id))
+
+    def test_v1_loose_asset_is_null(self):
+        asset = make_gumnut_asset(stack_id=None)
+
+        assert gumnut_asset_to_sync_asset_v1(asset, TEST_UUID).stackId is None
+
+    def test_v2_inherits_stack_id(self):
+        """V2 delegates to V1, so it carries the same stackId."""
+        stack = make_gumnut_stack()
+        asset = make_gumnut_asset(stack_id=stack.id)
+
+        sync = gumnut_asset_to_sync_asset_v2(asset, TEST_UUID)
+
+        assert sync.stackId == str(safe_uuid_from_stack_id(stack.id))
+
+    def test_v2_loose_asset_is_null(self):
+        asset = make_gumnut_asset(stack_id=None)
+
+        assert gumnut_asset_to_sync_asset_v2(asset, TEST_UUID).stackId is None
+
+
+# --- Stack converter -----------------------------------------------------------
+
+
+class TestStackConverter:
+    """gumnut_stack_to_sync_stack_v1 maps a stack row + resolved primary."""
+
+    def test_maps_all_fields(self):
+        created = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        updated = datetime(2025, 2, 2, tzinfo=timezone.utc)
+        stack = make_gumnut_stack()
+        stack.created_at = created
+        stack.updated_at = updated
+        primary = safe_uuid_from_asset_id(make_gumnut_asset().id)
+
+        sync = gumnut_stack_to_sync_stack_v1(stack, primary, TEST_UUID)
+
+        assert sync.id == safe_uuid_from_stack_id(stack.id)
+        assert sync.ownerId == TEST_UUID
+        assert sync.primaryAssetId == primary
+        assert sync.createdAt == created
+        assert sync.updatedAt == updated
+
+
+# --- Stack snapshot streaming (_stream_stacks) ---------------------------------
+
+
+class TestStreamStacks:
+    """The StacksV1 snapshot pass: reset-only, effective-primary, zero-member skip."""
+
+    @pytest.mark.anyio
+    async def test_existing_checkpoint_emits_nothing(self):
+        """A present checkpoint means the client already holds the snapshot —
+        emit no speculative updates and don't even page the stacks."""
+        client = create_mock_gumnut_client(create_mock_user(datetime.now(timezone.utc)))
+        checkpoint = Checkpoint(
+            entity_type=SyncEntityType.StackV1,
+            updated_at=datetime.now(timezone.utc),
+            cursor="StackV1|already-synced",
+        )
+
+        lines = await _collect(_stream_stacks(client, TEST_UUID, checkpoint))
+
+        assert lines == []
+        client.stacks.list_stacks.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_no_checkpoint_uses_pinned_primary(self):
+        """The effective primary honors a pinned cover (matching REST)."""
+        stack, members = make_gumnut_stack_with_members(count=3)
+        stack.primary_asset_id = members[2].id  # user pinned the 3rd frame
+        client = Mock()
+        client.stacks.list_stacks = _stacks_page(stack)
+        client.assets.list = _members_by_stack({stack.id: members})
+
+        lines = await _collect(_stream_stacks(client, TEST_UUID, None))
+
+        assert len(lines) == 1
+        assert lines[0]["type"] == "StackV1"
+        assert lines[0]["data"]["primaryAssetId"] == str(
+            safe_uuid_from_asset_id(members[2].id)
+        )
+        assert lines[0]["data"]["id"] == str(safe_uuid_from_stack_id(stack.id))
+
+    @pytest.mark.anyio
+    async def test_no_checkpoint_synthesizes_primary_for_unpinned_burst(self):
+        """An unpinned burst has no server cover, so the snapshot synthesizes one:
+        the first live frame (fetch_stack_members pins ascending order)."""
+        stack, members = make_gumnut_stack_with_members(count=3)  # unpinned auto_burst
+        assert stack.primary_asset_id is None
+        client = Mock()
+        client.stacks.list_stacks = _stacks_page(stack)
+        client.assets.list = _members_by_stack({stack.id: members})
+
+        lines = await _collect(_stream_stacks(client, TEST_UUID, None))
+
+        assert lines[0]["data"]["primaryAssetId"] == str(
+            safe_uuid_from_asset_id(members[0].id)
+        )
+
+    @pytest.mark.anyio
+    async def test_zero_member_stack_skipped_with_warning(self, caplog):
+        """A member-less stack has no honest required primary — skip it, don't
+        emit an invalid row. hydrate_stack logs the warning."""
+        stack = make_gumnut_stack(asset_count=0)
+        client = Mock()
+        client.stacks.list_stacks = _stacks_page(stack)
+        client.assets.list = _members_by_stack({stack.id: []})
+
+        with caplog.at_level("WARNING"):
+            lines = await _collect(_stream_stacks(client, TEST_UUID, None))
+
+        assert lines == []
+        assert any("no members" in record.message for record in caplog.records)
+
+    @pytest.mark.anyio
+    async def test_multiple_stacks_stream_in_order_with_deterministic_acks(self):
+        """Every stack streams in page order, each with a stable updated_at+id ack,
+        so a reset replays deterministically."""
+        stack_a, members_a = make_gumnut_stack_with_members(count=2)
+        stack_a.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        stack_b, members_b = make_gumnut_stack_with_members(count=2)
+        stack_b.updated_at = datetime(2025, 2, 2, tzinfo=timezone.utc)
+
+        client = Mock()
+        client.stacks.list_stacks = _stacks_page(stack_a, stack_b)
+        client.assets.list = _members_by_stack(
+            {stack_a.id: members_a, stack_b.id: members_b}
+        )
+
+        lines = [
+            (json.loads(line), line)
+            async for line in _stream_stacks(client, TEST_UUID, None)
+        ]
+
+        assert [data["data"]["id"] for data, _ in lines] == [
+            str(safe_uuid_from_stack_id(stack_a.id)),
+            str(safe_uuid_from_stack_id(stack_b.id)),
+        ]
+        assert lines[0][0]["ack"] == (
+            f"StackV1|{stack_a.updated_at.isoformat()}_{stack_a.id}|"
+        )
+        assert lines[1][0]["ack"] == (
+            f"StackV1|{stack_b.updated_at.isoformat()}_{stack_b.id}|"
+        )
+
+
+# --- Snapshot ordering within the full stream ----------------------------------
+
+
+class TestSnapshotOrdering:
+    """StackV1 must precede the assets that name it, and the stream still completes."""
+
+    @pytest.mark.anyio
+    async def test_stack_streamed_before_its_stacked_asset(self):
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        user = create_mock_user(updated_at)
+        client = create_mock_gumnut_client(user)
+
+        stack, members = make_gumnut_stack_with_members(count=1)
+        asset = members[0]  # the lone member, so it is also the effective primary
+
+        client.events.get.return_value = create_mock_events_response(
+            [
+                create_mock_event(
+                    entity_type="asset",
+                    entity_id=asset.id,
+                    event_type="asset_created",
+                    created_at=updated_at,
+                    cursor="cursor_asset_1",
+                )
+            ]
+        )
+        # assets.list serves both the sync entity fetch (ids=) and the stack
+        # member fetch (stack_id=); the same stacked asset satisfies each.
+        client.assets.list = Mock(
+            side_effect=lambda **kwargs: MockSyncCursorPage([asset])
+        )
+        client.stacks.list_stacks = _stacks_page(stack)
+
+        request = SyncStreamDto(
+            types=[SyncRequestType.StacksV1, SyncRequestType.AssetsV2]
+        )
+        events = await collect_stream(generate_sync_stream(client, request, {}, user))
+
+        types = [e["type"] for e in events]
+        assert types.index("StackV1") < types.index("AssetV2")
+
+        stack_event = next(e for e in events if e["type"] == "StackV1")
+        asset_event = next(e for e in events if e["type"] == "AssetV2")
+        # The asset points at exactly the stack row that preceded it.
+        assert asset_event["data"]["stackId"] == str(safe_uuid_from_stack_id(stack.id))
+        assert asset_event["data"]["stackId"] == stack_event["data"]["id"]
+        assert events[-1]["type"] == "SyncCompleteV1"
+
+    @pytest.mark.anyio
+    async def test_existing_stack_checkpoint_streams_no_stacks(self):
+        """With a StackV1 checkpoint, the full stream emits no StackV1 rows."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        user = create_mock_user(updated_at)
+        client = create_mock_gumnut_client(user)
+        client.stacks.list_stacks = _stacks_page(make_gumnut_stack())
+
+        checkpoint_map = {
+            SyncEntityType.StackV1: Checkpoint(
+                entity_type=SyncEntityType.StackV1,
+                updated_at=updated_at,
+                cursor="StackV1|synced",
+            )
+        }
+        request = SyncStreamDto(types=[SyncRequestType.StacksV1])
+
+        events = await collect_stream(
+            generate_sync_stream(client, request, checkpoint_map, user)
+        )
+
+        assert [e["type"] for e in events] == ["SyncCompleteV1"]
+        client.stacks.list_stacks.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_partner_stacks_v1_is_silent_noop(self, caplog):
+        """PartnerStacksV1 stays an intentional no-op: no rows, no 'unsupported'
+        warning, and it never triggers the stack snapshot."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        user = create_mock_user(updated_at)
+        client = create_mock_gumnut_client(user)
+        client.stacks.list_stacks = _stacks_page(make_gumnut_stack())
+
+        request = SyncStreamDto(types=[SyncRequestType.PartnerStacksV1])
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="routers.api.sync.stream"):
+            events = await collect_stream(
+                generate_sync_stream(client, request, {}, user)
+            )
+
+        assert [e["type"] for e in events] == ["SyncCompleteV1"]
+        assert not any(
+            "unsupported sync types" in record.message for record in caplog.records
+        )
+        client.stacks.list_stacks.assert_not_called()

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -19,7 +19,10 @@ from routers.api.sync.converters import (
     gumnut_asset_to_sync_asset_v2,
     gumnut_stack_to_sync_stack_v1,
 )
-from routers.api.sync.entity_fetch import fetch_entities_map
+from routers.api.sync.entity_fetch import (
+    StackMemberReadInconsistent,
+    fetch_entities_map,
+)
 from routers.api.sync.stream import generate_sync_stream
 from routers.api.sync.types import FetchedStack
 from routers.immich_models import SyncRequestType, SyncStreamDto
@@ -231,6 +234,20 @@ class TestStackEntityFetch:
 
         with pytest.raises(GumnutError):
             await fetch_entities_map(client, "stack", [good.id, bad.id])
+
+    @pytest.mark.anyio
+    async def test_empty_read_contradicting_asset_count_propagates(self):
+        # The row claims members but the state="all" read comes back empty — a
+        # transient contradiction, not a member-less stack (a member-less stack
+        # reports asset_count 0). It must propagate to retry, not skip, or the
+        # stack's members strand as a hidden burst.
+        stack = make_gumnut_stack(asset_count=2)
+        client = Mock()
+        client.stacks.list_stacks = mock_list_stacks([stack])
+        client.assets.list = _assets_list(members_by_stack={stack.id: []})
+
+        with pytest.raises(StackMemberReadInconsistent):
+            await fetch_entities_map(client, "stack", [stack.id])
 
     @pytest.mark.anyio
     async def test_undecodable_stack_id_skips_only_that_stack(self, caplog):

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -1,13 +1,7 @@
-"""Tests for Immich mobile stack-snapshot sync.
-
-Two behaviors ship together here:
-
-- The sync asset converters carry each asset's ``stackId`` (V1 and V2), so a
-  stacked asset names the stack row it belongs to; loose assets stay null.
-- ``StacksV1`` streams a *current-state snapshot* of ``StackV1`` rows on reset /
-  first sync only. There is no Gumnut stack event source yet, so an
-  already-synced client (checkpoint present) receives nothing — incremental
-  create/update/delete support is intentionally out of scope.
+"""Tests for Immich mobile stack-snapshot sync: the asset ``stackId`` mapping and
+the ``StacksV1`` upsert pass. The delivery semantics and scope boundary these
+tests pin live in the "Stack Snapshot (StacksV1)" section of
+``docs/architecture/sync-stream-architecture.md``.
 """
 
 import json
@@ -15,6 +9,7 @@ from datetime import datetime, timezone
 from unittest.mock import Mock
 
 import pytest
+from gumnut import GumnutError
 
 from routers.api.sync.converters import (
     gumnut_asset_to_sync_asset_v1,
@@ -49,7 +44,8 @@ def _stacks_page(*stacks):
 
     The snapshot pages with ``limit=`` and no ``ids`` filter, so — unlike the
     REST ``mock_list_stacks`` helper — this ignores kwargs and replays the full
-    page in the order given, which is the order the snapshot must preserve.
+    page in the order given. ``_stream_stacks`` then re-sorts by ``(updated_at,
+    id)``, so passing rows out of order here exercises that ordering.
     """
     return Mock(return_value=MockSyncCursorPage(list(stacks)))
 
@@ -61,11 +57,6 @@ def _members_by_stack(mapping):
             mapping.get(kwargs.get("stack_id"), [])
         )
     )
-
-
-async def _collect(gen):
-    """Collect an async generator of JSON lines into parsed dicts."""
-    return [json.loads(line) async for line in gen]
 
 
 # --- Asset stackId conversion --------------------------------------------------
@@ -140,24 +131,94 @@ class TestStackConverter:
 # --- Stack snapshot streaming (_stream_stacks) ---------------------------------
 
 
+def _stack_cursor(stack):
+    """The inner ack cursor `_stream_stacks` assigns a stack (no `StackV1|…|` wrapper).
+
+    This is exactly what `_parse_ack` stores as `Checkpoint.cursor`, so a test
+    can build a checkpoint that sits at a known stack's position.
+    """
+    return f"{stack.updated_at.isoformat()}_{stack.id}"
+
+
 class TestStreamStacks:
-    """The StacksV1 snapshot pass: reset-only, effective-primary, zero-member skip."""
+    """The StacksV1 upsert pass: (updated_at, id) order, checkpoint filter,
+    effective-primary, zero-member skip, undecodable-id degrade."""
 
     @pytest.mark.anyio
-    async def test_existing_checkpoint_emits_nothing(self):
-        """A present checkpoint means the client already holds the snapshot —
-        emit no speculative updates and don't even page the stacks."""
-        client = create_mock_gumnut_client(create_mock_user(datetime.now(timezone.utc)))
+    async def test_checkpoint_at_or_after_all_stacks_emits_nothing(self):
+        """A checkpoint at/after every current stack's cursor yields no rows —
+        the client is fully caught up. The pass still re-pages (there is no
+        lifecycle event stream, so every sync must scan for newer stacks)."""
+        stack, members = make_gumnut_stack_with_members(count=2)
+        client = Mock()
+        client.stacks.list_stacks = _stacks_page(stack)
+        client.assets.list = _members_by_stack({stack.id: members})
         checkpoint = Checkpoint(
             entity_type=SyncEntityType.StackV1,
-            updated_at=datetime.now(timezone.utc),
-            cursor="StackV1|already-synced",
+            updated_at=stack.updated_at,
+            cursor=_stack_cursor(stack),  # exactly at the only stack
         )
 
-        lines = await _collect(_stream_stacks(client, TEST_UUID, checkpoint))
+        lines = await collect_stream(_stream_stacks(client, TEST_UUID, checkpoint))
 
         assert lines == []
-        client.stacks.list_stacks.assert_not_called()
+        client.stacks.list_stacks.assert_called_once()  # re-paged, not suppressed
+        # The checkpoint filter runs before hydrate_stack, so a caught-up client
+        # pays zero per-stack member fetches. Locks that ordering in.
+        client.assets.list.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_checkpoint_emits_only_stacks_after_its_cursor(self):
+        """Incremental upsert (and, by the same mechanism, resume after a
+        truncated snapshot): a checkpoint at stack_a's cursor emits only stack_b,
+        so a burst created after the initial sync reaches the client instead of
+        leaving its assets pointing at a stack row the client never received."""
+        stack_a, members_a = make_gumnut_stack_with_members(count=2)
+        stack_a.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        stack_b, members_b = make_gumnut_stack_with_members(count=2)
+        stack_b.updated_at = datetime(2025, 2, 2, tzinfo=timezone.utc)
+        client = Mock()
+        client.stacks.list_stacks = _stacks_page(stack_a, stack_b)
+        client.assets.list = _members_by_stack(
+            {stack_a.id: members_a, stack_b.id: members_b}
+        )
+        checkpoint = Checkpoint(
+            entity_type=SyncEntityType.StackV1,
+            updated_at=stack_a.updated_at,
+            cursor=_stack_cursor(stack_a),
+        )
+
+        lines = await collect_stream(_stream_stacks(client, TEST_UUID, checkpoint))
+
+        assert [line["data"]["id"] for line in lines] == [
+            str(safe_uuid_from_stack_id(stack_b.id))
+        ]
+
+    @pytest.mark.anyio
+    async def test_undecodable_stack_id_skipped_without_aborting(self, caplog):
+        """An undecodable stack id (a systemic prefix change) must not truncate
+        the stream — skip that stack, still emit the decodable ones, and log one
+        aggregated warning. Mirrors _immich_stack_id on the asset side."""
+        good, good_members = make_gumnut_stack_with_members(count=2)
+        good.updated_at = datetime(2025, 2, 2, tzinfo=timezone.utc)
+        bad, bad_members = make_gumnut_stack_with_members(
+            count=2, stack_id="not_a_valid_stack_prefix"
+        )
+        # Sorts before `good`, so the skip has to not abort the rest of the loop.
+        bad.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        client = Mock()
+        client.stacks.list_stacks = _stacks_page(good, bad)
+        client.assets.list = _members_by_stack(
+            {good.id: good_members, bad.id: bad_members}
+        )
+
+        with caplog.at_level("WARNING"):
+            lines = await collect_stream(_stream_stacks(client, TEST_UUID, None))
+
+        assert [line["data"]["id"] for line in lines] == [
+            str(safe_uuid_from_stack_id(good.id))
+        ]
+        assert any("undecodable" in record.message for record in caplog.records)
 
     @pytest.mark.anyio
     async def test_no_checkpoint_uses_pinned_primary(self):
@@ -168,7 +229,7 @@ class TestStreamStacks:
         client.stacks.list_stacks = _stacks_page(stack)
         client.assets.list = _members_by_stack({stack.id: members})
 
-        lines = await _collect(_stream_stacks(client, TEST_UUID, None))
+        lines = await collect_stream(_stream_stacks(client, TEST_UUID, None))
 
         assert len(lines) == 1
         assert lines[0]["type"] == "StackV1"
@@ -187,7 +248,7 @@ class TestStreamStacks:
         client.stacks.list_stacks = _stacks_page(stack)
         client.assets.list = _members_by_stack({stack.id: members})
 
-        lines = await _collect(_stream_stacks(client, TEST_UUID, None))
+        lines = await collect_stream(_stream_stacks(client, TEST_UUID, None))
 
         assert lines[0]["data"]["primaryAssetId"] == str(
             safe_uuid_from_asset_id(members[0].id)
@@ -203,22 +264,23 @@ class TestStreamStacks:
         client.assets.list = _members_by_stack({stack.id: []})
 
         with caplog.at_level("WARNING"):
-            lines = await _collect(_stream_stacks(client, TEST_UUID, None))
+            lines = await collect_stream(_stream_stacks(client, TEST_UUID, None))
 
         assert lines == []
         assert any("no members" in record.message for record in caplog.records)
 
     @pytest.mark.anyio
     async def test_multiple_stacks_stream_in_order_with_deterministic_acks(self):
-        """Every stack streams in page order, each with a stable updated_at+id ack,
-        so a reset replays deterministically."""
+        """Stacks stream in (updated_at, id) order regardless of page order, each
+        with a stable updated_at+id ack, so the ack cursor advances monotonically
+        and a reset replays deterministically. Fed newest-first to prove the sort."""
         stack_a, members_a = make_gumnut_stack_with_members(count=2)
         stack_a.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
         stack_b, members_b = make_gumnut_stack_with_members(count=2)
         stack_b.updated_at = datetime(2025, 2, 2, tzinfo=timezone.utc)
 
         client = Mock()
-        client.stacks.list_stacks = _stacks_page(stack_a, stack_b)
+        client.stacks.list_stacks = _stacks_page(stack_b, stack_a)  # out of order
         client.assets.list = _members_by_stack(
             {stack_a.id: members_a, stack_b.id: members_b}
         )
@@ -238,6 +300,33 @@ class TestStreamStacks:
         assert lines[1][0]["ack"] == (
             f"StackV1|{stack_b.updated_at.isoformat()}_{stack_b.id}|"
         )
+
+    @pytest.mark.anyio
+    async def test_checkpoint_tiebreak_on_id_at_equal_updated_at(self):
+        """When two stacks share an updated_at, the id breaks the tie in both the
+        sort key and the cursor comparison. A checkpoint at the lower id emits
+        only the higher one — so the string cursor and the (updated_at, id) sort
+        can't disagree at the same-instant boundary."""
+        shared = datetime(2025, 3, 3, tzinfo=timezone.utc)
+        s1, m1 = make_gumnut_stack_with_members(count=2)
+        s2, m2 = make_gumnut_stack_with_members(count=2)
+        s1.updated_at = s2.updated_at = shared
+        # Designate low/high by actual (shortuuid-encoded) id order.
+        low, high = sorted([s1, s2], key=lambda s: s.id)
+        client = Mock()
+        client.stacks.list_stacks = _stacks_page(high, low)  # out of order
+        client.assets.list = _members_by_stack({s1.id: m1, s2.id: m2})
+        checkpoint = Checkpoint(
+            entity_type=SyncEntityType.StackV1,
+            updated_at=shared,
+            cursor=_stack_cursor(low),
+        )
+
+        lines = await collect_stream(_stream_stacks(client, TEST_UUID, checkpoint))
+
+        assert [line["data"]["id"] for line in lines] == [
+            str(safe_uuid_from_stack_id(high.id))
+        ]
 
 
 # --- Snapshot ordering within the full stream ----------------------------------
@@ -289,18 +378,21 @@ class TestSnapshotOrdering:
         assert events[-1]["type"] == "SyncCompleteV1"
 
     @pytest.mark.anyio
-    async def test_existing_stack_checkpoint_streams_no_stacks(self):
-        """With a StackV1 checkpoint, the full stream emits no StackV1 rows."""
+    async def test_caught_up_stack_checkpoint_streams_no_stacks(self):
+        """With a StackV1 checkpoint at/after the only stack, the full stream
+        emits no StackV1 rows (the client is caught up). The pass still pages —
+        it must scan for stacks newer than the checkpoint."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         user = create_mock_user(updated_at)
         client = create_mock_gumnut_client(user)
-        client.stacks.list_stacks = _stacks_page(make_gumnut_stack())
+        stack = make_gumnut_stack()
+        client.stacks.list_stacks = _stacks_page(stack)
 
         checkpoint_map = {
             SyncEntityType.StackV1: Checkpoint(
                 entity_type=SyncEntityType.StackV1,
-                updated_at=updated_at,
-                cursor="StackV1|synced",
+                updated_at=stack.updated_at,
+                cursor=_stack_cursor(stack),
             )
         }
         request = SyncStreamDto(types=[SyncRequestType.StacksV1])
@@ -310,7 +402,54 @@ class TestSnapshotOrdering:
         )
 
         assert [e["type"] for e in events] == ["SyncCompleteV1"]
-        client.stacks.list_stacks.assert_not_called()
+        client.stacks.list_stacks.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_stack_hydration_error_does_not_truncate_sync(self, caplog):
+        """A GumnutError while hydrating a stack ends the snapshot pass gracefully
+        — the asset loop still runs and the stream still completes — rather than
+        truncating the whole sync (the pass runs before the asset loop)."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        user = create_mock_user(updated_at)
+        client = create_mock_gumnut_client(user)
+        stack, members = make_gumnut_stack_with_members(count=1)
+        asset = members[0]
+
+        client.events.get.return_value = create_mock_events_response(
+            [
+                create_mock_event(
+                    entity_type="asset",
+                    entity_id=asset.id,
+                    event_type="asset_created",
+                    created_at=updated_at,
+                    cursor="cursor_asset_1",
+                )
+            ]
+        )
+        client.stacks.list_stacks = _stacks_page(stack)
+
+        def assets_list(**kwargs):
+            # The member fetch (stack_id=) fails; the asset entity fetch (ids=)
+            # succeeds, so we can prove the asset loop still ran.
+            if "stack_id" in kwargs:
+                raise GumnutError("stack member fetch failed")
+            return MockSyncCursorPage([asset])
+
+        client.assets.list = Mock(side_effect=assets_list)
+
+        request = SyncStreamDto(
+            types=[SyncRequestType.StacksV1, SyncRequestType.AssetsV2]
+        )
+        with caplog.at_level("WARNING"):
+            events = await collect_stream(
+                generate_sync_stream(client, request, {}, user)
+            )
+
+        types = [e["type"] for e in events]
+        assert "StackV1" not in types  # the only stack failed to hydrate
+        assert "AssetV2" in types  # asset loop still ran this cycle
+        assert events[-1]["type"] == "SyncCompleteV1"  # completed, not truncated
+        assert any("cut short" in record.message for record in caplog.records)
 
     @pytest.mark.anyio
     async def test_partner_stacks_v1_is_silent_noop(self, caplog):
@@ -322,9 +461,8 @@ class TestSnapshotOrdering:
         client.stacks.list_stacks = _stacks_page(make_gumnut_stack())
 
         request = SyncStreamDto(types=[SyncRequestType.PartnerStacksV1])
-        import logging
 
-        with caplog.at_level(logging.INFO, logger="routers.api.sync.stream"):
+        with caplog.at_level("INFO", logger="routers.api.sync.stream"):
             events = await collect_stream(
                 generate_sync_stream(client, request, {}, user)
             )

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -1,8 +1,4 @@
-"""Tests for Immich mobile stack-snapshot sync: the asset ``stackId`` mapping and
-the ``StacksV1`` upsert pass. The delivery semantics and scope boundary these
-tests pin live in the "Stack Snapshot (StacksV1)" section of
-``docs/architecture/sync-stream-architecture.md``.
-"""
+"""Tests for stack membership and incremental StackV1 upserts."""
 
 import json
 from datetime import datetime, timezone
@@ -40,18 +36,12 @@ from tests.unit.api.sync.conftest import (
 
 
 def _stacks_page(*stacks):
-    """A ``client.stacks.list_stacks`` mock returning ``stacks`` on any call.
-
-    The snapshot pages with ``limit=`` and no ``ids`` filter, so — unlike the
-    REST ``mock_list_stacks`` helper — this ignores kwargs and replays the full
-    page in the order given. ``_stream_stacks`` then re-sorts by ``(updated_at,
-    id)``, so passing rows out of order here exercises that ordering.
-    """
+    """Return the given stacks for any list_stacks call."""
     return Mock(return_value=MockSyncCursorPage(list(stacks)))
 
 
 def _members_by_stack(mapping):
-    """A ``client.assets.list`` mock keyed by the ``stack_id`` hydrate_stack asks for."""
+    """Return members by stack_id."""
     return Mock(
         side_effect=lambda **kwargs: MockSyncCursorPage(
             mapping.get(kwargs.get("stack_id"), [])
@@ -59,12 +49,7 @@ def _members_by_stack(mapping):
     )
 
 
-# --- Asset stackId conversion --------------------------------------------------
-
-
 class TestAssetStackIdConversion:
-    """The sync asset converters map the Gumnut stack FK to Immich's stackId."""
-
     def test_v1_maps_stack_id_to_uuid_string(self):
         stack = make_gumnut_stack()
         asset = make_gumnut_asset(stack_id=stack.id)
@@ -79,7 +64,6 @@ class TestAssetStackIdConversion:
         assert gumnut_asset_to_sync_asset_v1(asset, TEST_UUID).stackId is None
 
     def test_v2_inherits_stack_id(self):
-        """V2 delegates to V1, so it carries the same stackId."""
         stack = make_gumnut_stack()
         asset = make_gumnut_asset(stack_id=stack.id)
 
@@ -93,9 +77,6 @@ class TestAssetStackIdConversion:
         assert gumnut_asset_to_sync_asset_v2(asset, TEST_UUID).stackId is None
 
     def test_undecodable_stack_id_degrades_to_loose_without_raising(self, caplog):
-        """A malformed stack_id (e.g. a backend prefix change) must not abort the
-        sync stream — the asset syncs as loose, with only a debug log (a prefix
-        break is systemic; a per-asset warning would flood the sync)."""
         asset = make_gumnut_asset(stack_id="not_a_valid_stack_prefix")
 
         with caplog.at_level("DEBUG"):
@@ -105,12 +86,7 @@ class TestAssetStackIdConversion:
         assert any("not decodable" in record.message for record in caplog.records)
 
 
-# --- Stack converter -----------------------------------------------------------
-
-
 class TestStackConverter:
-    """gumnut_stack_to_sync_stack_v1 maps a stack row + resolved primary."""
-
     def test_maps_all_fields(self):
         created = datetime(2025, 1, 1, tzinfo=timezone.utc)
         updated = datetime(2025, 2, 2, tzinfo=timezone.utc)
@@ -128,27 +104,14 @@ class TestStackConverter:
         assert sync.updatedAt == updated
 
 
-# --- Stack snapshot streaming (_stream_stacks) ---------------------------------
-
-
 def _stack_cursor(stack):
-    """The inner ack cursor `_stream_stacks` assigns a stack (no `StackV1|…|` wrapper).
-
-    This is exactly what `_parse_ack` stores as `Checkpoint.cursor`, so a test
-    can build a checkpoint that sits at a known stack's position.
-    """
+    """Return the checkpoint cursor for a stack."""
     return f"{stack.updated_at.isoformat()}_{stack.id}"
 
 
 class TestStreamStacks:
-    """The StacksV1 upsert pass: (updated_at, id) order, checkpoint filter,
-    effective-primary, zero-member skip, undecodable-id degrade."""
-
     @pytest.mark.anyio
     async def test_checkpoint_at_or_after_all_stacks_emits_nothing(self):
-        """A checkpoint at/after every current stack's cursor yields no rows —
-        the client is fully caught up. The pass still re-pages (there is no
-        lifecycle event stream, so every sync must scan for newer stacks)."""
         stack, members = make_gumnut_stack_with_members(count=2)
         client = Mock()
         client.stacks.list_stacks = _stacks_page(stack)
@@ -156,23 +119,17 @@ class TestStreamStacks:
         checkpoint = Checkpoint(
             entity_type=SyncEntityType.StackV1,
             updated_at=stack.updated_at,
-            cursor=_stack_cursor(stack),  # exactly at the only stack
+            cursor=_stack_cursor(stack),
         )
 
         lines = await collect_stream(_stream_stacks(client, TEST_UUID, checkpoint))
 
         assert lines == []
-        client.stacks.list_stacks.assert_called_once()  # re-paged, not suppressed
-        # The checkpoint filter runs before hydrate_stack, so a caught-up client
-        # pays zero per-stack member fetches. Locks that ordering in.
+        client.stacks.list_stacks.assert_called_once()
         client.assets.list.assert_not_called()
 
     @pytest.mark.anyio
     async def test_checkpoint_emits_only_stacks_after_its_cursor(self):
-        """Incremental upsert (and, by the same mechanism, resume after a
-        truncated snapshot): a checkpoint at stack_a's cursor emits only stack_b,
-        so a burst created after the initial sync reaches the client instead of
-        leaving its assets pointing at a stack row the client never received."""
         stack_a, members_a = make_gumnut_stack_with_members(count=2)
         stack_a.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
         stack_b, members_b = make_gumnut_stack_with_members(count=2)
@@ -196,15 +153,11 @@ class TestStreamStacks:
 
     @pytest.mark.anyio
     async def test_undecodable_stack_id_skipped_without_aborting(self, caplog):
-        """An undecodable stack id (a systemic prefix change) must not truncate
-        the stream — skip that stack, still emit the decodable ones, and log one
-        aggregated warning. Mirrors _immich_stack_id on the asset side."""
         good, good_members = make_gumnut_stack_with_members(count=2)
         good.updated_at = datetime(2025, 2, 2, tzinfo=timezone.utc)
         bad, bad_members = make_gumnut_stack_with_members(
             count=2, stack_id="not_a_valid_stack_prefix"
         )
-        # Sorts before `good`, so the skip has to not abort the rest of the loop.
         bad.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
         client = Mock()
         client.stacks.list_stacks = _stacks_page(good, bad)
@@ -222,9 +175,8 @@ class TestStreamStacks:
 
     @pytest.mark.anyio
     async def test_no_checkpoint_uses_pinned_primary(self):
-        """The effective primary honors a pinned cover (matching REST)."""
         stack, members = make_gumnut_stack_with_members(count=3)
-        stack.primary_asset_id = members[2].id  # user pinned the 3rd frame
+        stack.primary_asset_id = members[2].id
         client = Mock()
         client.stacks.list_stacks = _stacks_page(stack)
         client.assets.list = _members_by_stack({stack.id: members})
@@ -240,9 +192,7 @@ class TestStreamStacks:
 
     @pytest.mark.anyio
     async def test_no_checkpoint_synthesizes_primary_for_unpinned_burst(self):
-        """An unpinned burst has no server cover, so the snapshot synthesizes one:
-        the first live frame (fetch_stack_members pins ascending order)."""
-        stack, members = make_gumnut_stack_with_members(count=3)  # unpinned auto_burst
+        stack, members = make_gumnut_stack_with_members(count=3)
         assert stack.primary_asset_id is None
         client = Mock()
         client.stacks.list_stacks = _stacks_page(stack)
@@ -256,8 +206,6 @@ class TestStreamStacks:
 
     @pytest.mark.anyio
     async def test_zero_member_stack_skipped_with_warning(self, caplog):
-        """A member-less stack has no honest required primary — skip it, don't
-        emit an invalid row. hydrate_stack logs the warning."""
         stack = make_gumnut_stack(asset_count=0)
         client = Mock()
         client.stacks.list_stacks = _stacks_page(stack)
@@ -271,16 +219,13 @@ class TestStreamStacks:
 
     @pytest.mark.anyio
     async def test_multiple_stacks_stream_in_order_with_deterministic_acks(self):
-        """Stacks stream in (updated_at, id) order regardless of page order, each
-        with a stable updated_at+id ack, so the ack cursor advances monotonically
-        and a reset replays deterministically. Fed newest-first to prove the sort."""
         stack_a, members_a = make_gumnut_stack_with_members(count=2)
         stack_a.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
         stack_b, members_b = make_gumnut_stack_with_members(count=2)
         stack_b.updated_at = datetime(2025, 2, 2, tzinfo=timezone.utc)
 
         client = Mock()
-        client.stacks.list_stacks = _stacks_page(stack_b, stack_a)  # out of order
+        client.stacks.list_stacks = _stacks_page(stack_b, stack_a)
         client.assets.list = _members_by_stack(
             {stack_a.id: members_a, stack_b.id: members_b}
         )
@@ -303,18 +248,13 @@ class TestStreamStacks:
 
     @pytest.mark.anyio
     async def test_checkpoint_tiebreak_on_id_at_equal_updated_at(self):
-        """When two stacks share an updated_at, the id breaks the tie in both the
-        sort key and the cursor comparison. A checkpoint at the lower id emits
-        only the higher one — so the string cursor and the (updated_at, id) sort
-        can't disagree at the same-instant boundary."""
         shared = datetime(2025, 3, 3, tzinfo=timezone.utc)
         s1, m1 = make_gumnut_stack_with_members(count=2)
         s2, m2 = make_gumnut_stack_with_members(count=2)
         s1.updated_at = s2.updated_at = shared
-        # Designate low/high by actual (shortuuid-encoded) id order.
         low, high = sorted([s1, s2], key=lambda s: s.id)
         client = Mock()
-        client.stacks.list_stacks = _stacks_page(high, low)  # out of order
+        client.stacks.list_stacks = _stacks_page(high, low)
         client.assets.list = _members_by_stack({s1.id: m1, s2.id: m2})
         checkpoint = Checkpoint(
             entity_type=SyncEntityType.StackV1,
@@ -329,12 +269,7 @@ class TestStreamStacks:
         ]
 
 
-# --- Snapshot ordering within the full stream ----------------------------------
-
-
 class TestSnapshotOrdering:
-    """StackV1 must precede the assets that name it, and the stream still completes."""
-
     @pytest.mark.anyio
     async def test_stack_streamed_before_its_stacked_asset(self):
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
@@ -342,7 +277,7 @@ class TestSnapshotOrdering:
         client = create_mock_gumnut_client(user)
 
         stack, members = make_gumnut_stack_with_members(count=1)
-        asset = members[0]  # the lone member, so it is also the effective primary
+        asset = members[0]
 
         client.events.get.return_value = create_mock_events_response(
             [
@@ -355,8 +290,7 @@ class TestSnapshotOrdering:
                 )
             ]
         )
-        # assets.list serves both the sync entity fetch (ids=) and the stack
-        # member fetch (stack_id=); the same stacked asset satisfies each.
+        # Serve both the entity fetch (ids=) and stack hydration (stack_id=).
         client.assets.list = Mock(
             side_effect=lambda **kwargs: MockSyncCursorPage([asset])
         )
@@ -372,16 +306,12 @@ class TestSnapshotOrdering:
 
         stack_event = next(e for e in events if e["type"] == "StackV1")
         asset_event = next(e for e in events if e["type"] == "AssetV2")
-        # The asset points at exactly the stack row that preceded it.
         assert asset_event["data"]["stackId"] == str(safe_uuid_from_stack_id(stack.id))
         assert asset_event["data"]["stackId"] == stack_event["data"]["id"]
         assert events[-1]["type"] == "SyncCompleteV1"
 
     @pytest.mark.anyio
     async def test_caught_up_stack_checkpoint_streams_no_stacks(self):
-        """With a StackV1 checkpoint at/after the only stack, the full stream
-        emits no StackV1 rows (the client is caught up). The pass still pages —
-        it must scan for stacks newer than the checkpoint."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         user = create_mock_user(updated_at)
         client = create_mock_gumnut_client(user)
@@ -406,9 +336,6 @@ class TestSnapshotOrdering:
 
     @pytest.mark.anyio
     async def test_stack_hydration_error_does_not_truncate_sync(self, caplog):
-        """A GumnutError while hydrating a stack ends the snapshot pass gracefully
-        — the asset loop still runs and the stream still completes — rather than
-        truncating the whole sync (the pass runs before the asset loop)."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         user = create_mock_user(updated_at)
         client = create_mock_gumnut_client(user)
@@ -429,8 +356,7 @@ class TestSnapshotOrdering:
         client.stacks.list_stacks = _stacks_page(stack)
 
         def assets_list(**kwargs):
-            # The member fetch (stack_id=) fails; the asset entity fetch (ids=)
-            # succeeds, so we can prove the asset loop still ran.
+            # Fail stack hydration but allow the later asset fetch.
             if "stack_id" in kwargs:
                 raise GumnutError("stack member fetch failed")
             return MockSyncCursorPage([asset])
@@ -446,15 +372,13 @@ class TestSnapshotOrdering:
             )
 
         types = [e["type"] for e in events]
-        assert "StackV1" not in types  # the only stack failed to hydrate
-        assert "AssetV2" in types  # asset loop still ran this cycle
-        assert events[-1]["type"] == "SyncCompleteV1"  # completed, not truncated
+        assert "StackV1" not in types
+        assert "AssetV2" in types
+        assert events[-1]["type"] == "SyncCompleteV1"
         assert any("cut short" in record.message for record in caplog.records)
 
     @pytest.mark.anyio
     async def test_partner_stacks_v1_is_silent_noop(self, caplog):
-        """PartnerStacksV1 stays an intentional no-op: no rows, no 'unsupported'
-        warning, and it never triggers the stack snapshot."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         user = create_mock_user(updated_at)
         client = create_mock_gumnut_client(user)

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -242,6 +242,35 @@ class TestStackEntityFetch:
             for record in caplog.records
         )
 
+    @pytest.mark.anyio
+    async def test_undecodable_stack_id_skips_only_that_stack(self, caplog):
+        # An undecodable stack id (prefix drift) must degrade to a skip, not
+        # raise out of the first sync pass and truncate everything. The decode
+        # is guarded before hydration; the sibling stack still resolves.
+        good, good_members = make_gumnut_stack_with_members(count=2)
+        good.primary_asset_id = good_members[0].id
+        bad, bad_members = make_gumnut_stack_with_members(
+            count=2, stack_id="not_a_valid_stack_prefix"
+        )
+        client = Mock()
+        client.stacks.list_stacks = mock_list_stacks([good, bad])
+        client.assets.list = _assets_list(
+            members_by_stack={good.id: good_members, bad.id: bad_members}
+        )
+
+        with caplog.at_level("WARNING"):
+            result, missing = await fetch_entities_map(
+                client, "stack", [good.id, bad.id]
+            )
+
+        assert isinstance(result.get(good.id), FetchedStack)
+        assert bad.id in missing
+        assert bad.id not in result
+        assert any(
+            "undecodable stack id" in record.message.lower()
+            for record in caplog.records
+        )
+
 
 class TestEventDrivenStacks:
     """Stacks flow through generate_sync_stream on the shared event-cursor path."""
@@ -464,3 +493,27 @@ class TestEventDrivenStacks:
             "unsupported" in record.message.lower() for record in caplog.records
         )
         client.stacks.list_stacks.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_undecodable_stack_deleted_event_is_skipped(self, caplog):
+        # A stack_deleted with an undecodable id must skip, not truncate the
+        # sync (stacks are the first pass, so an unguarded decode would take
+        # every later pass and SyncCompleteV1 with it).
+        user = create_mock_user(UPDATED_AT)
+        client = create_mock_gumnut_client(user)
+        client.events.get.return_value = create_mock_events_response(
+            [
+                create_mock_event(
+                    "stack", "not_a_valid_stack_prefix", "stack_deleted", UPDATED_AT
+                )
+            ]
+        )
+
+        request = SyncStreamDto(types=[SyncRequestType.StacksV1])
+        with caplog.at_level("WARNING"):
+            events = await collect_stream(
+                generate_sync_stream(client, request, {}, user)
+            )
+
+        assert not any(e["type"] == "StackDeleteV1" for e in events)
+        assert events[-1]["type"] == "SyncCompleteV1"

--- a/tests/unit/api/sync/test_sync_v2.py
+++ b/tests/unit/api/sync/test_sync_v2.py
@@ -228,7 +228,7 @@ def test_album_user_converter_sets_owner_role():
 def test_requested_empty_v3_types_are_explicit_noops():
     """Every v3 type the client requests but the adapter has no data for is an
     explicit no-op (so it is not logged "unsupported" on every sync). Excludes
-    UserMetadataV1, which is emitted, not a no-op."""
+    UserMetadataV1 and StacksV1, which are emitted, not no-ops."""
     empty_requested = {
         SyncRequestType.AssetMetadataV1,
         SyncRequestType.PartnersV1,
@@ -237,7 +237,6 @@ def test_requested_empty_v3_types_are_explicit_noops():
         SyncRequestType.AlbumAssetExifsV1,
         SyncRequestType.MemoriesV1,
         SyncRequestType.MemoryToAssetsV1,
-        SyncRequestType.StacksV1,
     }
     assert empty_requested <= set(_NOOP_REQUEST_TYPES)
     assert empty_requested <= _SUPPORTED_REQUEST_TYPES
@@ -247,6 +246,11 @@ def test_requested_empty_v3_types_are_explicit_noops():
     # UserMetadataV1 is emitted, so it must NOT be a no-op, but still supported.
     assert SyncRequestType.UserMetadataV1 not in _NOOP_REQUEST_TYPES
     assert SyncRequestType.UserMetadataV1 in _SUPPORTED_REQUEST_TYPES
+    # StacksV1 became a current-state snapshot (see _stream_stacks): supported,
+    # emitted, and therefore no longer a no-op. PartnerStacksV1 stays a no-op.
+    assert SyncRequestType.StacksV1 not in _NOOP_REQUEST_TYPES
+    assert SyncRequestType.StacksV1 in _SUPPORTED_REQUEST_TYPES
+    assert SyncRequestType.PartnerStacksV1 in _NOOP_REQUEST_TYPES
 
 
 # --- UserMetadataV1 preferences (minimumFaces override) ------------------------

--- a/tests/unit/api/sync/test_sync_v2.py
+++ b/tests/unit/api/sync/test_sync_v2.py
@@ -246,8 +246,6 @@ def test_requested_empty_v3_types_are_explicit_noops():
     # UserMetadataV1 is emitted, so it must NOT be a no-op, but still supported.
     assert SyncRequestType.UserMetadataV1 not in _NOOP_REQUEST_TYPES
     assert SyncRequestType.UserMetadataV1 in _SUPPORTED_REQUEST_TYPES
-    # StacksV1 became a current-state snapshot (see _stream_stacks): supported,
-    # emitted, and therefore no longer a no-op. PartnerStacksV1 stays a no-op.
     assert SyncRequestType.StacksV1 not in _NOOP_REQUEST_TYPES
     assert SyncRequestType.StacksV1 in _SUPPORTED_REQUEST_TYPES
     assert SyncRequestType.PartnerStacksV1 in _NOOP_REQUEST_TYPES


### PR DESCRIPTION
## Summary

Replace the per-sync full-table stack snapshot with cursor-driven `StacksV1` events. Immich clients now receive stack upserts and deletes as deltas, while synced assets carry their stack membership in both V1 and V2 formats.

## Behavior

- Stream stack upserts before member assets so the mobile timeline never sees an asset reference an unknown stack. Buffer `StackDeleteV1` until after asset deletes and membership-clearing updates.
- Apply the event payload `stack_id` to asset updates, preserving membership at the sync cutoff when an asset moves again during hydration.
- Resolve the required `primaryAssetId` with lean, short-circuit member queries: pinned member, first live member, then first all-state member for an all-trashed stack. Reads are concurrency-bounded and queued siblings are cancelled after a failure.
- Treat an empty all-state member read as retryable even when `asset_count` is zero, because the count excludes trashed members. The stream ends without `SyncCompleteV1`, leaving the cursor unacknowledged for retry.
- Degrade undecodable stack IDs to loose assets without truncating the stream.

The Gumnut API contract supplies stack lifecycle events and emits `asset_updated` events before `stack_deleted` when a stack dissolves.

## Documentation

The sync architecture now records the visibility, retry, primary-selection, cutoff, and dissolve contracts. The active gap analysis marks mobile stack sync closed, and streaming-error guidance is cursor- and dependency-aware.

## Test plan

- `uv run ruff format`
- `uv run ruff check`
- `uv run pyright`
- `uv run pytest` — 1,689 passed
- `uv run scripts/lint_docs.py`

Generated by an AI coding agent.