### PR TITLE
Retry a stack row missing from the sync bulk read unless a delete explains it

### DIFF
--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Sync Stream Architecture"
-last-updated: 2026-08-11
+last-updated: 2026-08-12
 ---
 
 # Sync Stream Architecture
@@ -93,6 +93,19 @@ the shared effective-primary rule, and carries only the resulting UUID into the
 converter. Reads are concurrency-bounded. An empty all-state member read is
 retryable even when `asset_count` is zero, because that count excludes trashed
 members; propagating the error truncates the stream before its cursor is acked.
+
+A stack row **absent from the bulk `list_stacks` read** is likewise retriable —
+skipping it would advance the cursor past the stack while the asset pass still
+stamps `stackId` on its members, hiding the burst on the mobile timeline. The
+one legitimate absence is a stack created and deleted within the same sync
+window (the row is already gone), so the guard excuses exactly the ids with a
+`stack_deleted` event in the window: first the current events page, then a
+look-ahead scan of the remaining stack events up to the window bound (the
+events API has no entity-id filter). Anything left unexplained raises
+`StackRowReadIncomplete` and truncates the stream with the cursor preserved;
+read lag resolves on the next sync, and a delete that landed after the window
+bound is found inside the next window. Undecodable-id rows are excluded from
+the guard — the read returned them; they are degraded deliberately.
 
 The asset converter maps a member's `stack_id` to the Immich `stackId` through
 the shared `immich_stack_id` helper (`gumnut_id_conversion.py`); the upload-ready

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -207,12 +207,16 @@ _SUPPORTED_REQUEST_TYPES: frozenset[SyncRequestType] = frozenset(
 
 async def _require_missing_stacks_deleted(
     gumnut_client: AsyncGumnut,
-    missing_ids: set[str],
+    absent_ids: set[str],
     page_events: Sequence[EventData],
     page_has_more: bool,
     sync_started_at: datetime,
 ) -> None:
-    """Raise unless every missing stack row is explained by an in-window delete.
+    """Raise unless every absent stack row is explained by an in-window delete.
+
+    ``absent_ids`` are ids the bulk read did not return at all — distinct from
+    ``fetch_entities_map``'s ``missing_ids``, which the read returned but
+    deliberately degraded.
 
     A stack **created and deleted within one sync window** is legitimately
     absent from ``list_stacks`` — its create is an upsert event, but the row is
@@ -228,14 +232,16 @@ async def _require_missing_stacks_deleted(
     for why the transient shapes self-heal and a persistent failure wedges the
     pass, deliberately).
     """
-    unexplained = missing_ids - {
+    unexplained = absent_ids - {
         event.entity_id for event in page_events if event.event_type == "stack_deleted"
     }
     last_cursor = page_events[-1].cursor
     has_more = page_has_more
     while unexplained and has_more:
-        # Params dict matches _stream_entity_type's call shape, including the
-        # plain-string entity_types the SDK accepts as a comma-delimited value.
+        # The dict is deliberate: the SDK types entity_types as a string
+        # sequence, but the API also accepts the plain comma-delimited string
+        # _stream_entity_type sends — the untyped dict is what lets the same
+        # wire shape pass the type checker.
         params: dict[str, Any] = {
             "created_at_lt": sync_started_at,
             "entity_types": "stack",

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -239,7 +239,7 @@ async def _require_missing_stacks_deleted(
     has_more = page_has_more
     while unexplained and has_more:
         # The dict is deliberate: the SDK types entity_types as a string
-        # sequence, but the API also accepts the plain comma-delimited string
+        # sequence, but the API also accepts the plain string
         # _stream_entity_type sends — the untyped dict is what lets the same
         # wire shape pass the type checker.
         params: dict[str, Any] = {

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -66,6 +66,13 @@ class StackRowReadIncomplete(Exception):
     members, and the mobile timeline hides any asset whose ``stackId`` names no
     stack row — a hidden burst that would not self-heal until some later stack
     event re-emitted the row.
+
+    Both transient shapes resolve on the retry: a lagging row becomes visible,
+    and a stack deleted *after* the window bound gets its delete event inside
+    the next window. A stack that fails *persistently* wedges the pass until it
+    recovers — loud in the logs, and the same trade-off the member-read
+    failures in ``entity_fetch`` already make; never stranding a member is the
+    priority.
     """
 
 
@@ -202,6 +209,7 @@ async def _require_missing_stacks_deleted(
     gumnut_client: AsyncGumnut,
     missing_ids: set[str],
     page_events: Sequence[EventData],
+    page_has_more: bool,
     sync_started_at: datetime,
 ) -> None:
     """Raise unless every missing stack row is explained by an in-window delete.
@@ -216,19 +224,16 @@ async def _require_missing_stacks_deleted(
     filter, so the look-ahead is a scan — acceptable because it runs only in
     the rare missing-row case and stack events are sparse.
 
-    Any id left unexplained raises :class:`StackRowReadIncomplete`, ending the
-    stream before the page's cursor is emitted. Both transient shapes then
-    self-heal on the next sync: a lagging row becomes visible, and a stack
-    deleted *after* ``sync_started_at`` gets its delete event inside the next
-    window. A stack that fails *persistently* wedges the pass until it recovers
-    — loud in the logs, and the same trade-off the member-read failures in
-    ``entity_fetch`` already make; never stranding a member is the priority.
+    Any id left unexplained raises :class:`StackRowReadIncomplete` (see there
+    for why the transient shapes self-heal and a persistent failure wedges the
+    pass, deliberately).
     """
     unexplained = missing_ids - {
         event.entity_id for event in page_events if event.event_type == "stack_deleted"
     }
     last_cursor = page_events[-1].cursor
-    while unexplained:
+    has_more = page_has_more
+    while unexplained and has_more:
         # Params dict matches _stream_entity_type's call shape, including the
         # plain-string entity_types the SDK accepts as a comma-delimited value.
         params: dict[str, Any] = {
@@ -245,8 +250,7 @@ async def _require_missing_stacks_deleted(
             event.entity_id for event in events if event.event_type == "stack_deleted"
         }
         last_cursor = events[-1].cursor
-        if not events_response.has_more:
-            break
+        has_more = events_response.has_more
 
     if unexplained:
         raise StackRowReadIncomplete(
@@ -336,16 +340,16 @@ async def _stream_entity_type(
         # Track entity IDs that were requested but not returned (deleted/404)
         not_returned = set(upsert_ids) - entities_map.keys()
         if not_returned:
-            # For stacks, an inert skip is only safe when a delete explains the
-            # absence — otherwise the asset pass would stamp stackId on members
-            # of a stack the client never receives, hiding the burst. Rows the
-            # fetch returned but deliberately degraded (undecodable id, in
-            # missing_ids) are excluded: they are not evidence of read lag.
+            # A missing stack row is only safely skippable when a delete
+            # explains it — see StackRowReadIncomplete. Rows the fetch returned
+            # but deliberately degraded (undecodable id, in missing_ids) are
+            # excluded: they are not evidence of read lag.
             if gumnut_entity_type == "stack":
                 await _require_missing_stacks_deleted(
                     gumnut_client,
                     not_returned - missing_ids,
                     events,
+                    events_response.has_more,
                     sync_started_at,
                 )
             stats.not_found_ids[gumnut_entity_type].update(not_returned)

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -9,12 +9,13 @@ import json
 import logging
 from collections import defaultdict
 from datetime import datetime, timezone
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from typing import Any, AsyncGenerator
 from uuid import UUID
 
 from gumnut import AsyncGumnut
 from gumnut.types.album_response import AlbumResponse
+from gumnut.types.events_response import Data as EventData
 from gumnut.types.asset_response import AssetResponse
 from gumnut.types.face_response import FaceResponse
 from gumnut.types.user_response import UserResponse
@@ -52,6 +53,21 @@ logger = logging.getLogger(__name__)
 
 # Page size for events API pagination
 EVENTS_PAGE_SIZE = GUMNUT_API_MAX_PAGE_SIZE
+
+
+class StackRowReadIncomplete(Exception):
+    """A stack upsert event names a row the bulk read did not return, and no
+    delete event in the sync window explains the absence.
+
+    A transiently-invisible row (e.g. read lag between the events endpoint and
+    ``list_stacks``), not a deleted stack — surfaced so the sync truncates and
+    retries with the cursor preserved. Skipping instead would advance the
+    cursor past the stack while the asset pass still stamps ``stackId`` on its
+    members, and the mobile timeline hides any asset whose ``stackId`` names no
+    stack row — a hidden burst that would not self-heal until some later stack
+    event re-emitted the row.
+    """
+
 
 # Delete event types that are converted to Immich delete sync models
 _DELETE_EVENT_TYPES = frozenset(
@@ -182,6 +198,64 @@ _SUPPORTED_REQUEST_TYPES: frozenset[SyncRequestType] = frozenset(
 )
 
 
+async def _require_missing_stacks_deleted(
+    gumnut_client: AsyncGumnut,
+    missing_ids: set[str],
+    page_events: Sequence[EventData],
+    sync_started_at: datetime,
+) -> None:
+    """Raise unless every missing stack row is explained by an in-window delete.
+
+    A stack **created and deleted within one sync window** is legitimately
+    absent from ``list_stacks`` — its create is an upsert event, but the row is
+    already gone — so treating every missing row as retriable would wedge the
+    sync forever on a stack that can never be fetched. The absence is excused
+    exactly when a ``stack_deleted`` event for the id exists in the window:
+    first checked against the current page (free), then by paging the remaining
+    stack events forward to the window bound. The events API has no entity-id
+    filter, so the look-ahead is a scan — acceptable because it runs only in
+    the rare missing-row case and stack events are sparse.
+
+    Any id left unexplained raises :class:`StackRowReadIncomplete`, ending the
+    stream before the page's cursor is emitted. Both transient shapes then
+    self-heal on the next sync: a lagging row becomes visible, and a stack
+    deleted *after* ``sync_started_at`` gets its delete event inside the next
+    window. A stack that fails *persistently* wedges the pass until it recovers
+    — loud in the logs, and the same trade-off the member-read failures in
+    ``entity_fetch`` already make; never stranding a member is the priority.
+    """
+    unexplained = missing_ids - {
+        event.entity_id for event in page_events if event.event_type == "stack_deleted"
+    }
+    last_cursor = page_events[-1].cursor
+    while unexplained:
+        # Params dict matches _stream_entity_type's call shape, including the
+        # plain-string entity_types the SDK accepts as a comma-delimited value.
+        params: dict[str, Any] = {
+            "created_at_lt": sync_started_at,
+            "entity_types": "stack",
+            "limit": EVENTS_PAGE_SIZE,
+            "after_cursor": last_cursor,
+        }
+        events_response = await gumnut_client.events.get(**params)
+        events = events_response.data
+        if not events:
+            break
+        unexplained -= {
+            event.entity_id for event in events if event.event_type == "stack_deleted"
+        }
+        last_cursor = events[-1].cursor
+        if not events_response.has_more:
+            break
+
+    if unexplained:
+        raise StackRowReadIncomplete(
+            f"{len(unexplained)} stack row(s) missing from the bulk read with "
+            f"no delete event in the sync window "
+            f"(sample: {sorted(unexplained)[:10]})"
+        )
+
+
 async def _stream_entity_type(
     gumnut_client: AsyncGumnut,
     gumnut_entity_type: str,
@@ -262,6 +336,18 @@ async def _stream_entity_type(
         # Track entity IDs that were requested but not returned (deleted/404)
         not_returned = set(upsert_ids) - entities_map.keys()
         if not_returned:
+            # For stacks, an inert skip is only safe when a delete explains the
+            # absence — otherwise the asset pass would stamp stackId on members
+            # of a stack the client never receives, hiding the burst. Rows the
+            # fetch returned but deliberately degraded (undecodable id, in
+            # missing_ids) are excluded: they are not evidence of read lag.
+            if gumnut_entity_type == "stack":
+                await _require_missing_stacks_deleted(
+                    gumnut_client,
+                    not_returned - missing_ids,
+                    events,
+                    sync_started_at,
+                )
             stats.not_found_ids[gumnut_entity_type].update(not_returned)
 
         # Verify that IDs referenced in event payloads (e.g. face_updated's

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -744,6 +744,14 @@ class TestEventDrivenStacks:
         assert not any(
             call.kwargs.get("ids") for call in client.assets.list.call_args_list
         )
+        # The page reported has_more=False, so the guard must conclude from it
+        # alone — no look-ahead scan call.
+        stack_event_reads = [
+            call
+            for call in client.events.get.call_args_list
+            if call.kwargs.get("entity_types") == "stack"
+        ]
+        assert len(stack_event_reads) == 1
 
     @pytest.mark.anyio
     async def test_missing_stack_row_with_same_page_delete_is_skipped(self):
@@ -850,6 +858,35 @@ class TestEventDrivenStacks:
         assert not any(
             e["type"] in {"StackV1", "StackDeleteV1", "SyncCompleteV1"} for e in events
         )
+
+    @pytest.mark.anyio
+    async def test_scan_hitting_empty_page_despite_has_more_truncates(self):
+        # Degraded upstream input: the trigger page claims has_more=True but
+        # the look-ahead page comes back empty. The guard must fall out of the
+        # scan and still raise rather than loop or excuse the absence.
+        user = create_mock_user(UPDATED_AT)
+        client = create_mock_gumnut_client(user)
+        stack = make_gumnut_stack()
+        pages_by_cursor = {
+            None: create_mock_events_response(
+                [
+                    create_mock_event(
+                        "stack", stack.id, "stack_created", UPDATED_AT, "cur_s1"
+                    )
+                ],
+                has_more=True,
+            ),
+            "cur_s1": create_mock_events_response([], has_more=True),
+        }
+        client.events.get = AsyncMock(
+            side_effect=lambda **kwargs: pages_by_cursor[kwargs.get("after_cursor")]
+        )
+        client.stacks.list_stacks = mock_list_stacks([])
+
+        request = SyncStreamDto(types=[SyncRequestType.StacksV1])
+        events = await collect_stream(generate_sync_stream(client, request, {}, user))
+
+        assert not any(e["type"] in {"StackV1", "SyncCompleteV1"} for e in events)
 
     @pytest.mark.anyio
     async def test_undecodable_stack_row_degrades_without_truncating(self):

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -708,9 +708,7 @@ class TestEventDrivenStacks:
         )
 
     @pytest.mark.anyio
-    async def test_missing_stack_row_without_delete_truncates_before_asset_pass(
-        self, caplog
-    ):
+    async def test_missing_stack_row_without_delete_truncates_before_asset_pass(self):
         # A stack_created whose row the bulk read doesn't return, with no
         # delete anywhere in the window, is transient (e.g. read lag). The
         # stream must truncate so the cursor is preserved — skipping would let
@@ -739,10 +737,7 @@ class TestEventDrivenStacks:
         request = SyncStreamDto(
             types=[SyncRequestType.StacksV1, SyncRequestType.AssetsV2]
         )
-        with caplog.at_level("ERROR"):
-            events = await collect_stream(
-                generate_sync_stream(client, request, {}, user)
-            )
+        events = await collect_stream(generate_sync_stream(client, request, {}, user))
 
         assert not any(e["type"] in {"StackV1", "AssetV2"} for e in events)
         assert not any(e["type"] == "SyncCompleteV1" for e in events)
@@ -815,7 +810,49 @@ class TestEventDrivenStacks:
         assert events[-1]["type"] == "SyncCompleteV1"
 
     @pytest.mark.anyio
-    async def test_undecodable_stack_row_degrades_without_truncating(self, caplog):
+    async def test_scan_explaining_only_one_of_two_missing_stacks_truncates(self):
+        # Two rows missing; the look-ahead scan finds a delete for one of them
+        # in a later page. The other stays unexplained, so the stream must
+        # still truncate — exercising the scan's has_more chaining and partial
+        # set subtraction.
+        user = create_mock_user(UPDATED_AT)
+        client = create_mock_gumnut_client(user)
+        deleted_stack = make_gumnut_stack()
+        lagging_stack = make_gumnut_stack()
+        pages_by_cursor = {
+            None: create_mock_events_response(
+                [
+                    create_mock_event(
+                        "stack", deleted_stack.id, "stack_created", UPDATED_AT, "cur_s1"
+                    ),
+                    create_mock_event(
+                        "stack", lagging_stack.id, "stack_created", UPDATED_AT, "cur_s2"
+                    ),
+                ],
+                has_more=True,
+            ),
+            "cur_s2": create_mock_events_response(
+                [
+                    create_mock_event(
+                        "stack", deleted_stack.id, "stack_deleted", UPDATED_AT, "cur_s3"
+                    )
+                ]
+            ),
+        }
+        client.events.get = AsyncMock(
+            side_effect=lambda **kwargs: pages_by_cursor[kwargs.get("after_cursor")]
+        )
+        client.stacks.list_stacks = mock_list_stacks([])
+
+        request = SyncStreamDto(types=[SyncRequestType.StacksV1])
+        events = await collect_stream(generate_sync_stream(client, request, {}, user))
+
+        assert not any(
+            e["type"] in {"StackV1", "StackDeleteV1", "SyncCompleteV1"} for e in events
+        )
+
+    @pytest.mark.anyio
+    async def test_undecodable_stack_row_degrades_without_truncating(self):
         # An undecodable id is returned by the bulk read and deliberately
         # degraded (missing_ids) — it is not evidence of read lag, so it must
         # not trip the missing-row guard even with no delete in the window.
@@ -828,10 +865,7 @@ class TestEventDrivenStacks:
         client.stacks.list_stacks = mock_list_stacks([stack])
 
         request = SyncStreamDto(types=[SyncRequestType.StacksV1])
-        with caplog.at_level("WARNING"):
-            events = await collect_stream(
-                generate_sync_stream(client, request, {}, user)
-            )
+        events = await collect_stream(generate_sync_stream(client, request, {}, user))
 
         assert not any(e["type"] == "StackV1" for e in events)
         assert events[-1]["type"] == "SyncCompleteV1"

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -708,14 +708,124 @@ class TestEventDrivenStacks:
         )
 
     @pytest.mark.anyio
-    async def test_stack_vanished_between_event_and_fetch_is_skipped(self, caplog):
+    async def test_missing_stack_row_without_delete_truncates_before_asset_pass(
+        self, caplog
+    ):
+        # A stack_created whose row the bulk read doesn't return, with no
+        # delete anywhere in the window, is transient (e.g. read lag). The
+        # stream must truncate so the cursor is preserved — skipping would let
+        # the asset pass stamp stackId on members of a stack the client never
+        # receives, hiding the burst.
+        user = create_mock_user(UPDATED_AT)
+        client = create_mock_gumnut_client(user)
+        stack = make_gumnut_stack()
+        asset = make_gumnut_asset(stack_id=stack.id)
+        client.events.get = _events_by_type(
+            {
+                "stack": [
+                    create_mock_event(
+                        "stack", stack.id, "stack_created", UPDATED_AT, "cur_v"
+                    )
+                ],
+                "asset": [
+                    create_mock_event(
+                        "asset", asset.id, "asset_created", UPDATED_AT, "cur_a"
+                    )
+                ],
+            }
+        )
+        client.stacks.list_stacks = mock_list_stacks([])  # row not visible yet
+
+        request = SyncStreamDto(
+            types=[SyncRequestType.StacksV1, SyncRequestType.AssetsV2]
+        )
+        with caplog.at_level("ERROR"):
+            events = await collect_stream(
+                generate_sync_stream(client, request, {}, user)
+            )
+
+        assert not any(e["type"] in {"StackV1", "AssetV2"} for e in events)
+        assert not any(e["type"] == "SyncCompleteV1" for e in events)
+        assert not any(
+            call.kwargs.get("ids") for call in client.assets.list.call_args_list
+        )
+
+    @pytest.mark.anyio
+    async def test_missing_stack_row_with_same_page_delete_is_skipped(self):
+        # Created and deleted within one page: the row is legitimately gone,
+        # so the absence is inert — the delete still reaches the client.
         user = create_mock_user(UPDATED_AT)
         client = create_mock_gumnut_client(user)
         stack = make_gumnut_stack()
         client.events.get.return_value = create_mock_events_response(
-            [create_mock_event("stack", stack.id, "stack_created", UPDATED_AT, "cur_v")]
+            [
+                create_mock_event(
+                    "stack", stack.id, "stack_created", UPDATED_AT, "cur_s1"
+                ),
+                create_mock_event(
+                    "stack", stack.id, "stack_deleted", UPDATED_AT, "cur_s2"
+                ),
+            ]
         )
-        client.stacks.list_stacks = mock_list_stacks([])  # nothing comes back
+        client.stacks.list_stacks = mock_list_stacks([])
+
+        request = SyncStreamDto(types=[SyncRequestType.StacksV1])
+        events = await collect_stream(generate_sync_stream(client, request, {}, user))
+
+        assert not any(e["type"] == "StackV1" for e in events)
+        delete_events = [e for e in events if e["type"] == "StackDeleteV1"]
+        assert len(delete_events) == 1
+        assert events[-1]["type"] == "SyncCompleteV1"
+
+    @pytest.mark.anyio
+    async def test_missing_stack_row_with_later_page_delete_is_skipped(self):
+        # The delete that explains the absence sits in a later page of the
+        # window, so the guard's look-ahead scan has to find it.
+        user = create_mock_user(UPDATED_AT)
+        client = create_mock_gumnut_client(user)
+        stack = make_gumnut_stack()
+        pages_by_cursor = {
+            None: create_mock_events_response(
+                [
+                    create_mock_event(
+                        "stack", stack.id, "stack_created", UPDATED_AT, "cur_s1"
+                    )
+                ],
+                has_more=True,
+            ),
+            "cur_s1": create_mock_events_response(
+                [
+                    create_mock_event(
+                        "stack", stack.id, "stack_deleted", UPDATED_AT, "cur_s2"
+                    )
+                ]
+            ),
+        }
+        client.events.get = AsyncMock(
+            side_effect=lambda **kwargs: pages_by_cursor[kwargs.get("after_cursor")]
+        )
+        client.stacks.list_stacks = mock_list_stacks([])
+
+        request = SyncStreamDto(types=[SyncRequestType.StacksV1])
+        events = await collect_stream(generate_sync_stream(client, request, {}, user))
+
+        assert not any(e["type"] == "StackV1" for e in events)
+        delete_events = [e for e in events if e["type"] == "StackDeleteV1"]
+        assert len(delete_events) == 1
+        assert events[-1]["type"] == "SyncCompleteV1"
+
+    @pytest.mark.anyio
+    async def test_undecodable_stack_row_degrades_without_truncating(self, caplog):
+        # An undecodable id is returned by the bulk read and deliberately
+        # degraded (missing_ids) — it is not evidence of read lag, so it must
+        # not trip the missing-row guard even with no delete in the window.
+        user = create_mock_user(UPDATED_AT)
+        client = create_mock_gumnut_client(user)
+        stack = make_gumnut_stack(stack_id="not_a_valid_stack_prefix")
+        client.events.get.return_value = create_mock_events_response(
+            [create_mock_event("stack", stack.id, "stack_created", UPDATED_AT, "cur_u")]
+        )
+        client.stacks.list_stacks = mock_list_stacks([stack])
 
         request = SyncStreamDto(types=[SyncRequestType.StacksV1])
         with caplog.at_level("WARNING"):

--- a/tests/unit/api/sync/test_sync_stream_stacks.py
+++ b/tests/unit/api/sync/test_sync_stream_stacks.py
@@ -860,6 +860,54 @@ class TestEventDrivenStacks:
         )
 
     @pytest.mark.anyio
+    async def test_scan_finds_delete_on_second_scan_page(self):
+        # The explaining delete sits two scan pages ahead, behind an unrelated
+        # delete — pinning the scan's page-to-page cursor advance. Keying the
+        # mock by after_cursor makes stale-cursor reuse fail fast (KeyError)
+        # instead of looping.
+        user = create_mock_user(UPDATED_AT)
+        client = create_mock_gumnut_client(user)
+        stack = make_gumnut_stack()
+        other_stack = make_gumnut_stack()
+        pages_by_cursor = {
+            None: create_mock_events_response(
+                [
+                    create_mock_event(
+                        "stack", stack.id, "stack_created", UPDATED_AT, "cur_s1"
+                    )
+                ],
+                has_more=True,
+            ),
+            "cur_s1": create_mock_events_response(
+                [
+                    create_mock_event(
+                        "stack", other_stack.id, "stack_deleted", UPDATED_AT, "cur_s2"
+                    )
+                ],
+                has_more=True,
+            ),
+            "cur_s2": create_mock_events_response(
+                [
+                    create_mock_event(
+                        "stack", stack.id, "stack_deleted", UPDATED_AT, "cur_s3"
+                    )
+                ]
+            ),
+        }
+        client.events.get = AsyncMock(
+            side_effect=lambda **kwargs: pages_by_cursor[kwargs.get("after_cursor")]
+        )
+        client.stacks.list_stacks = mock_list_stacks([])
+
+        request = SyncStreamDto(types=[SyncRequestType.StacksV1])
+        events = await collect_stream(generate_sync_stream(client, request, {}, user))
+
+        assert not any(e["type"] == "StackV1" for e in events)
+        delete_events = [e for e in events if e["type"] == "StackDeleteV1"]
+        assert len(delete_events) == 2
+        assert events[-1]["type"] == "SyncCompleteV1"
+
+    @pytest.mark.anyio
     async def test_scan_hitting_empty_page_despite_has_more_truncates(self):
         # Degraded upstream input: the trigger page claims has_more=True but
         # the look-ahead page comes back empty. The guard must fall out of the


### PR DESCRIPTION
## What

- Add a guard to the sync stream's stack pass: a stack upsert whose row is absent from the bulk `list_stacks` read now truncates the stream (cursor preserved, next sync retries) unless a `stack_deleted` event in the sync window explains the absence — checked against the current events page first, then a look-ahead scan of the remaining stack events, seeded by the triggering page's `has_more`.
- Exclude undecodable-id rows from the guard: the read returned them, and they are deliberately degraded rather than evidence of read lag.
- Seven tests cover the guard's branches (no-delete truncation with scan-skip pin, same-page delete, later-page delete, mixed explained/unexplained, second-scan-page delete pinning cursor chaining, empty-page-despite-has_more, undecodable exclusion); the sync-stream architecture doc gains the matching paragraph.

## Why

A transiently-invisible row (e.g. read lag between the events endpoint and `list_stacks`) was previously treated as permanently missing and skipped, advancing the events cursor past it — while the asset pass still stamped `stackId` on the stack's members. The Immich mobile timeline hides any asset whose `stackId` names no stack row, so the whole burst disappeared with no self-heal until some later stack event re-emitted it. This was the third variant of the "transiently-unavailable stack strands its members" class surfaced in the review of #345; the two row-present variants were fixed there, and this row-absent one was deferred because a naive "raise on any missing row" would wedge forever on a stack created and deleted within one sync window — the delete-event excusal here is what makes the raise safe. Both transient shapes self-heal on retry: a lagging row becomes visible, and a stack deleted after the window bound gets its delete event inside the next window.

## Test plan

- `uv run pytest` — full suite passes (1712 tests), including 36 in `tests/unit/api/sync/test_sync_stream_stacks.py`
- `uv run ruff check`, `uv run ruff format --check`, `uv run pyright`, `uv run scripts/lint_docs.py` — all clean

Generated by an AI coding agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)