### PR TITLE
Emit on_asset_stack_update on stack mutations

### DIFF
--- a/docs/references/websocket-events-reference.md
+++ b/docs/references/websocket-events-reference.md
@@ -1,6 +1,6 @@
 ---
 title: "Immich WebSocket Events Reference"
-last-updated: 2026-07-31
+last-updated: 2026-08-12
 ---
 
 # Immich WebSocket Events Reference
@@ -110,8 +110,19 @@ Otherwise as in the Summary Table; emitted from `notification.service.ts`, and t
 ### `on_asset_stack_update`
 
 **Sent to**: Stack owner (by userId)
+**Payload**: none — the event carries no data (see below)
 
-Otherwise as in the Summary Table; emitted from `notification.service.ts`. The adapter omits it because no web or mobile handler subscribes; see `../architecture/websocket-implementation.md`.
+**Trigger**:
+- **Upstream Immich**: emitted from `notification.service.ts` on `StackCreate`, `StackUpdate`, `StackDelete`, and `StackDeleteAll`.
+- **immich-adapter**: emitted from the five mutating stack routes in `routers/api/stacks.py`, one emit per successful mutation — `create_stack`, `update_stack` (only when the cover actually changes; a cover-less PUT is a pure read and emits nothing), `remove_asset_from_stack`, `delete_stack`, and `delete_stacks` (a single emit after a clean bulk dissolve). All are scoped to the owning user's room.
+
+**Payload shape**: none. Upstream calls `clientSend('on_asset_stack_update', userId)` with no data argument — the repository type `on_asset_stack_update: string[]` is a rest-param (`...data: string[]`) that spreads to zero args, not an id array. The adapter therefore emits with `payload=None` via `emit_user_event`, never `emit_user_event_per_id`.
+
+**Client handling**:
+- **Web**: Declared in the `Events` type map but **not subscribed** — no `.on('on_asset_stack_update', …)` handler is registered.
+- **Mobile**: Not referenced.
+
+**Note**: Because no current Immich client subscribes, this emission is upstream-parity / forward-compat rather than an immediate UI trigger. The durable convergence path for stack changes is the event-driven sync stream, not this hint.
 
 ---
 

--- a/routers/api/stacks.py
+++ b/routers/api/stacks.py
@@ -15,7 +15,7 @@ from routers.immich_models import (
     UserResponseDto,
 )
 from routers.utils.concurrency import gather_with_concurrency
-from routers.utils.current_user import get_current_user
+from routers.utils.current_user import get_current_user, get_current_user_id
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
 from routers.utils.gumnut_id_conversion import (
     uuid_to_gumnut_asset_id,
@@ -27,6 +27,7 @@ from routers.utils.stack_conversion import (
     hydrate_stack,
     hydrate_stacks,
 )
+from services.websockets import WebSocketEvent, emit_user_event
 
 logger = logging.getLogger(__name__)
 
@@ -224,6 +225,7 @@ async def search_stacks(
 async def delete_stacks(
     request: BulkIdsDto,
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
+    current_user_id: UUID = Depends(get_current_user_id),
 ):
     """Dissolve every stack in the bulk id list; the photos are untouched.
 
@@ -264,6 +266,11 @@ async def delete_stacks(
             extra={"failed": len(failures), "requested": len(gumnut_stack_ids)},
         )
         raise failures[0]
+
+    # One realtime hint for the whole clean batch (upstream StackDeleteAll ->
+    # a single on_asset_stack_update). A partial batch raises above without
+    # emitting; the client reconciles through the sync stream regardless.
+    await emit_user_event(WebSocketEvent.STACK_UPDATE, current_user_id)
     return
 
 
@@ -289,6 +296,12 @@ async def create_stack(
         asset_ids=gumnut_asset_ids,
         primary_asset_id=gumnut_asset_ids[0],
     )
+
+    # Best-effort realtime hint that the caller's stacks changed (upstream
+    # StackCreate -> on_asset_stack_update). Fire-and-forget after the mutation
+    # committed; emit_user_event swallows transport errors so a WS hiccup can't
+    # fail a stack that the backend already created.
+    await emit_user_event(WebSocketEvent.STACK_UPDATE, current_user.id)
 
     hydrated = await hydrate_stack(client, stack)
     if hydrated is None:
@@ -348,12 +361,17 @@ async def update_stack(
     gumnut_stack_id = uuid_to_gumnut_stack_id(id)
 
     if request.primaryAssetId is None:
+        # A cover-less PUT is a pure read — no backend mutation — so no event is
+        # emitted here. Upstream's update() emits unconditionally, but signalling
+        # "stack updated" when nothing changed would be misleading noise.
         stack = await client.stacks.retrieve_stack(gumnut_stack_id)
     else:
         stack = await client.stacks.set_cover(
             gumnut_stack_id,
             primary_asset_id=uuid_to_gumnut_asset_id(request.primaryAssetId),
         )
+        # Cover actually changed (upstream StackUpdate -> on_asset_stack_update).
+        await emit_user_event(WebSocketEvent.STACK_UPDATE, current_user.id)
 
     hydrated = await hydrate_stack(client, stack)
     response = _build_representable_response(hydrated, current_user)
@@ -368,6 +386,7 @@ async def update_stack(
 async def delete_stack(
     id: UUID,
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
+    current_user_id: UUID = Depends(get_current_user_id),
 ):
     """Dissolve one stack; only the grouping is removed, the photos are not.
 
@@ -375,6 +394,9 @@ async def delete_stack(
     as it does from `get_stack`.
     """
     await client.stacks.delete(uuid_to_gumnut_stack_id(id))
+    # Realtime hint that the stack dissolved (upstream StackDelete ->
+    # on_asset_stack_update).
+    await emit_user_event(WebSocketEvent.STACK_UPDATE, current_user_id)
     return
 
 
@@ -383,6 +405,7 @@ async def remove_asset_from_stack(
     id: UUID,
     assetId: UUID,
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
+    current_user_id: UUID = Depends(get_current_user_id),
 ):
     """Remove one asset from a stack, leaving the asset itself untouched.
 
@@ -395,4 +418,8 @@ async def remove_asset_from_stack(
         uuid_to_gumnut_stack_id(id),
         asset_ids=[uuid_to_gumnut_asset_id(assetId)],
     )
+    # Membership changed (upstream removeAsset -> StackUpdate ->
+    # on_asset_stack_update); a below-two-members dissolve is covered by the
+    # same hint.
+    await emit_user_event(WebSocketEvent.STACK_UPDATE, current_user_id)
     return

--- a/services/websockets.py
+++ b/services/websockets.py
@@ -49,6 +49,13 @@ class WebSocketEvent(Enum):
     # type `(asset: AssetResponseDto) => void`). Web upserts the asset into the
     # timeline manager on receipt; mobile triggers a generic sync refresh.
     ASSET_UPDATE = "on_asset_update"
+    # Carries no payload. Upstream emits `clientSend("on_asset_stack_update",
+    # userId)` with no data arg — the repository type `on_asset_stack_update:
+    # string[]` is a rest-param that spreads to zero args, not an id array. So
+    # this is emitted with the default `payload=None` via emit_user_event, never
+    # emit_user_event_per_id. Emitted on stack create / cover change / dissolve /
+    # member removal, scoped to the owning user's room.
+    STACK_UPDATE = "on_asset_stack_update"
     SESSION_DELETE = "on_session_delete"
     SERVER_VERSION = "on_server_version"
 

--- a/tests/unit/api/test_stacks.py
+++ b/tests/unit/api/test_stacks.py
@@ -32,7 +32,6 @@ from routers.api.stacks import (
     update_stack,
 )
 from routers.immich_models import BulkIdsDto, StackCreateDto, StackUpdateDto
-from services.websockets import WebSocketEvent
 from routers.utils.concurrency import BULK_FANOUT_CONCURRENCY_LIMIT
 from routers.utils.current_user import get_current_user, get_current_user_id
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
@@ -42,6 +41,7 @@ from routers.utils.gumnut_id_conversion import (
     uuid_to_gumnut_asset_id,
     uuid_to_gumnut_stack_id,
 )
+from services.websockets import WebSocketEvent
 from tests.conftest import (
     MockPaginatedListing,
     MockSyncCursorPage,

--- a/tests/unit/api/test_stacks.py
+++ b/tests/unit/api/test_stacks.py
@@ -9,7 +9,7 @@ import asyncio
 import inspect
 import logging
 import math
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
 
 import pytest
@@ -32,8 +32,9 @@ from routers.api.stacks import (
     update_stack,
 )
 from routers.immich_models import BulkIdsDto, StackCreateDto, StackUpdateDto
+from services.websockets import WebSocketEvent
 from routers.utils.concurrency import BULK_FANOUT_CONCURRENCY_LIMIT
-from routers.utils.current_user import get_current_user
+from routers.utils.current_user import get_current_user, get_current_user_id
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
 from routers.utils.gumnut_id_conversion import (
     safe_uuid_from_asset_id,
@@ -919,19 +920,26 @@ def _removal_client() -> Mock:
     return client
 
 
-async def _delete_stack(client, stack_uuid):
-    return await delete_stack(id=stack_uuid, client=client)  # type: ignore[call-arg]
-
-
-async def _remove_asset(client, stack_uuid, asset_uuid):
-    return await remove_asset_from_stack(  # type: ignore[call-arg]
-        id=stack_uuid, assetId=asset_uuid, client=client
+async def _delete_stack(client, stack_uuid, current_user_id=None):
+    return await delete_stack(  # type: ignore[call-arg]
+        id=stack_uuid, client=client, current_user_id=current_user_id or uuid4()
     )
 
 
-async def _delete_stacks(client, stack_uuids):
+async def _remove_asset(client, stack_uuid, asset_uuid, current_user_id=None):
+    return await remove_asset_from_stack(  # type: ignore[call-arg]
+        id=stack_uuid,
+        assetId=asset_uuid,
+        client=client,
+        current_user_id=current_user_id or uuid4(),
+    )
+
+
+async def _delete_stacks(client, stack_uuids, current_user_id=None):
     return await delete_stacks(  # type: ignore[call-arg]
-        request=BulkIdsDto(ids=list(stack_uuids)), client=client
+        request=BulkIdsDto(ids=list(stack_uuids)),
+        client=client,
+        current_user_id=current_user_id or uuid4(),
     )
 
 
@@ -1141,6 +1149,120 @@ class TestDeleteStacks:
             await _delete_stacks(client, [uuid4(), uuid4()])
 
 
+class TestStackUpdateWebSocket:
+    """`on_asset_stack_update` emission from the mutating stack routes.
+
+    The event carries no payload (see `services/websockets.py`); these tests pin
+    that it fires once per successful mutation, targets the owning user's room,
+    and stays silent on the read-only PUT path. Emission is patched out so the
+    tests assert the call, not a live socket.
+    """
+
+    @staticmethod
+    def _patch_emit():
+        return patch("routers.api.stacks.emit_user_event", new_callable=AsyncMock)
+
+    @pytest.mark.anyio
+    async def test_create_emits_scoped_to_the_owner(self, mock_current_user):
+        stack, members = make_gumnut_stack_with_members(count=2)
+        client = _write_client(stack, members)
+
+        with self._patch_emit() as mock_emit:
+            await _create(client, mock_current_user, _member_uuids(members))
+
+        mock_emit.assert_awaited_once_with(
+            WebSocketEvent.STACK_UPDATE, mock_current_user.id
+        )
+
+    @pytest.mark.anyio
+    async def test_cover_change_emits(self, mock_current_user):
+        stack, members = make_gumnut_stack_with_members(count=2)
+        client = _write_client(stack, members)
+        stack_uuid = safe_uuid_from_stack_id(stack.id)
+        cover_uuid = safe_uuid_from_asset_id(members[0].id)
+
+        with self._patch_emit() as mock_emit:
+            await _update(
+                client, mock_current_user, stack_uuid, primaryAssetId=cover_uuid
+            )
+
+        mock_emit.assert_awaited_once_with(
+            WebSocketEvent.STACK_UPDATE, mock_current_user.id
+        )
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "body", [{}, {"primaryAssetId": None}], ids=["omitted", "explicit-null"]
+    )
+    async def test_cover_less_put_is_silent(self, mock_current_user, body):
+        """A cover-less PUT is a pure read, so it emits nothing — unlike upstream,
+        which emits `StackUpdate` unconditionally."""
+        stack, members = make_gumnut_stack_with_members(count=2)
+        stack.primary_asset_id = members[1].id
+        client = _write_client(stack, members)
+        stack_uuid = safe_uuid_from_stack_id(stack.id)
+
+        with self._patch_emit() as mock_emit:
+            await _update(client, mock_current_user, stack_uuid, **body)
+
+        mock_emit.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_delete_emits_scoped_to_the_owner(self):
+        client = _removal_client()
+        user_id = uuid4()
+
+        with self._patch_emit() as mock_emit:
+            await _delete_stack(client, uuid4(), current_user_id=user_id)
+
+        mock_emit.assert_awaited_once_with(WebSocketEvent.STACK_UPDATE, user_id)
+
+    @pytest.mark.anyio
+    async def test_remove_asset_emits_scoped_to_the_owner(self):
+        client = _removal_client()
+        user_id = uuid4()
+
+        with self._patch_emit() as mock_emit:
+            await _remove_asset(client, uuid4(), uuid4(), current_user_id=user_id)
+
+        mock_emit.assert_awaited_once_with(WebSocketEvent.STACK_UPDATE, user_id)
+
+    @pytest.mark.anyio
+    async def test_clean_bulk_dissolve_emits_once(self):
+        client = _removal_client()
+        user_id = uuid4()
+
+        with self._patch_emit() as mock_emit:
+            await _delete_stacks(
+                client, [uuid4(), uuid4(), uuid4()], current_user_id=user_id
+            )
+
+        mock_emit.assert_awaited_once_with(WebSocketEvent.STACK_UPDATE, user_id)
+
+    @pytest.mark.anyio
+    async def test_bulk_dissolve_is_silent_when_a_delete_fails(self):
+        """A partial batch raises before emitting; the client reconciles through
+        the sync stream instead of a hint for a half-applied dissolve."""
+        client = _removal_client()
+        client.stacks.delete = AsyncMock(side_effect=make_sdk_status_error(500, "boom"))
+
+        with self._patch_emit() as mock_emit:
+            with pytest.raises(GumnutError):
+                await _delete_stacks(client, [uuid4(), uuid4()])
+
+        mock_emit.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_empty_bulk_dissolve_is_silent(self):
+        """A no-op bulk delete changed nothing, so it emits nothing."""
+        client = _removal_client()
+
+        with self._patch_emit() as mock_emit:
+            await _delete_stacks(client, [])
+
+        mock_emit.assert_not_awaited()
+
+
 class TestRouteDependencies:
     """Every stack route is user-scoped, so each must resolve a client and user.
 
@@ -1168,7 +1290,16 @@ class TestRouteDependencies:
         "handler", [delete_stacks, delete_stack, remove_asset_from_stack]
     )
     def test_removal_handler_declares_the_client_dependency(self, handler):
-        """The removal routes forward to the backend but hydrate nothing, so they
-        take the client (and must authenticate) without a `current_user`."""
+        """The removal routes forward to the backend and hydrate nothing, so they
+        take the client (and must authenticate) without a full `current_user`."""
         default = inspect.signature(handler).parameters["client"].default
         assert default.dependency is get_authenticated_gumnut_client
+
+    @pytest.mark.parametrize(
+        "handler", [delete_stacks, delete_stack, remove_asset_from_stack]
+    )
+    def test_removal_handler_declares_the_user_id_dependency(self, handler):
+        """The removal routes emit `on_asset_stack_update` to the owning user's
+        room, so each resolves the caller's id even though it hydrates nothing."""
+        default = inspect.signature(handler).parameters["current_user_id"].default
+        assert default.dependency is get_current_user_id


### PR DESCRIPTION
## What

- Add `STACK_UPDATE = "on_asset_stack_update"` to `WebSocketEvent` and emit it (payload `None`) from the five mutating stack routes: `create_stack`, `update_stack` (cover-change branch only), `remove_asset_from_stack`, `delete_stack`, and `delete_stacks` (one emit per clean bulk dissolve). Each is scoped to the owning user's room, mirroring upstream Immich's emit sites in `stack.service.ts`.
- Add a lightweight `get_current_user_id` dependency to the three delete/remove routes so they can resolve the room key.
- Update `docs/references/websocket-events-reference.md` and add emit tests in `tests/unit/api/test_stacks.py`.

## Why

E4 moved stack changes onto the event-driven sync stream (the pull path). This is the push half: when one client mutates a stack, the adapter now sends the same realtime hint Immich's own server does, so it behaves like upstream rather than silently dropping the event.

**Payload is empty, deliberately.** Upstream calls `clientSend('on_asset_stack_update', userId)` with no data argument — its repository type `on_asset_stack_update: string[]` is a rest-param that spreads to zero args, not an id array. So the adapter emits with `payload=None` via `emit_user_event`, never `emit_user_event_per_id`.

**No current Immich client subscribes to this event.** The web client declares `on_asset_stack_update` in its `Events` type map but registers no `.on()` handler for it; the mobile client has zero references. So this emission is upstream-parity / forward-compat, not an immediate UI trigger — the durable convergence path for stack changes remains the event-driven sync stream. This is why the reference doc's prior "the adapter omits it because no handler subscribes" note is replaced rather than kept.

**Scope notes:**
- No push-side trigger exists outside these HTTP routes (there is no add-asset-to-existing-stack route, and the sync stream is pull-based), so no polling loop is invented — emission rides the existing stack CRUD routes.
- The cover-less PUT path is a pure read and stays silent, diverging from upstream's unconditional `StackUpdate` emit — signalling "updated" when nothing changed would be misleading noise.
- A partial bulk dissolve raises before emitting; the client reconciles through the sync stream.
- `emit_user_event` already swallows `SocketIOError`, so a transport failure can't fail the originating mutation (no new try/except at call sites).

## Test plan

- `uv run pytest` — full suite green (1702 passed). New tests in `tests/unit/api/test_stacks.py` cover: emit on create / cover change / single dissolve / clean bulk dissolve / member removal; silence on the cover-less read, a partial-failure batch, and an empty batch; owner-scoping of the room id; and the `get_current_user_id` dependency wiring on the three delete/remove routes.
- `uv run ruff check`, `uv run ruff format --check`, `uv run pyright` — clean.
- `uv run scripts/lint_docs.py` — clean.

Generated by an AI coding agent.