### PR TITLE
Stream batch download archives

### DIFF
--- a/config/logging.py
+++ b/config/logging.py
@@ -2,9 +2,29 @@ import logging
 import logging.config
 import sys
 
+from config.telemetry import redact_sensitive_cdn_url
+
 # Unified log format constants to avoid duplication
 LOG_FORMAT = "%(asctime)s | %(levelname)-5s | %(name)s | %(message)s"
 LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+class RedactSensitiveHttpxQuery(logging.Filter):
+    """Redact signed-CDN secrets from HTTPX's automatic request log."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.name != "httpx" or not isinstance(record.args, tuple):
+            return True
+        if len(record.args) < 2:
+            return True
+
+        redacted_url = redact_sensitive_cdn_url(str(record.args[1]))
+        if redacted_url != str(record.args[1]):
+            args = list(record.args)
+            args[1] = redacted_url
+            record.args = tuple(args)
+        return True
+
 
 # Python dictionary configuration equivalent to the YAML
 LOGGING_CONFIG = {
@@ -13,11 +33,15 @@ LOGGING_CONFIG = {
     "formatters": {
         "default": {"format": LOG_FORMAT, "datefmt": LOG_DATE_FORMAT},
     },
+    "filters": {
+        "redact_sensitive_httpx_query": {"()": RedactSensitiveHttpxQuery},
+    },
     "handlers": {
         "default": {
             "formatter": "default",
             "class": "logging.StreamHandler",
             "stream": sys.stdout,
+            "filters": ["redact_sensitive_httpx_query"],
         },
     },
     "loggers": {

--- a/config/sentry.py
+++ b/config/sentry.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 import sentry_sdk
 
 from config.settings import get_settings
+from config.telemetry import redact_sensitive_cdn_query, redact_sensitive_cdn_url
 
 logger = logging.getLogger(__name__)
 
@@ -27,18 +28,32 @@ def _enrich_http_spans(event, _hint):
         data = span.get("data")
         if not isinstance(data, dict):
             data = {}
+
+        query = data.get("http.query")
+        if isinstance(query, str):
+            data["http.query"] = redact_sensitive_cdn_query(query)
+
+        data_url = data.get("url")
+        if isinstance(data_url, str):
+            data["url"] = redact_sensitive_cdn_url(data_url)
+
+        description_url: str | None = None
+        description = span.get("description")
+        if isinstance(description, str):
+            parts = description.split(" ", 1)
+            if len(parts) == 2:
+                description_url = redact_sensitive_cdn_url(parts[1])
+                span["description"] = f"{parts[0]} {description_url}"
+
         if "server.address" in data:
+            span["data"] = data
             continue
 
         url = data.get("url")
         if not isinstance(url, str) or not url:
-            description = span.get("description")
-            if not isinstance(description, str):
+            if description_url is None:
                 continue
-            parts = description.split(" ", 1)
-            if len(parts) < 2:
-                continue
-            url = parts[1]
+            url = description_url
 
         parsed = urlparse(url)
         if parsed.scheme not in ("http", "https"):

--- a/config/sentry.py
+++ b/config/sentry.py
@@ -1,13 +1,41 @@
 import logging
 import os
+from typing import Any
 from urllib.parse import urlparse
 
 import sentry_sdk
+from sentry_sdk.types import Event, Hint
 
 from config.settings import get_settings
-from config.telemetry import redact_sensitive_cdn_query, redact_sensitive_cdn_url
+from config.telemetry import (
+    redact_sensitive_cdn_query,
+    redact_sensitive_cdn_text,
+    redact_sensitive_cdn_url,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def _redact_error_event(event: Event, _hint: Hint) -> Event:
+    """Remove signed-CDN credentials and filenames from error event values."""
+
+    def redact(value: Any) -> Any:
+        if isinstance(value, str):
+            return redact_sensitive_cdn_text(value)
+        if isinstance(value, dict):
+            for key, item in value.items():
+                value[key] = redact(item)
+        elif isinstance(value, list):
+            for index, item in enumerate(value):
+                value[index] = redact(item)
+        return value
+
+    try:
+        redact(event)
+        return event
+    except Exception:
+        # before_send must never drop an otherwise useful error event.
+        return event
 
 
 def _enrich_http_spans(event, _hint):
@@ -87,6 +115,7 @@ def init_sentry():
             # there is an active span.
             profile_lifecycle="trace",
             environment=get_settings().environment,
+            before_send=_redact_error_event,
             before_send_transaction=_enrich_http_spans,
         )
     else:

--- a/config/telemetry.py
+++ b/config/telemetry.py
@@ -5,7 +5,7 @@ from urllib.parse import unquote_plus, urlsplit, urlunsplit
 
 _SENSITIVE_CDN_QUERY_KEYS = frozenset({"dl", "verify"})
 _REDACTED_QUERY_VALUE = "REDACTED"
-_URL_IN_TEXT = re.compile(r"https?://[^\s'\"<>\[\]{}(),]+")
+_URL_IN_TEXT = re.compile(r"https?://\S+")
 
 
 def redact_sensitive_cdn_query(query: str) -> str:

--- a/config/telemetry.py
+++ b/config/telemetry.py
@@ -1,0 +1,33 @@
+"""Targeted redaction for signed CDN telemetry."""
+
+from urllib.parse import unquote_plus, urlsplit, urlunsplit
+
+_SENSITIVE_CDN_QUERY_KEYS = frozenset({"dl", "verify"})
+_REDACTED_QUERY_VALUE = "REDACTED"
+
+
+def redact_sensitive_cdn_query(query: str) -> str:
+    """Redact CDN credentials and filenames without changing other parameters."""
+    parts = [part.partition("=") for part in query.split("&")]
+    if not any(unquote_plus(key) == "verify" for key, _separator, _value in parts):
+        return query
+
+    redacted_parts: list[str] = []
+    for key, separator, value in parts:
+        if unquote_plus(key) in _SENSITIVE_CDN_QUERY_KEYS:
+            redacted_parts.append(f"{key}={_REDACTED_QUERY_VALUE}")
+        else:
+            redacted_parts.append(f"{key}{separator}{value}")
+    return "&".join(redacted_parts)
+
+
+def redact_sensitive_cdn_url(url: str) -> str:
+    """Redact only sensitive CDN query values in a URL-shaped string."""
+    try:
+        parsed = urlsplit(url)
+        redacted_query = redact_sensitive_cdn_query(parsed.query)
+        if redacted_query == parsed.query:
+            return url
+        return urlunsplit(parsed._replace(query=redacted_query))
+    except (TypeError, ValueError):
+        return url

--- a/config/telemetry.py
+++ b/config/telemetry.py
@@ -1,9 +1,11 @@
 """Targeted redaction for signed CDN telemetry."""
 
+import re
 from urllib.parse import unquote_plus, urlsplit, urlunsplit
 
 _SENSITIVE_CDN_QUERY_KEYS = frozenset({"dl", "verify"})
 _REDACTED_QUERY_VALUE = "REDACTED"
+_URL_IN_TEXT = re.compile(r"https?://[^\s'\"<>\[\]{}(),]+")
 
 
 def redact_sensitive_cdn_query(query: str) -> str:
@@ -31,3 +33,13 @@ def redact_sensitive_cdn_url(url: str) -> str:
         return urlunsplit(parsed._replace(query=redacted_query))
     except (TypeError, ValueError):
         return url
+
+
+def redact_sensitive_cdn_text(text: str) -> str:
+    """Redact signed-CDN URLs or bare queries embedded in telemetry text."""
+    redacted = _URL_IN_TEXT.sub(
+        lambda match: redact_sensitive_cdn_url(match.group(0)), text
+    )
+    if redacted != text:
+        return redacted
+    return redact_sensitive_cdn_query(text)

--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Immich Adapter Architecture"
-last-updated: 2026-08-12
+last-updated: 2026-08-18
 ---
 
 # Immich Adapter Architecture
@@ -72,6 +72,9 @@ Asset converters translate Gumnut metadata, timestamps, checksums, media variant
 - outgoing checksums are base64 SHA-1 even though stronger hashes exist internally;
 - thumbnail selection depends on the requested/display aspect ratio;
 - video upload events may wait for a renderable derived image.
+- batch downloads resolve original variants and file sizes through the Gumnut API,
+  then stream the signed CDN responses into an on-the-fly ZIP without taking
+  custody of complete assets or archives.
 
 The canonical rules and source anchors are in [Asset and Media Handling](../references/asset-and-media-handling.md).
 

--- a/docs/architecture/adapter-architecture.md
+++ b/docs/architecture/adapter-architecture.md
@@ -72,11 +72,12 @@ Asset converters translate Gumnut metadata, timestamps, checksums, media variant
 - outgoing checksums are base64 SHA-1 even though stronger hashes exist internally;
 - thumbnail selection depends on the requested/display aspect ratio;
 - video upload events may wait for a renderable derived image.
-- batch downloads resolve original variants and file sizes through the Gumnut API,
-  then stream the signed CDN responses into an on-the-fly ZIP without taking
-  custody of complete assets or archives.
 
 The canonical rules and source anchors are in [Asset and Media Handling](../references/asset-and-media-handling.md).
+
+Batch downloads resolve original variants and file sizes through the Gumnut API,
+then stream the signed CDN responses into an on-the-fly ZIP without taking
+custody of complete assets or archives.
 
 ## Collection translation
 

--- a/docs/design-docs/immich-adapter-gap-analysis.md
+++ b/docs/design-docs/immich-adapter-gap-analysis.md
@@ -2,7 +2,7 @@
 title: "Immich Adapter Gap Analysis"
 status: active
 created: 2026-04-15
-last-updated: 2026-08-11
+last-updated: 2026-08-18
 ---
 
 # Immich Adapter Gap Analysis
@@ -32,7 +32,6 @@ A route being present in OpenAPI does not prove a client uses it. Check the pinn
 | Shared links | Compatibility stubs; mutations do not create durable public links | Gumnut API sharing/access model plus adapter | Revisit: high value, large auth/storage design |
 | Tags | Empty/fake compatibility surface | Gumnut API tag hierarchy and asset relations plus adapter | Revisit after core data model |
 | Reverse geocoding | Empty read; map markers themselves work | Geocoding provider/storage plus adapter | Revisit independently |
-| Download/archive | Empty archive/info stubs; individual originals work | Adapter | Close: clear user value |
 | Activities/comments | Unreachable without sharing | Sharing model first | Intentional until sharing exists |
 | Memories writes | Read path is available; save/hide persistence is not | Gumnut API memory model plus adapter | Revisit |
 | Partners and album sharing | Unsupported single-user deployment model | Cross-user authorization and sharing | Revisit as a larger product capability |
@@ -71,10 +70,9 @@ These decisions are product/architecture choices, not promises that every unsupp
 
 ### Close next
 
-1. **Download/archive** — adapter-only and visible to users.
-2. **Pagination/scaling** — remove full-library reads where the Gumnut API can expose the required sort/filter/count behavior.
-3. **Memories write path** — complete only with a durable backend model.
-4. **Search limitations** — address from observed client workflows rather than broad speculative parity.
+1. **Pagination/scaling** — remove full-library reads where the Gumnut API can expose the required sort/filter/count behavior.
+2. **Memories write path** — complete only with a durable backend model.
+3. **Search limitations** — address from observed client workflows rather than broad speculative parity.
 
 ### Revisit with product capability
 

--- a/main.py
+++ b/main.py
@@ -43,6 +43,7 @@ from routers.api import (
     users,
     view,
 )
+from routers.api.download import close_archive_zip_executor
 from services import websockets
 from services.streaming_upload import close_streaming_http_client
 from routers.utils.cdn_client import close_cdn_http_client
@@ -105,6 +106,7 @@ async def lifespan(app: FastAPI):
     await close_shared_http_client()
     await close_cdn_http_client()
     close_streaming_http_client()
+    await close_archive_zip_executor()
     # Close Redis client
     await close_redis_client()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "redis~=8.0",
     "sentry-sdk[fastapi,httpx]>=2.37.1",
     "shortuuid>=1.0.13",
+    "stream-zip>=0.0.83",
     "user-agents>=2.2.0",
     # uvicorn 0.44.0 added keepalive pings for the websockets-sansio impl,
     # which is what we run via `--ws websockets-sansio` to avoid the legacy

--- a/routers/api/constants.py
+++ b/routers/api/constants.py
@@ -7,10 +7,11 @@ GUMNUT_API_MAX_PAGE_SIZE = 200
 # endpoints. Keep all adapter-side chunking tied to this single upstream limit.
 GUMNUT_API_MAX_BULK_IDS = 200
 
-# Immich's default maximum uncompressed size for one download archive. The web
-# client forwards this preference to POST /download/info, whose DTO requires a
-# positive value, so the compatibility response must not use the old stub's 0.
-DEFAULT_DOWNLOAD_ARCHIVE_SIZE = 4 * 1024**3
+# Immich Web buffers each archive into an XHR Blob before saving it. Use a
+# positive compatibility default that keeps typical browser-side blobs well
+# below upstream's 4 GiB default; one individually larger asset can still make
+# an archive exceed this grouping target.
+DEFAULT_DOWNLOAD_ARCHIVE_SIZE = 512 * 1024**2
 
 # Placeholder device_id the adapter sends to the Gumnut API on upload. The
 # Gumnut API requires device_asset_id/device_id, but Immich v3 dropped both

--- a/routers/api/constants.py
+++ b/routers/api/constants.py
@@ -7,6 +7,11 @@ GUMNUT_API_MAX_PAGE_SIZE = 200
 # endpoints. Keep all adapter-side chunking tied to this single upstream limit.
 GUMNUT_API_MAX_BULK_IDS = 200
 
+# Immich's default maximum uncompressed size for one download archive. The web
+# client forwards this preference to POST /download/info, whose DTO requires a
+# positive value, so the compatibility response must not use the old stub's 0.
+DEFAULT_DOWNLOAD_ARCHIVE_SIZE = 4 * 1024**3
+
 # Placeholder device_id the adapter sends to the Gumnut API on upload. The
 # Gumnut API requires device_asset_id/device_id, but Immich v3 dropped both
 # from the upload DTO (clients no longer send them). The adapter passes this

--- a/routers/api/download.py
+++ b/routers/api/download.py
@@ -1,13 +1,17 @@
 """Immich-compatible batch download planning and streaming ZIP archives."""
 
+import asyncio
 import posixpath
 import re
-from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Iterable
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import copy_context
 from dataclasses import dataclass
 from datetime import datetime
 from itertools import batched
 from stat import S_IFREG
-from typing import Annotated
+from threading import Lock
+from typing import Annotated, TypeVar, cast
 from uuid import UUID
 
 import httpx
@@ -16,7 +20,7 @@ from fastapi.responses import StreamingResponse
 from gumnut import AsyncGumnut
 from gumnut.types.asset_response import AssetResponse
 from pydantic.json_schema import SkipJsonSchema
-from stream_zip import ZIP_AUTO, AsyncMemberFile, async_stream_zip
+from stream_zip import ZIP_AUTO, AsyncMemberFile, stream_zip
 
 from routers.api.constants import (
     DEFAULT_DOWNLOAD_ARCHIVE_SIZE,
@@ -49,7 +53,11 @@ _DOWNLOAD_ARCHIVE_INCLUDE = ["file_data", "variants"]
 _ZIP_MIN_TIMESTAMP = datetime(1980, 1, 1)
 _ZIP_MAX_TIMESTAMP = datetime(2107, 12, 31, 23, 59, 58)
 _ARCHIVE_CDN_CHUNK_SIZE = 64 * 1024
+_ARCHIVE_ZIP_MAX_WORKERS = 8
 _UNSAFE_FILENAME_CHARACTERS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+_archive_zip_executor: ThreadPoolExecutor | None = None
+_archive_zip_executor_lock = Lock()
+_T = TypeVar("_T")
 
 
 @dataclass(slots=True)
@@ -57,6 +65,43 @@ class _ArchiveStreamState:
     """Per-response ownership of the currently open CDN connection."""
 
     response: httpx.Response | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _ArchiveAsset:
+    """Compact metadata retained after archive preflight validation."""
+
+    filename: str
+    modified_at: datetime
+    size: int
+    url: str
+
+
+def _get_archive_zip_executor() -> ThreadPoolExecutor:
+    """Return the bounded executor reserved for ZIP generation."""
+    global _archive_zip_executor
+    if _archive_zip_executor is None:
+        with _archive_zip_executor_lock:
+            if _archive_zip_executor is None:
+                _archive_zip_executor = ThreadPoolExecutor(
+                    max_workers=_ARCHIVE_ZIP_MAX_WORKERS,
+                    thread_name_prefix="archive-zip",
+                )
+    return _archive_zip_executor
+
+
+async def close_archive_zip_executor() -> None:
+    """Shut down the archive executor during application teardown."""
+    global _archive_zip_executor
+    with _archive_zip_executor_lock:
+        executor = _archive_zip_executor
+        _archive_zip_executor = None
+    if executor is not None:
+        await asyncio.to_thread(
+            executor.shutdown,
+            wait=True,
+            cancel_futures=True,
+        )
 
 
 async def _assets_by_ids(
@@ -80,25 +125,23 @@ async def _assets_by_ids(
                 yield asset
 
 
-async def _validated_archive_assets(
-    client: AsyncGumnut, asset_ids: list[UUID]
+async def _validated_info_assets_by_ids(
+    client: AsyncGumnut,
+    asset_ids: list[UUID],
 ) -> list[AssetResponse]:
-    """Resolve every requested asset before starting an archive response."""
+    """Resolve every requested asset and its download-info metadata."""
     assets = [
         asset
         async for asset in _assets_by_ids(
-            client, asset_ids, include=_DOWNLOAD_ARCHIVE_INCLUDE
+            client,
+            asset_ids,
+            include=_DOWNLOAD_INFO_INCLUDE,
         )
     ]
     requested_ids = {uuid_to_gumnut_asset_id(asset_id) for asset_id in asset_ids}
     resolved_ids = {asset.id for asset in assets}
-    originals_available = all(
-        asset.file_data is not None
-        and asset.asset_urls is not None
-        and "original" in asset.asset_urls
-        for asset in assets
-    )
-    if requested_ids != resolved_ids or not originals_available:
+    metadata_available = all(asset.file_data is not None for asset in assets)
+    if requested_ids != resolved_ids or not metadata_available:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Not found or no asset.download access",
@@ -106,9 +149,42 @@ async def _validated_archive_assets(
     return assets
 
 
-async def _iterate_assets(assets: list[AssetResponse]) -> AsyncIterator[AssetResponse]:
-    for asset in assets:
-        yield asset
+async def _validated_archive_assets(
+    client: AsyncGumnut,
+    asset_ids: list[UUID],
+) -> list[_ArchiveAsset]:
+    """Preflight every archive member while retaining only streaming metadata."""
+    assets: list[_ArchiveAsset] = []
+    resolved_ids: set[str] = set()
+    async for asset in _assets_by_ids(
+        client,
+        asset_ids,
+        include=_DOWNLOAD_ARCHIVE_INCLUDE,
+    ):
+        file_data = asset.file_data
+        asset_urls = asset.asset_urls
+        if file_data is None or not asset_urls or "original" not in asset_urls:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Not found or no asset.download access",
+            )
+        resolved_ids.add(asset.id)
+        assets.append(
+            _ArchiveAsset(
+                filename=asset.original_file_name,
+                modified_at=file_data.file_modified_at,
+                size=file_data.file_size_bytes,
+                url=asset_urls["original"].url,
+            )
+        )
+
+    requested_ids = {uuid_to_gumnut_asset_id(asset_id) for asset_id in asset_ids}
+    if requested_ids != resolved_ids:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Not found or no asset.download access",
+        )
+    return assets
 
 
 async def _assets_for_info(
@@ -117,9 +193,8 @@ async def _assets_for_info(
 ) -> AsyncIterator[AssetResponse]:
     """Resolve the selector precedence used by Immich's download service."""
     if request.assetIds is not None:
-        async for asset in _assets_by_ids(
-            client, request.assetIds, include=_DOWNLOAD_INFO_INCLUDE
-        ):
+        assets = await _validated_info_assets_by_ids(client, request.assetIds)
+        for asset in assets:
             yield asset
         return
     elif request.albumId is not None:
@@ -188,7 +263,7 @@ async def _build_download_info(
 
 def _sanitize_archive_filename(filename: str) -> str:
     """Return a safe, flat ZIP member filename with no traversal semantics."""
-    sanitized = _UNSAFE_FILENAME_CHARACTERS.sub("", filename).strip().rstrip(".")
+    sanitized = _UNSAFE_FILENAME_CHARACTERS.sub("", filename).strip().rstrip(" .")
     reserved_windows_name = re.fullmatch(
         r"(?i)(con|prn|aux|nul|com[0-9]|lpt[0-9])(?:\..*)?", sanitized
     )
@@ -200,18 +275,19 @@ def _sanitize_archive_filename(filename: str) -> str:
 def _deduplicated_archive_name(
     original_file_name: str,
     next_suffix: dict[str, int],
-    emitted: set[str],
+    emitted_keys: set[str],
 ) -> str:
-    """Return a globally unique member name and reserve it."""
+    """Return a case-insensitively unique member name and reserve it."""
     base = _sanitize_archive_filename(original_file_name)
-    suffix = next_suffix.get(base, 0)
+    base_key = base.casefold()
+    suffix = next_suffix.get(base_key, 0)
     stem, extension = posixpath.splitext(base)
     candidate = base if suffix == 0 else f"{stem}+{suffix}{extension}"
-    while candidate in emitted:
+    while candidate.casefold() in emitted_keys:
         suffix += 1
         candidate = f"{stem}+{suffix}{extension}"
-    next_suffix[base] = suffix + 1
-    emitted.add(candidate)
+    next_suffix[base_key] = suffix + 1
+    emitted_keys.add(candidate.casefold())
     return candidate
 
 
@@ -240,38 +316,70 @@ async def _cdn_asset_chunks(
 
 
 async def _archive_members(
-    assets: AsyncIterable[AssetResponse],
+    assets: Iterable[_ArchiveAsset],
     state: _ArchiveStreamState,
 ) -> AsyncIterator[AsyncMemberFile]:
     next_suffix: dict[str, int] = {}
-    emitted_names: set[str] = set()
-    async for asset in assets:
-        asset_urls = asset.asset_urls
-        file_data = asset.file_data
-        if file_data is None or not asset_urls or "original" not in asset_urls:
-            raise RuntimeError("archive asset was not validated before streaming")
-        variant = asset_urls["original"]
+    emitted_name_keys: set[str] = set()
+    for asset in assets:
         yield (
-            _deduplicated_archive_name(
-                asset.original_file_name, next_suffix, emitted_names
-            ),
-            _zip_modified_at(file_data.file_modified_at),
+            _deduplicated_archive_name(asset.filename, next_suffix, emitted_name_keys),
+            _zip_modified_at(asset.modified_at),
             S_IFREG | 0o600,
-            ZIP_AUTO(file_data.file_size_bytes, level=0),
-            _cdn_asset_chunks(variant.url, state),
+            ZIP_AUTO(asset.size, level=0),
+            _cdn_asset_chunks(asset.url, state),
         )
 
 
+async def _async_archive_zip(
+    files: AsyncIterable[AsyncMemberFile],
+) -> AsyncIterator[bytes]:
+    """Bridge stream-zip through the archive-only bounded executor."""
+    loop = asyncio.get_running_loop()
+
+    def to_sync_iterable(async_iterable: AsyncIterable[_T]) -> Iterable[_T]:
+        async_iterator = async_iterable.__aiter__()
+
+        async def get_next() -> _T:
+            return await anext(async_iterator)
+
+        while True:
+            try:
+                yield asyncio.run_coroutine_threadsafe(get_next(), loop).result()
+            except StopAsyncIteration:
+                break
+
+    sync_member_files = (
+        member_file[0:4] + (to_sync_iterable(member_file[4]),)
+        for member_file in to_sync_iterable(files)
+    )
+    chunks = iter(
+        stream_zip(
+            files=sync_member_files,
+            extended_timestamps=False,
+        )
+    )
+    done = object()
+    executor = _get_archive_zip_executor()
+    while True:
+        context = copy_context()
+
+        def next_chunk() -> bytes | object:
+            return next(chunks, done)
+
+        value = await loop.run_in_executor(executor, context.run, next_chunk)
+        if value is done:
+            break
+        yield cast(bytes, value)
+
+
 async def _stream_archive(
-    assets: AsyncIterable[AssetResponse],
+    assets: Iterable[_ArchiveAsset],
 ) -> AsyncGenerator[bytes]:
     """Yield ZIP bytes and close the active CDN response on cancellation."""
     state = _ArchiveStreamState()
     try:
-        async for chunk in async_stream_zip(
-            _archive_members(assets, state),
-            extended_timestamps=False,
-        ):
+        async for chunk in _async_archive_zip(_archive_members(assets, state)):
             yield chunk
     finally:
         if state.response is not None:
@@ -286,14 +394,14 @@ async def download_archive(
     slug: Annotated[str | SkipJsonSchema[None], Query()] = None,
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
 ) -> StreamingResponse:
-    """Stream requested original assets as an on-the-fly ZIP archive.
+    """Stream requested uploads as an on-the-fly ZIP archive.
 
-    Gumnut does not currently expose edited variants, so the accepted
-    ``edited`` compatibility flag falls back to each asset's original.
+    Gumnut asset chains are currently root-only, so the accepted ``edited``
+    compatibility flag has no effect: the current rendering is the upload.
     """
     assets = await _validated_archive_assets(client, request.assetIds)
     return StreamingResponse(
-        _stream_archive(_iterate_assets(assets)),
+        _stream_archive(assets),
         media_type="application/zip",
         headers={"Content-Disposition": 'attachment; filename="assets.zip"'},
     )

--- a/routers/api/download.py
+++ b/routers/api/download.py
@@ -4,14 +4,14 @@ import asyncio
 import posixpath
 import re
 from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Iterable
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from contextvars import copy_context
 from dataclasses import dataclass
 from datetime import datetime
 from itertools import batched
 from stat import S_IFREG
-from threading import Lock
-from typing import Annotated, TypeVar, cast
+from threading import Event, Lock
+from typing import Annotated, Any, TypeVar, cast
 from unicodedata import normalize
 from uuid import UUID
 
@@ -56,6 +56,7 @@ _ZIP_MIN_TIMESTAMP = datetime(1980, 1, 1)
 _ZIP_MAX_TIMESTAMP = datetime(2107, 12, 31, 23, 59, 58)
 _ARCHIVE_CDN_CHUNK_SIZE = 64 * 1024
 _ARCHIVE_ZIP_MAX_WORKERS = 8
+_MAX_ARCHIVE_COMPONENT_BYTES = 255
 _UNSAFE_FILENAME_CHARACTERS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
 _archive_zip_executor: ThreadPoolExecutor | None = None
 _archive_zip_executor_lock = Lock()
@@ -113,8 +114,8 @@ async def _assets_by_ids(
     include: list[str],
 ) -> AsyncIterator[AssetResponse]:
     """Yield asset metadata in request order, one backend-sized chunk at a time."""
-    gumnut_ids = [uuid_to_gumnut_asset_id(asset_id) for asset_id in asset_ids]
-    for chunk in batched(gumnut_ids, GUMNUT_API_MAX_BULK_IDS):
+    for asset_id_chunk in batched(asset_ids, GUMNUT_API_MAX_BULK_IDS):
+        chunk = [uuid_to_gumnut_asset_id(asset_id) for asset_id in asset_id_chunk]
         assets_by_id: dict[str, AssetResponse] = {}
         async for asset in client.assets.list(
             ids=chunk,
@@ -140,9 +141,7 @@ async def _validated_info_assets_by_ids(
             include=_DOWNLOAD_INFO_INCLUDE,
         )
     ]
-    requested_ids = {uuid_to_gumnut_asset_id(asset_id) for asset_id in asset_ids}
-    resolved_ids = {asset.id for asset in assets}
-    if requested_ids != resolved_ids:
+    if len(assets) != len(asset_ids):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Not found or no asset.download access",
@@ -156,7 +155,6 @@ async def _validated_archive_assets(
 ) -> list[_ArchiveAsset]:
     """Preflight every archive member while retaining only streaming metadata."""
     assets: list[_ArchiveAsset] = []
-    resolved_ids: set[str] = set()
     async for asset in _assets_by_ids(
         client,
         asset_ids,
@@ -174,7 +172,6 @@ async def _validated_archive_assets(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Not found or no asset.download access",
             )
-        resolved_ids.add(asset.id)
         assets.append(
             _ArchiveAsset(
                 filename=asset.original_file_name,
@@ -184,8 +181,7 @@ async def _validated_archive_assets(
             )
         )
 
-    requested_ids = {uuid_to_gumnut_asset_id(asset_id) for asset_id in asset_ids}
-    if requested_ids != resolved_ids:
+    if len(assets) != len(asset_ids):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Not found or no asset.download access",
@@ -276,12 +272,46 @@ async def _build_download_info(
 def _sanitize_archive_filename(filename: str) -> str:
     """Return a safe, flat ZIP member filename with no traversal semantics."""
     sanitized = _UNSAFE_FILENAME_CHARACTERS.sub("", filename).strip().rstrip(" .")
-    reserved_windows_name = re.fullmatch(
-        r"(?i)(con|prn|aux|nul|com[0-9]|lpt[0-9])(?:\..*)?", sanitized
-    )
-    if sanitized in {"", ".", ".."} or reserved_windows_name:
+
+    if _is_unusable_archive_name(sanitized):
         return "unnamed"
     return sanitized
+
+
+def _is_unusable_archive_name(filename: str) -> bool:
+    """Return whether a filename is empty or aliases a Windows device."""
+    reserved_windows_name = re.fullmatch(
+        r"(?i)(con|prn|aux|nul|com[0-9]|lpt[0-9])(?:\..*)?", filename
+    )
+    return filename in {"", ".", ".."} or reserved_windows_name is not None
+
+
+def _truncate_utf8(value: str, max_bytes: int) -> str:
+    """Truncate text without splitting a UTF-8 code point."""
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+    return encoded[:max_bytes].decode("utf-8", errors="ignore")
+
+
+def _archive_name_candidate(base: str, suffix: int) -> str:
+    """Build a ZIP member name within common filesystem component limits."""
+    stem, extension = posixpath.splitext(base)
+    suffix_text = "" if suffix == 0 else f"+{suffix}"
+    suffix_size = len(suffix_text.encode("utf-8"))
+    extension = _truncate_utf8(
+        extension,
+        max(0, _MAX_ARCHIVE_COMPONENT_BYTES - suffix_size),
+    )
+    stem = _truncate_utf8(
+        stem,
+        max(
+            0,
+            _MAX_ARCHIVE_COMPONENT_BYTES - suffix_size - len(extension.encode("utf-8")),
+        ),
+    )
+    candidate = f"{stem}{suffix_text}{extension}".rstrip(" .")
+    return "unnamed" if _is_unusable_archive_name(candidate) else candidate
 
 
 def _deduplicated_archive_name(
@@ -295,13 +325,13 @@ def _deduplicated_archive_name(
         return normalize("NFC", name).casefold()
 
     base = _sanitize_archive_filename(original_file_name)
-    base_key = name_key(base)
+    base_candidate = _archive_name_candidate(base, 0)
+    base_key = name_key(base_candidate)
     suffix = next_suffix.get(base_key, 0)
-    stem, extension = posixpath.splitext(base)
-    candidate = base if suffix == 0 else f"{stem}+{suffix}{extension}"
+    candidate = base_candidate if suffix == 0 else _archive_name_candidate(base, suffix)
     while name_key(candidate) in emitted_keys:
         suffix += 1
-        candidate = f"{stem}+{suffix}{extension}"
+        candidate = _archive_name_candidate(base, suffix)
     next_suffix[base_key] = suffix + 1
     emitted_keys.add(name_key(candidate))
     return candidate
@@ -350,20 +380,46 @@ async def _archive_members(
 async def _async_archive_zip(
     files: AsyncIterable[AsyncMemberFile],
 ) -> AsyncIterator[bytes]:
-    """Bridge stream-zip through the archive-only bounded executor."""
+    """Bridge stream-zip through the archive-only bounded executor.
+
+    The synchronous ZIP worker blocks on event-loop reads. Shield its executor
+    future so task cancellation can first cancel that read, then wait for a
+    running worker to unwind before the caller closes the active CDN response.
+    """
     loop = asyncio.get_running_loop()
+    bridge_cancelled = Event()
+    pending_lock = Lock()
+    pending_read: Future[Any] | None = None
+
+    def cancel_pending_read() -> None:
+        bridge_cancelled.set()
+        with pending_lock:
+            future = pending_read
+        if future is not None:
+            future.cancel()
 
     def to_sync_iterable(async_iterable: AsyncIterable[_T]) -> Iterable[_T]:
+        nonlocal pending_read
         async_iterator = async_iterable.__aiter__()
 
         async def get_next() -> _T:
             return await anext(async_iterator)
 
         while True:
+            future = asyncio.run_coroutine_threadsafe(get_next(), loop)
+            with pending_lock:
+                pending_read = future
+                cancelled = bridge_cancelled.is_set()
+            if cancelled:
+                future.cancel()
             try:
-                yield asyncio.run_coroutine_threadsafe(get_next(), loop).result()
+                yield future.result()
             except StopAsyncIteration:
                 break
+            finally:
+                with pending_lock:
+                    if pending_read is future:
+                        pending_read = None
 
     sync_member_files = (
         member_file[0:4] + (to_sync_iterable(member_file[4]),)
@@ -383,7 +439,26 @@ async def _async_archive_zip(
         def next_chunk() -> bytes | object:
             return next(chunks, done)
 
-        value = await loop.run_in_executor(executor, context.run, next_chunk)
+        concurrent_call = executor.submit(context.run, next_chunk)
+        executor_call = asyncio.wrap_future(concurrent_call, loop=loop)
+        try:
+            value = await asyncio.shield(executor_call)
+        except BaseException:
+            cancel_pending_read()
+            if not concurrent_call.cancel():
+                while not executor_call.done():
+                    try:
+                        await asyncio.shield(executor_call)
+                    except asyncio.CancelledError:
+                        continue
+                    except BaseException:
+                        break
+                if executor_call.done() and not executor_call.cancelled():
+                    try:
+                        executor_call.result()
+                    except BaseException:
+                        pass
+            raise
         if value is done:
             break
         yield cast(bytes, value)

--- a/routers/api/download.py
+++ b/routers/api/download.py
@@ -12,6 +12,7 @@ from itertools import batched
 from stat import S_IFREG
 from threading import Lock
 from typing import Annotated, TypeVar, cast
+from unicodedata import normalize
 from uuid import UUID
 
 import httpx
@@ -277,17 +278,21 @@ def _deduplicated_archive_name(
     next_suffix: dict[str, int],
     emitted_keys: set[str],
 ) -> str:
-    """Return a case-insensitively unique member name and reserve it."""
+    """Return a filesystem-equivalent unique member name and reserve it."""
+
+    def name_key(name: str) -> str:
+        return normalize("NFC", name).casefold()
+
     base = _sanitize_archive_filename(original_file_name)
-    base_key = base.casefold()
+    base_key = name_key(base)
     suffix = next_suffix.get(base_key, 0)
     stem, extension = posixpath.splitext(base)
     candidate = base if suffix == 0 else f"{stem}+{suffix}{extension}"
-    while candidate.casefold() in emitted_keys:
+    while name_key(candidate) in emitted_keys:
         suffix += 1
         candidate = f"{stem}+{suffix}{extension}"
     next_suffix[base_key] = suffix + 1
-    emitted_keys.add(candidate.casefold())
+    emitted_keys.add(name_key(candidate))
     return candidate
 
 

--- a/routers/api/download.py
+++ b/routers/api/download.py
@@ -34,6 +34,7 @@ from routers.immich_models import (
     DownloadInfoDto,
     DownloadResponseDto,
 )
+from routers.utils.asset_conversion import resolve_file_modified_at
 from routers.utils.cdn_client import iter_cdn_response_bytes, open_cdn_response
 from routers.utils.gumnut_client import get_authenticated_gumnut_client
 from routers.utils.gumnut_id_conversion import (
@@ -50,7 +51,7 @@ router = APIRouter(
 )
 
 _DOWNLOAD_INFO_INCLUDE = ["file_data"]
-_DOWNLOAD_ARCHIVE_INCLUDE = ["file_data", "variants"]
+_DOWNLOAD_ARCHIVE_INCLUDE = ["file_data", "metadata", "variants"]
 _ZIP_MIN_TIMESTAMP = datetime(1980, 1, 1)
 _ZIP_MAX_TIMESTAMP = datetime(2107, 12, 31, 23, 59, 58)
 _ARCHIVE_CDN_CHUNK_SIZE = 64 * 1024
@@ -130,7 +131,7 @@ async def _validated_info_assets_by_ids(
     client: AsyncGumnut,
     asset_ids: list[UUID],
 ) -> list[AssetResponse]:
-    """Resolve every requested asset and its download-info metadata."""
+    """Resolve every requested asset before building download info."""
     assets = [
         asset
         async for asset in _assets_by_ids(
@@ -141,8 +142,7 @@ async def _validated_info_assets_by_ids(
     ]
     requested_ids = {uuid_to_gumnut_asset_id(asset_id) for asset_id in asset_ids}
     resolved_ids = {asset.id for asset in assets}
-    metadata_available = all(asset.file_data is not None for asset in assets)
-    if requested_ids != resolved_ids or not metadata_available:
+    if requested_ids != resolved_ids:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Not found or no asset.download access",
@@ -164,7 +164,12 @@ async def _validated_archive_assets(
     ):
         file_data = asset.file_data
         asset_urls = asset.asset_urls
-        if file_data is None or not asset_urls or "original" not in asset_urls:
+        if (
+            file_data is None
+            or file_data.file_size_bytes is None
+            or not asset_urls
+            or "original" not in asset_urls
+        ):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Not found or no asset.download access",
@@ -173,7 +178,7 @@ async def _validated_archive_assets(
         assets.append(
             _ArchiveAsset(
                 filename=asset.original_file_name,
-                modified_at=file_data.file_modified_at,
+                modified_at=resolve_file_modified_at(asset),
                 size=file_data.file_size_bytes,
                 url=asset_urls["original"].url,
             )
@@ -231,7 +236,13 @@ async def _assets_for_info(
 
 
 def _asset_size(asset: AssetResponse) -> int:
-    return asset.file_data.file_size_bytes if asset.file_data is not None else 0
+    file_data = asset.file_data
+    if file_data is None or file_data.file_size_bytes is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Not found or no asset.download access",
+        )
+    return file_data.file_size_bytes
 
 
 async def _build_download_info(

--- a/routers/api/download.py
+++ b/routers/api/download.py
@@ -1,20 +1,22 @@
 """Immich-compatible batch download planning and streaming ZIP archives."""
 
-import logging
 import posixpath
 import re
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator
+from dataclasses import dataclass
+from datetime import datetime
 from itertools import batched
 from stat import S_IFREG
 from typing import Annotated
 from uuid import UUID
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 from gumnut import AsyncGumnut
 from gumnut.types.asset_response import AssetResponse
 from pydantic.json_schema import SkipJsonSchema
-from stream_zip import ZIP_AUTO, async_stream_zip
+from stream_zip import ZIP_AUTO, AsyncMemberFile, async_stream_zip
 
 from routers.api.constants import (
     DEFAULT_DOWNLOAD_ARCHIVE_SIZE,
@@ -36,64 +38,100 @@ from routers.utils.gumnut_id_conversion import (
     uuid_to_gumnut_asset_id,
 )
 
-logger = logging.getLogger(__name__)
-
 router = APIRouter(
     prefix="/api/download",
     tags=["download"],
     responses={404: {"description": "Not found"}},
 )
 
-_DOWNLOAD_ASSET_INCLUDE = ["file_data", "variants"]
+_DOWNLOAD_INFO_INCLUDE = ["file_data"]
+_DOWNLOAD_ARCHIVE_INCLUDE = ["file_data", "variants"]
+_ZIP_MIN_TIMESTAMP = datetime(1980, 1, 1)
+_ZIP_MAX_TIMESTAMP = datetime(2107, 12, 31, 23, 59, 58)
+_ARCHIVE_CDN_CHUNK_SIZE = 64 * 1024
 _UNSAFE_FILENAME_CHARACTERS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
 
 
-def _is_downloadable(asset: AssetResponse) -> bool:
-    return bool(
-        asset.file_data is not None
-        and asset.asset_urls
-        and "original" in asset.asset_urls
-    )
+@dataclass(slots=True)
+class _ArchiveStreamState:
+    """Per-response ownership of the currently open CDN connection."""
+
+    response: httpx.Response | None = None
 
 
 async def _assets_by_ids(
-    client: AsyncGumnut, asset_ids: list[UUID]
-) -> list[AssetResponse]:
-    """Fetch asset metadata in backend-sized chunks and restore request order."""
+    client: AsyncGumnut,
+    asset_ids: list[UUID],
+    *,
+    include: list[str],
+) -> AsyncIterator[AssetResponse]:
+    """Yield asset metadata in request order, one backend-sized chunk at a time."""
     gumnut_ids = [uuid_to_gumnut_asset_id(asset_id) for asset_id in asset_ids]
-    assets_by_id: dict[str, AssetResponse] = {}
     for chunk in batched(gumnut_ids, GUMNUT_API_MAX_BULK_IDS):
+        assets_by_id: dict[str, AssetResponse] = {}
         async for asset in client.assets.list(
             ids=chunk,
-            include=_DOWNLOAD_ASSET_INCLUDE,
+            include=include,
             limit=GUMNUT_API_MAX_PAGE_SIZE,
         ):
             assets_by_id[asset.id] = asset
-    return [
-        assets_by_id[asset_id] for asset_id in gumnut_ids if asset_id in assets_by_id
+        for asset_id in chunk:
+            if asset := assets_by_id.get(asset_id):
+                yield asset
+
+
+async def _validated_archive_assets(
+    client: AsyncGumnut, asset_ids: list[UUID]
+) -> list[AssetResponse]:
+    """Resolve every requested asset before starting an archive response."""
+    assets = [
+        asset
+        async for asset in _assets_by_ids(
+            client, asset_ids, include=_DOWNLOAD_ARCHIVE_INCLUDE
+        )
     ]
+    requested_ids = {uuid_to_gumnut_asset_id(asset_id) for asset_id in asset_ids}
+    resolved_ids = {asset.id for asset in assets}
+    originals_available = all(
+        asset.file_data is not None
+        and asset.asset_urls is not None
+        and "original" in asset.asset_urls
+        for asset in assets
+    )
+    if requested_ids != resolved_ids or not originals_available:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Not found or no asset.download access",
+        )
+    return assets
+
+
+async def _iterate_assets(assets: list[AssetResponse]) -> AsyncIterator[AssetResponse]:
+    for asset in assets:
+        yield asset
 
 
 async def _assets_for_info(
     request: DownloadInfoDto,
     client: AsyncGumnut,
-) -> list[AssetResponse]:
+) -> AsyncIterator[AssetResponse]:
     """Resolve the selector precedence used by Immich's download service."""
     if request.assetIds is not None:
-        assets = await _assets_by_ids(client, request.assetIds)
+        async for asset in _assets_by_ids(
+            client, request.assetIds, include=_DOWNLOAD_INFO_INCLUDE
+        ):
+            yield asset
+        return
     elif request.albumId is not None:
         album_id = uuid_to_gumnut_album_id(request.albumId)
         # Preserve Immich's not-found behavior for an invalid/inaccessible album
         # instead of silently returning an empty successful download.
         await client.albums.retrieve(album_id)
-        assets = [
-            asset
-            async for asset in client.assets.list(
-                album_id=album_id,
-                include=_DOWNLOAD_ASSET_INCLUDE,
-                limit=GUMNUT_API_MAX_PAGE_SIZE,
-            )
-        ]
+        assets = client.assets.list(
+            album_id=album_id,
+            include=_DOWNLOAD_INFO_INCLUDE,
+            limit=GUMNUT_API_MAX_PAGE_SIZE,
+        )
     elif request.userId is not None:
         current_user = await client.users.me()
         current_user_id = safe_uuid_from_user_id(current_user.id)
@@ -102,34 +140,32 @@ async def _assets_for_info(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Cannot download another user's library",
             )
-        assets = [
-            asset
-            async for asset in client.assets.list(
-                include=_DOWNLOAD_ASSET_INCLUDE,
-                limit=GUMNUT_API_MAX_PAGE_SIZE,
-            )
-        ]
+        assets = client.assets.list(
+            include=_DOWNLOAD_INFO_INCLUDE,
+            limit=GUMNUT_API_MAX_PAGE_SIZE,
+        )
     else:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="assetIds, albumId, or userId is required",
         )
 
-    return [asset for asset in assets if _is_downloadable(asset)]
+    async for asset in assets:
+        yield asset
 
 
 def _asset_size(asset: AssetResponse) -> int:
     return asset.file_data.file_size_bytes if asset.file_data is not None else 0
 
 
-def _build_download_info(
-    assets: list[AssetResponse], target_size: int
+async def _build_download_info(
+    assets: AsyncIterable[AssetResponse], target_size: int
 ) -> DownloadResponseDto:
     archives: list[DownloadArchiveInfo] = []
     archive_ids: list[UUID] = []
     archive_size = 0
 
-    for asset in assets:
+    async for asset in assets:
         archive_ids.append(safe_uuid_from_asset_id(asset.id))
         archive_size += _asset_size(asset)
         # Match Immich: the asset that crosses the threshold remains in the
@@ -161,49 +197,86 @@ def _sanitize_archive_filename(filename: str) -> str:
     return sanitized
 
 
-def _deduplicated_archive_names(assets: list[AssetResponse]) -> list[str]:
-    seen: dict[str, int] = {}
-    names: list[str] = []
-    for asset in assets:
-        filename = _sanitize_archive_filename(asset.original_file_name)
-        count = seen.get(filename, 0)
-        seen[filename] = count + 1
-        if count:
-            stem, extension = posixpath.splitext(filename)
-            filename = f"{stem}+{count}{extension}"
-        names.append(filename)
-    return names
+def _deduplicated_archive_name(
+    original_file_name: str,
+    next_suffix: dict[str, int],
+    emitted: set[str],
+) -> str:
+    """Return a globally unique member name and reserve it."""
+    base = _sanitize_archive_filename(original_file_name)
+    suffix = next_suffix.get(base, 0)
+    stem, extension = posixpath.splitext(base)
+    candidate = base if suffix == 0 else f"{stem}+{suffix}{extension}"
+    while candidate in emitted:
+        suffix += 1
+        candidate = f"{stem}+{suffix}{extension}"
+    next_suffix[base] = suffix + 1
+    emitted.add(candidate)
+    return candidate
 
 
-async def _cdn_asset_chunks(url: str) -> AsyncIterator[bytes]:
+def _zip_modified_at(modified_at: datetime) -> datetime:
+    """Clamp timestamps to the range representable by a DOS ZIP header."""
+    if modified_at.year < _ZIP_MIN_TIMESTAMP.year:
+        return _ZIP_MIN_TIMESTAMP.replace(tzinfo=modified_at.tzinfo)
+    if modified_at.year > _ZIP_MAX_TIMESTAMP.year:
+        return _ZIP_MAX_TIMESTAMP.replace(tzinfo=modified_at.tzinfo)
+    return modified_at
+
+
+async def _cdn_asset_chunks(
+    url: str, state: _ArchiveStreamState
+) -> AsyncGenerator[bytes]:
     response = await open_cdn_response(url)
-    async for chunk in iter_cdn_response_bytes(response):
-        yield chunk
+    state.response = response
+    body = iter_cdn_response_bytes(response, chunk_size=_ARCHIVE_CDN_CHUNK_SIZE)
+    try:
+        async for chunk in body:
+            yield chunk
+    finally:
+        await body.aclose()
+        if state.response is response:
+            state.response = None
 
 
-async def _archive_members(assets: list[AssetResponse]):
-    names = _deduplicated_archive_names(assets)
-    for asset, filename in zip(assets, names, strict=True):
+async def _archive_members(
+    assets: AsyncIterable[AssetResponse],
+    state: _ArchiveStreamState,
+) -> AsyncIterator[AsyncMemberFile]:
+    next_suffix: dict[str, int] = {}
+    emitted_names: set[str] = set()
+    async for asset in assets:
         asset_urls = asset.asset_urls
         file_data = asset.file_data
         if file_data is None or not asset_urls or "original" not in asset_urls:
-            # Direct archive requests can bypass /download/info. Match Immich's
-            # missing-asset tolerance and omit an unavailable original.
-            logger.warning(
-                "Skipping unavailable original in download archive",
-                extra={"asset_id": asset.id},
-            )
-            continue
+            raise RuntimeError("archive asset was not validated before streaming")
         variant = asset_urls["original"]
-        size = file_data.file_size_bytes
-        modified_at = file_data.file_modified_at
         yield (
-            filename,
-            modified_at,
+            _deduplicated_archive_name(
+                asset.original_file_name, next_suffix, emitted_names
+            ),
+            _zip_modified_at(file_data.file_modified_at),
             S_IFREG | 0o600,
-            ZIP_AUTO(size, level=0),
-            _cdn_asset_chunks(variant.url),
+            ZIP_AUTO(file_data.file_size_bytes, level=0),
+            _cdn_asset_chunks(variant.url, state),
         )
+
+
+async def _stream_archive(
+    assets: AsyncIterable[AssetResponse],
+) -> AsyncGenerator[bytes]:
+    """Yield ZIP bytes and close the active CDN response on cancellation."""
+    state = _ArchiveStreamState()
+    try:
+        async for chunk in async_stream_zip(
+            _archive_members(assets, state),
+            extended_timestamps=False,
+        ):
+            yield chunk
+    finally:
+        if state.response is not None:
+            await state.response.aclose()
+            state.response = None
 
 
 @router.post("/archive")
@@ -218,21 +291,9 @@ async def download_archive(
     Gumnut does not currently expose edited variants, so the accepted
     ``edited`` compatibility flag falls back to each asset's original.
     """
-    requested_assets = await _assets_by_ids(client, request.assetIds)
-    assets: list[AssetResponse] = []
-    for asset in requested_assets:
-        if _is_downloadable(asset):
-            assets.append(asset)
-        else:
-            # Direct archive requests can bypass /download/info. Match Immich's
-            # missing-asset tolerance and omit an unavailable original before
-            # assigning duplicate-name suffixes to the remaining members.
-            logger.warning(
-                "Skipping unavailable original in download archive",
-                extra={"asset_id": asset.id},
-            )
+    assets = await _validated_archive_assets(client, request.assetIds)
     return StreamingResponse(
-        async_stream_zip(_archive_members(assets)),
+        _stream_archive(_iterate_assets(assets)),
         media_type="application/zip",
         headers={"Content-Disposition": 'attachment; filename="assets.zip"'},
     )
@@ -246,7 +307,7 @@ async def get_download_info(
     client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
 ) -> DownloadResponseDto:
     """Return archive groups and original byte sizes for a batch download."""
-    assets = await _assets_for_info(request, client)
-    return _build_download_info(
-        assets, request.archiveSize or DEFAULT_DOWNLOAD_ARCHIVE_SIZE
+    return await _build_download_info(
+        _assets_for_info(request, client),
+        request.archiveSize or DEFAULT_DOWNLOAD_ARCHIVE_SIZE,
     )

--- a/routers/api/download.py
+++ b/routers/api/download.py
@@ -281,7 +281,7 @@ def _sanitize_archive_filename(filename: str) -> str:
 def _is_unusable_archive_name(filename: str) -> bool:
     """Return whether a filename is empty or aliases a Windows device."""
     reserved_windows_name = re.fullmatch(
-        r"(?i)(con|prn|aux|nul|com[0-9]|lpt[0-9])(?:\..*)?", filename
+        r"(?i)(con|prn|aux|nul|com[0-9¹²³]|lpt[0-9¹²³])(?:\..*)?", filename
     )
     return filename in {"", ".", ".."} or reserved_windows_name is not None
 

--- a/routers/api/download.py
+++ b/routers/api/download.py
@@ -1,10 +1,42 @@
-from fastapi import APIRouter, Query, Response
+"""Immich-compatible batch download planning and streaming ZIP archives."""
 
+import logging
+import posixpath
+import re
+from collections.abc import AsyncIterator
+from itertools import batched
+from stat import S_IFREG
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import StreamingResponse
+from gumnut import AsyncGumnut
+from gumnut.types.asset_response import AssetResponse
+from pydantic.json_schema import SkipJsonSchema
+from stream_zip import ZIP_AUTO, async_stream_zip
+
+from routers.api.constants import (
+    DEFAULT_DOWNLOAD_ARCHIVE_SIZE,
+    GUMNUT_API_MAX_BULK_IDS,
+    GUMNUT_API_MAX_PAGE_SIZE,
+)
 from routers.immich_models import (
     DownloadArchiveDto,
+    DownloadArchiveInfo,
     DownloadInfoDto,
     DownloadResponseDto,
 )
+from routers.utils.cdn_client import iter_cdn_response_bytes, open_cdn_response
+from routers.utils.gumnut_client import get_authenticated_gumnut_client
+from routers.utils.gumnut_id_conversion import (
+    safe_uuid_from_asset_id,
+    safe_uuid_from_user_id,
+    uuid_to_gumnut_album_id,
+    uuid_to_gumnut_asset_id,
+)
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/api/download",
@@ -12,41 +44,209 @@ router = APIRouter(
     responses={404: {"description": "Not found"}},
 )
 
+_DOWNLOAD_ASSET_INCLUDE = ["file_data", "variants"]
+_UNSAFE_FILENAME_CHARACTERS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+
+
+def _is_downloadable(asset: AssetResponse) -> bool:
+    return bool(
+        asset.file_data is not None
+        and asset.asset_urls
+        and "original" in asset.asset_urls
+    )
+
+
+async def _assets_by_ids(
+    client: AsyncGumnut, asset_ids: list[UUID]
+) -> list[AssetResponse]:
+    """Fetch asset metadata in backend-sized chunks and restore request order."""
+    gumnut_ids = [uuid_to_gumnut_asset_id(asset_id) for asset_id in asset_ids]
+    assets_by_id: dict[str, AssetResponse] = {}
+    for chunk in batched(gumnut_ids, GUMNUT_API_MAX_BULK_IDS):
+        async for asset in client.assets.list(
+            ids=chunk,
+            include=_DOWNLOAD_ASSET_INCLUDE,
+            limit=GUMNUT_API_MAX_PAGE_SIZE,
+        ):
+            assets_by_id[asset.id] = asset
+    return [
+        assets_by_id[asset_id] for asset_id in gumnut_ids if asset_id in assets_by_id
+    ]
+
+
+async def _assets_for_info(
+    request: DownloadInfoDto,
+    client: AsyncGumnut,
+) -> list[AssetResponse]:
+    """Resolve the selector precedence used by Immich's download service."""
+    if request.assetIds is not None:
+        assets = await _assets_by_ids(client, request.assetIds)
+    elif request.albumId is not None:
+        album_id = uuid_to_gumnut_album_id(request.albumId)
+        # Preserve Immich's not-found behavior for an invalid/inaccessible album
+        # instead of silently returning an empty successful download.
+        await client.albums.retrieve(album_id)
+        assets = [
+            asset
+            async for asset in client.assets.list(
+                album_id=album_id,
+                include=_DOWNLOAD_ASSET_INCLUDE,
+                limit=GUMNUT_API_MAX_PAGE_SIZE,
+            )
+        ]
+    elif request.userId is not None:
+        current_user = await client.users.me()
+        current_user_id = safe_uuid_from_user_id(current_user.id)
+        if request.userId != current_user_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Cannot download another user's library",
+            )
+        assets = [
+            asset
+            async for asset in client.assets.list(
+                include=_DOWNLOAD_ASSET_INCLUDE,
+                limit=GUMNUT_API_MAX_PAGE_SIZE,
+            )
+        ]
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="assetIds, albumId, or userId is required",
+        )
+
+    return [asset for asset in assets if _is_downloadable(asset)]
+
+
+def _asset_size(asset: AssetResponse) -> int:
+    return asset.file_data.file_size_bytes if asset.file_data is not None else 0
+
+
+def _build_download_info(
+    assets: list[AssetResponse], target_size: int
+) -> DownloadResponseDto:
+    archives: list[DownloadArchiveInfo] = []
+    archive_ids: list[UUID] = []
+    archive_size = 0
+
+    for asset in assets:
+        archive_ids.append(safe_uuid_from_asset_id(asset.id))
+        archive_size += _asset_size(asset)
+        # Match Immich: the asset that crosses the threshold remains in the
+        # current archive, so one oversized asset naturally forms one archive.
+        if archive_size > target_size:
+            archives.append(
+                DownloadArchiveInfo(assetIds=archive_ids, size=archive_size)
+            )
+            archive_ids = []
+            archive_size = 0
+
+    if archive_ids:
+        archives.append(DownloadArchiveInfo(assetIds=archive_ids, size=archive_size))
+
+    return DownloadResponseDto(
+        archives=archives,
+        totalSize=sum(archive.size for archive in archives),
+    )
+
+
+def _sanitize_archive_filename(filename: str) -> str:
+    """Return a safe, flat ZIP member filename with no traversal semantics."""
+    sanitized = _UNSAFE_FILENAME_CHARACTERS.sub("", filename).strip().rstrip(".")
+    reserved_windows_name = re.fullmatch(
+        r"(?i)(con|prn|aux|nul|com[0-9]|lpt[0-9])(?:\..*)?", sanitized
+    )
+    if sanitized in {"", ".", ".."} or reserved_windows_name:
+        return "unnamed"
+    return sanitized
+
+
+def _deduplicated_archive_names(assets: list[AssetResponse]) -> list[str]:
+    seen: dict[str, int] = {}
+    names: list[str] = []
+    for asset in assets:
+        filename = _sanitize_archive_filename(asset.original_file_name)
+        count = seen.get(filename, 0)
+        seen[filename] = count + 1
+        if count:
+            stem, extension = posixpath.splitext(filename)
+            filename = f"{stem}+{count}{extension}"
+        names.append(filename)
+    return names
+
+
+async def _cdn_asset_chunks(url: str) -> AsyncIterator[bytes]:
+    response = await open_cdn_response(url)
+    async for chunk in iter_cdn_response_bytes(response):
+        yield chunk
+
+
+async def _archive_members(assets: list[AssetResponse]):
+    names = _deduplicated_archive_names(assets)
+    for asset, filename in zip(assets, names, strict=True):
+        asset_urls = asset.asset_urls
+        file_data = asset.file_data
+        if file_data is None or not asset_urls or "original" not in asset_urls:
+            # Direct archive requests can bypass /download/info. Match Immich's
+            # missing-asset tolerance and omit an unavailable original.
+            logger.warning(
+                "Skipping unavailable original in download archive",
+                extra={"asset_id": asset.id},
+            )
+            continue
+        variant = asset_urls["original"]
+        size = file_data.file_size_bytes
+        modified_at = file_data.file_modified_at
+        yield (
+            filename,
+            modified_at,
+            S_IFREG | 0o600,
+            ZIP_AUTO(size, level=0),
+            _cdn_asset_chunks(variant.url),
+        )
+
 
 @router.post("/archive")
 async def download_archive(
     request: DownloadArchiveDto,
-    key: str = Query(default=None),
-    slug: str = Query(default=None),
-) -> Response:
-    """
-    Download an archive of assets.
-    This is a stub implementation that returns empty binary data.
-    """
-    # Return fake binary content as a zip file
-    fake_zip_content = b""
+    key: Annotated[str | SkipJsonSchema[None], Query()] = None,
+    slug: Annotated[str | SkipJsonSchema[None], Query()] = None,
+    client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
+) -> StreamingResponse:
+    """Stream requested original assets as an on-the-fly ZIP archive.
 
-    return Response(
-        content=fake_zip_content,
-        media_type="application/octet-stream",
-        headers={
-            "Content-Disposition": "attachment; filename=assets.zip",
-            "Content-Length": str(len(fake_zip_content)),
-        },
+    Gumnut does not currently expose edited variants, so the accepted
+    ``edited`` compatibility flag falls back to each asset's original.
+    """
+    requested_assets = await _assets_by_ids(client, request.assetIds)
+    assets: list[AssetResponse] = []
+    for asset in requested_assets:
+        if _is_downloadable(asset):
+            assets.append(asset)
+        else:
+            # Direct archive requests can bypass /download/info. Match Immich's
+            # missing-asset tolerance and omit an unavailable original before
+            # assigning duplicate-name suffixes to the remaining members.
+            logger.warning(
+                "Skipping unavailable original in download archive",
+                extra={"asset_id": asset.id},
+            )
+    return StreamingResponse(
+        async_stream_zip(_archive_members(assets)),
+        media_type="application/zip",
+        headers={"Content-Disposition": 'attachment; filename="assets.zip"'},
     )
 
 
-@router.post("/info", status_code=201)
+@router.post("/info", status_code=status.HTTP_201_CREATED)
 async def get_download_info(
     request: DownloadInfoDto,
-    key: str = Query(default=None),
-    slug: str = Query(default=None),
+    key: Annotated[str | SkipJsonSchema[None], Query()] = None,
+    slug: Annotated[str | SkipJsonSchema[None], Query()] = None,
+    client: AsyncGumnut = Depends(get_authenticated_gumnut_client),
 ) -> DownloadResponseDto:
-    """
-    Get download information.
-    This is a stub implementation that returns fake download info.
-    """
-    return DownloadResponseDto(
-        archives=[],
-        totalSize=0,
+    """Return archive groups and original byte sizes for a batch download."""
+    assets = await _assets_for_info(request, client)
+    return _build_download_info(
+        assets, request.archiveSize or DEFAULT_DOWNLOAD_ARCHIVE_SIZE
     )

--- a/routers/api/users.py
+++ b/routers/api/users.py
@@ -44,6 +44,7 @@ from routers.utils.current_user import (
     get_current_user_id,
     map_user_quota,
 )
+from routers.api.constants import DEFAULT_DOWNLOAD_ARCHIVE_SIZE
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +58,9 @@ router = APIRouter(
 userPreferencesResponse: UserPreferencesResponseDto = UserPreferencesResponseDto(
     albums=AlbumsResponse(defaultAssetOrder=AssetOrder.desc),
     cast=CastResponse(gCastEnabled=False),
-    download=DownloadResponse(archiveSize=0, includeEmbeddedVideos=False),
+    download=DownloadResponse(
+        archiveSize=DEFAULT_DOWNLOAD_ARCHIVE_SIZE, includeEmbeddedVideos=False
+    ),
     emailNotifications=EmailNotificationsResponse(
         albumInvite=False, albumUpdate=False, enabled=False
     ),

--- a/routers/api/users.py
+++ b/routers/api/users.py
@@ -5,7 +5,7 @@ from uuid import UUID, uuid4
 from typing import List
 import logging
 
-from routers.api.constants import STUB_LICENSE_KEY
+from routers.api.constants import DEFAULT_DOWNLOAD_ARCHIVE_SIZE, STUB_LICENSE_KEY
 from routers.immich_models import (
     AlbumsResponse,
     AssetOrder,
@@ -44,7 +44,6 @@ from routers.utils.current_user import (
     get_current_user_id,
     map_user_quota,
 )
-from routers.api.constants import DEFAULT_DOWNLOAD_ARCHIVE_SIZE
 
 logger = logging.getLogger(__name__)
 

--- a/routers/utils/cdn_client.py
+++ b/routers/utils/cdn_client.py
@@ -127,8 +127,9 @@ async def open_cdn_response(
 
     The caller owns the successful response and must consume it through
     :func:`iter_cdn_response_bytes` (or close it explicitly). Keeping this
-    status mapping in one place makes archive members and individual media
-    downloads fail consistently.
+    status classification in one place keeps callers from interpreting CDN
+    responses differently. Archive failures can still surface after the ZIP
+    response headers have been sent, while individual downloads open first.
     """
     client = await get_cdn_http_client()
     headers = {"Range": range_header} if range_header is not None else {}

--- a/routers/utils/cdn_client.py
+++ b/routers/utils/cdn_client.py
@@ -7,6 +7,8 @@ and a streaming helper that maps CDN errors to adapter HTTP exceptions.
 
 import asyncio
 import logging
+from collections.abc import AsyncGenerator
+from urllib.parse import urlsplit
 
 import httpx
 from fastapi import HTTPException, status
@@ -57,6 +59,11 @@ DEFAULT_FORWARDED_HEADERS = (
     "last-modified",
     "cache-control",
 )
+
+
+def _cdn_log_context(cdn_url: str) -> dict[str, str]:
+    """Return non-sensitive CDN context safe for structured logs."""
+    return {"cdn_host": urlsplit(cdn_url).hostname or "unknown"}
 
 
 async def stream_from_cdn(
@@ -133,7 +140,8 @@ async def open_cdn_response(
         )
     except httpx.HTTPError as exc:
         logger.warning(
-            "CDN connection error", extra={"cdn_url": cdn_url, "error": str(exc)}
+            "CDN connection error",
+            extra={**_cdn_log_context(cdn_url), "error_type": type(exc).__name__},
         )
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -143,7 +151,10 @@ async def open_cdn_response(
     if cdn_response.status_code in (403, 404):
         logger.warning(
             "CDN asset not found",
-            extra={"cdn_url": cdn_url, "status_code": cdn_response.status_code},
+            extra={
+                **_cdn_log_context(cdn_url),
+                "status_code": cdn_response.status_code,
+            },
         )
         await cdn_response.aclose()
         raise HTTPException(
@@ -152,7 +163,7 @@ async def open_cdn_response(
         )
 
     if cdn_response.status_code == 416:
-        logger.warning("CDN range not satisfiable", extra={"cdn_url": cdn_url})
+        logger.warning("CDN range not satisfiable", extra=_cdn_log_context(cdn_url))
         error_headers: dict[str, str] = {"Accept-Ranges": "bytes"}
         if content_range := cdn_response.headers.get("content-range"):
             error_headers["Content-Range"] = content_range
@@ -166,7 +177,10 @@ async def open_cdn_response(
     if cdn_response.status_code >= 400:
         logger.warning(
             "CDN upstream error",
-            extra={"cdn_url": cdn_url, "status_code": cdn_response.status_code},
+            extra={
+                **_cdn_log_context(cdn_url),
+                "status_code": cdn_response.status_code,
+            },
         )
         await cdn_response.aclose()
         raise HTTPException(
@@ -177,10 +191,14 @@ async def open_cdn_response(
     return cdn_response
 
 
-async def iter_cdn_response_bytes(cdn_response: httpx.Response):
+async def iter_cdn_response_bytes(
+    cdn_response: httpx.Response,
+    *,
+    chunk_size: int = 8192,
+) -> AsyncGenerator[bytes]:
     """Yield a validated CDN response body and always release its connection."""
     try:
-        async for chunk in cdn_response.aiter_bytes(chunk_size=8192):
+        async for chunk in cdn_response.aiter_bytes(chunk_size=chunk_size):
             yield chunk
     finally:
         await cdn_response.aclose()

--- a/routers/utils/cdn_client.py
+++ b/routers/utils/cdn_client.py
@@ -82,11 +82,49 @@ async def stream_from_cdn(
         HTTPException: 404 for CDN 403/404, 416 for range-not-satisfiable,
             502 for CDN 5xx or connection errors.
     """
-    client = await get_cdn_http_client()
+    cdn_response = await open_cdn_response(cdn_url, range_header=range_header)
 
-    headers: dict[str, str] = {}
-    if range_header is not None:
-        headers["Range"] = range_header
+    content_type = cdn_response.headers.get("content-type") or mimetype
+    response_headers: dict[str, str] = {}
+
+    # Forward allowlisted upstream headers when present
+    for h in forwarded_headers:
+        v = cdn_response.headers.get(h)
+        if v:
+            response_headers[h if h == "etag" else h.title()] = v
+
+    # iOS AVPlayer probes Accept-Ranges on the initial non-Range 200 response to
+    # decide whether the source is seekable. Without it, MP4s whose moov atom
+    # isn't at the front are not playable and the player can fail abruptly.
+    # R2 via the Cloudflare Worker supports byte ranges unconditionally, so it
+    # is safe to advertise this on every successful CDN response.
+    response_headers["Accept-Ranges"] = "bytes"
+
+    if cdn_response.status_code == 206:
+        content_range = cdn_response.headers.get("content-range")
+        if content_range:
+            response_headers["Content-Range"] = content_range
+
+    return StreamingResponse(
+        iter_cdn_response_bytes(cdn_response),
+        status_code=cdn_response.status_code,
+        media_type=content_type,
+        headers=response_headers,
+    )
+
+
+async def open_cdn_response(
+    cdn_url: str, range_header: str | None = None
+) -> httpx.Response:
+    """Open and validate one streamed CDN response without reading its body.
+
+    The caller owns the successful response and must consume it through
+    :func:`iter_cdn_response_bytes` (or close it explicitly). Keeping this
+    status mapping in one place makes archive members and individual media
+    downloads fail consistently.
+    """
+    client = await get_cdn_http_client()
+    headers = {"Range": range_header} if range_header is not None else {}
 
     try:
         cdn_response = await client.send(
@@ -116,8 +154,8 @@ async def stream_from_cdn(
     if cdn_response.status_code == 416:
         logger.warning("CDN range not satisfiable", extra={"cdn_url": cdn_url})
         error_headers: dict[str, str] = {"Accept-Ranges": "bytes"}
-        if cr := cdn_response.headers.get("content-range"):
-            error_headers["Content-Range"] = cr
+        if content_range := cdn_response.headers.get("content-range"):
+            error_headers["Content-Range"] = content_range
         await cdn_response.aclose()
         raise HTTPException(
             status_code=status.HTTP_416_RANGE_NOT_SATISFIABLE,
@@ -136,37 +174,13 @@ async def stream_from_cdn(
             detail="CDN upstream error",
         )
 
-    content_type = cdn_response.headers.get("content-type") or mimetype
-    response_headers: dict[str, str] = {}
+    return cdn_response
 
-    # Forward allowlisted upstream headers when present
-    for h in forwarded_headers:
-        v = cdn_response.headers.get(h)
-        if v:
-            response_headers[h if h == "etag" else h.title()] = v
 
-    # iOS AVPlayer probes Accept-Ranges on the initial non-Range 200 response to
-    # decide whether the source is seekable. Without it, MP4s whose moov atom
-    # isn't at the front are not playable and the player can fail abruptly.
-    # R2 via the Cloudflare Worker supports byte ranges unconditionally, so it
-    # is safe to advertise this on every successful CDN response.
-    response_headers["Accept-Ranges"] = "bytes"
-
-    if cdn_response.status_code == 206:
-        content_range = cdn_response.headers.get("content-range")
-        if content_range:
-            response_headers["Content-Range"] = content_range
-
-    async def _stream_and_close():
-        try:
-            async for chunk in cdn_response.aiter_bytes(chunk_size=8192):
-                yield chunk
-        finally:
-            await cdn_response.aclose()
-
-    return StreamingResponse(
-        _stream_and_close(),
-        status_code=cdn_response.status_code,
-        media_type=content_type,
-        headers=response_headers,
-    )
+async def iter_cdn_response_bytes(cdn_response: httpx.Response):
+    """Yield a validated CDN response body and always release its connection."""
+    try:
+        async for chunk in cdn_response.aiter_bytes(chunk_size=8192):
+            yield chunk
+    finally:
+        await cdn_response.aclose()

--- a/tests/unit/api/test_download.py
+++ b/tests/unit/api/test_download.py
@@ -330,6 +330,14 @@ def test_archive_names_revalidate_windows_devices_after_truncation() -> None:
     assert _archive_names([filename]) == ["unnamed"]
 
 
+@pytest.mark.parametrize(
+    "filename",
+    ["COM¹.jpg", "COM².jpg", "COM³.jpg", "LPT¹.jpg", "LPT².jpg", "LPT³.jpg"],
+)
+def test_archive_names_reject_superscript_windows_devices(filename: str) -> None:
+    assert _archive_names([filename]) == ["unnamed"]
+
+
 def test_distinct_truncated_names_share_suffix_progression() -> None:
     next_suffix: dict[str, int] = {}
     emitted: set[str] = set()

--- a/tests/unit/api/test_download.py
+++ b/tests/unit/api/test_download.py
@@ -1,5 +1,7 @@
 """Tests for batch download planning and streamed ZIP archives."""
 
+from collections.abc import AsyncGenerator, AsyncIterator
+from datetime import datetime
 from io import BytesIO
 from typing import cast
 from unittest.mock import AsyncMock, Mock, patch
@@ -8,6 +10,7 @@ from zipfile import ZipFile
 
 import pytest
 from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
 from gumnut.types.asset_response import AssetResponse
 
 from routers.api.constants import GUMNUT_API_MAX_BULK_IDS
@@ -15,8 +18,10 @@ from routers.api.download import (
     _assets_by_ids,
     _assets_for_info,
     _build_download_info,
-    _deduplicated_archive_names,
+    _deduplicated_archive_name,
+    _stream_archive,
     download_archive,
+    get_download_info,
 )
 from routers.immich_models import DownloadArchiveDto, DownloadInfoDto
 from routers.utils.gumnut_id_conversion import (
@@ -40,20 +45,34 @@ def _download_asset(
         original_file_name=filename,
     )
     asset.file_data.file_size_bytes = size
-    asset.asset_urls = (
-        {"original": Mock(url=url or f"https://cdn.example.com/{asset_id}")}
-        if url is not None or filename
-        else {}
-    )
+    asset.asset_urls = {
+        "original": Mock(url=url or f"https://cdn.example.com/{asset_id}")
+    }
     return cast(AssetResponse, asset)
 
 
-async def _collect_response_body(response) -> bytes:
-    return b"".join([chunk async for chunk in response.body_iterator])
+async def _collect_response_body(response: StreamingResponse) -> bytes:
+    return b"".join([cast(bytes, chunk) async for chunk in response.body_iterator])
+
+
+async def _asset_stream(assets: list[AssetResponse]) -> AsyncIterator[AssetResponse]:
+    for asset in assets:
+        yield asset
+
+
+def _archive_names(filenames: list[str]) -> list[str]:
+    next_suffix: dict[str, int] = {}
+    emitted: set[str] = set()
+    return [
+        _deduplicated_archive_name(filename, next_suffix, emitted)
+        for filename in filenames
+    ]
 
 
 @pytest.mark.anyio
-async def test_archive_streams_valid_zip_in_request_order_with_safe_unique_names():
+async def test_archive_streams_valid_zip_in_request_order_with_safe_unique_names() -> (
+    None
+):
     first_id = uuid4()
     second_id = uuid4()
     assets = [
@@ -71,15 +90,13 @@ async def test_archive_streams_valid_zip_in_request_order_with_safe_unique_names
         ),
     ]
     client = Mock()
-    # Deliberately reverse the backend result; the archive must follow request order.
     client.assets.list = Mock(return_value=MockSyncCursorPage(list(reversed(assets))))
-
     chunks = {
         "https://cdn.example.com/first": (b"first",),
         "https://cdn.example.com/second": (b"sec", b"ond"),
     }
 
-    async def fake_cdn_chunks(url: str):
+    async def fake_cdn_chunks(url: str, state: object) -> AsyncIterator[bytes]:
         for chunk in chunks[url]:
             yield chunk
 
@@ -100,18 +117,22 @@ async def test_archive_streams_valid_zip_in_request_order_with_safe_unique_names
 
 
 @pytest.mark.anyio
-async def test_assets_by_ids_chunks_backend_filter_and_preserves_duplicates():
+async def test_assets_by_ids_chunks_backend_filter_and_preserves_duplicates() -> None:
     asset_ids = [uuid4() for _ in range(GUMNUT_API_MAX_BULK_IDS + 1)]
     selected = _download_asset(asset_ids[0])
     client = Mock()
     client.assets.list = Mock(
-        side_effect=[
-            MockSyncCursorPage([selected]),
-            MockSyncCursorPage([]),
-        ]
+        side_effect=[MockSyncCursorPage([selected]), MockSyncCursorPage([selected])]
     )
 
-    result = await _assets_by_ids(client, [*asset_ids, asset_ids[0]])
+    result = [
+        asset
+        async for asset in _assets_by_ids(
+            client,
+            [*asset_ids, asset_ids[0]],
+            include=["file_data", "variants"],
+        )
+    ]
 
     assert result == [selected, selected]
     assert client.assets.list.call_count == 2
@@ -121,7 +142,36 @@ async def test_assets_by_ids_chunks_backend_filter_and_preserves_duplicates():
     assert first_call.kwargs["include"] == ["file_data", "variants"]
 
 
-def test_download_info_matches_immich_threshold_grouping():
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("asset_count", "expected_chunk_lengths"),
+    [
+        (GUMNUT_API_MAX_BULK_IDS, [GUMNUT_API_MAX_BULK_IDS]),
+        (GUMNUT_API_MAX_BULK_IDS + 1, [GUMNUT_API_MAX_BULK_IDS, 1]),
+    ],
+)
+async def test_assets_by_ids_pins_exact_bulk_boundaries(
+    asset_count: int, expected_chunk_lengths: list[int]
+) -> None:
+    asset_ids = [uuid4() for _ in range(asset_count)]
+    client = Mock()
+    client.assets.list = Mock(
+        side_effect=[MockSyncCursorPage([]) for _ in expected_chunk_lengths]
+    )
+
+    result = [
+        asset
+        async for asset in _assets_by_ids(client, asset_ids, include=["file_data"])
+    ]
+
+    assert result == []
+    assert [
+        len(call.kwargs["ids"]) for call in client.assets.list.call_args_list
+    ] == expected_chunk_lengths
+
+
+@pytest.mark.anyio
+async def test_download_info_matches_immich_threshold_grouping() -> None:
     assets = [
         _download_asset(uuid4(), size=5_000),
         _download_asset(uuid4(), size=100_000),
@@ -129,7 +179,11 @@ def test_download_info_matches_immich_threshold_grouping():
         _download_asset(uuid4(), size=123_000),
     ]
 
-    result = _build_download_info(assets, 30_000)
+    async def asset_stream() -> AsyncIterator[AssetResponse]:
+        for asset in assets:
+            yield asset
+
+    result = await _build_download_info(asset_stream(), 30_000)
 
     assert result.totalSize == 251_456
     assert [archive.size for archive in result.archives] == [105_000, 146_456]
@@ -140,14 +194,17 @@ def test_download_info_matches_immich_threshold_grouping():
 
 
 @pytest.mark.anyio
-async def test_album_info_validates_album_then_pages_its_assets():
+async def test_album_info_validates_album_then_pages_its_assets() -> None:
     album_id = uuid4()
     asset = _download_asset(uuid4())
     client = Mock()
     client.albums.retrieve = AsyncMock(return_value=Mock())
     client.assets.list = Mock(return_value=MockSyncCursorPage([asset]))
 
-    result = await _assets_for_info(DownloadInfoDto(albumId=album_id), client)
+    result = [
+        item
+        async for item in _assets_for_info(DownloadInfoDto(albumId=album_id), client)
+    ]
 
     assert result == [asset]
     client.albums.retrieve.assert_awaited_once_with(uuid_to_gumnut_album_id(album_id))
@@ -157,7 +214,7 @@ async def test_album_info_validates_album_then_pages_its_assets():
 
 
 @pytest.mark.anyio
-async def test_user_info_only_allows_the_authenticated_user():
+async def test_user_info_only_allows_the_authenticated_user() -> None:
     client = Mock()
     client.assets.list = Mock()
     current_user_id = uuid4()
@@ -166,29 +223,27 @@ async def test_user_info_only_allows_the_authenticated_user():
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await _assets_for_info(DownloadInfoDto(userId=uuid4()), client)
+        _ = [
+            asset
+            async for asset in _assets_for_info(DownloadInfoDto(userId=uuid4()), client)
+        ]
 
     assert exc_info.value.status_code == 403
     client.assets.list.assert_not_called()
 
 
 @pytest.mark.anyio
-async def test_info_requires_one_selector():
+async def test_info_requires_one_selector() -> None:
     with pytest.raises(HTTPException) as exc_info:
-        await _assets_for_info(DownloadInfoDto(), Mock())
+        _ = [asset async for asset in _assets_for_info(DownloadInfoDto(), Mock())]
 
     assert exc_info.value.status_code == 400
 
 
-def test_archive_names_sanitize_empty_and_deduplicate_extensions():
-    assets = [
-        _download_asset(uuid4(), filename=".."),
-        _download_asset(uuid4(), filename=".."),
-        _download_asset(uuid4(), filename=r"folder\photo.tar.gz"),
-        _download_asset(uuid4(), filename=r"folder\photo.tar.gz"),
-    ]
-
-    assert _deduplicated_archive_names(assets) == [
+def test_archive_names_sanitize_empty_and_deduplicate_extensions() -> None:
+    assert _archive_names(
+        ["..", "..", r"folder\photo.tar.gz", r"folder\photo.tar.gz"]
+    ) == [
         "unnamed",
         "unnamed+1",
         "folderphoto.tar.gz",
@@ -196,18 +251,199 @@ def test_archive_names_sanitize_empty_and_deduplicate_extensions():
     ]
 
 
+def test_archive_names_avoid_collisions_with_generated_suffixes() -> None:
+    assert _archive_names(["a.jpg", "a.jpg", "a+1.jpg"]) == [
+        "a.jpg",
+        "a+1.jpg",
+        "a+1+1.jpg",
+    ]
+
+
 @pytest.mark.anyio
-async def test_info_omits_assets_without_an_original_variant():
+async def test_info_requests_only_file_data_without_signing_original_urls() -> None:
     current_user_id = uuid4()
-    available = _download_asset(uuid4())
-    unavailable = _download_asset(uuid4())
-    unavailable.asset_urls = {}
+    assets = [_download_asset(uuid4()), _download_asset(uuid4())]
     client = Mock()
-    client.assets.list = Mock(return_value=MockSyncCursorPage([available, unavailable]))
+    client.assets.list = Mock(return_value=MockSyncCursorPage(assets))
     client.users.me = AsyncMock(
         return_value=Mock(id=uuid_to_gumnut_user_id(current_user_id))
     )
 
-    result = await _assets_for_info(DownloadInfoDto(userId=current_user_id), client)
+    result = [
+        asset
+        async for asset in _assets_for_info(
+            DownloadInfoDto(userId=current_user_id), client
+        )
+    ]
 
-    assert result == [available]
+    assert result == assets
+    assert client.assets.list.call_args.kwargs["include"] == ["file_data"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("archive_size", "expected_sizes"),
+    [(None, [12]), (10, [11, 1])],
+)
+async def test_get_download_info_composes_default_and_explicit_thresholds(
+    archive_size: int | None, expected_sizes: list[int]
+) -> None:
+    asset_ids = [uuid4(), uuid4(), uuid4()]
+    assets = [
+        _download_asset(asset_ids[0], size=10),
+        _download_asset(asset_ids[1], size=1),
+        _download_asset(asset_ids[2], size=1),
+    ]
+    client = Mock()
+    client.assets.list = Mock(return_value=MockSyncCursorPage(assets))
+
+    result = await get_download_info(
+        DownloadInfoDto(assetIds=asset_ids, archiveSize=archive_size), client=client
+    )
+
+    assert result.totalSize == 12
+    assert [archive.size for archive in result.archives] == expected_sizes
+    assert client.assets.list.call_args.kwargs["include"] == ["file_data"]
+
+
+@pytest.mark.anyio
+async def test_closing_partial_archive_immediately_closes_active_cdn_response() -> None:
+    asset = _download_asset(uuid4(), size=1_000_004)
+    response = Mock()
+    response.aclose = AsyncMock()
+    chunk_sizes: list[int | None] = []
+
+    async def aiter_bytes(chunk_size: int | None = None) -> AsyncIterator[bytes]:
+        chunk_sizes.append(chunk_size)
+        yield b"x" * 1_000_000
+        yield b"rest"
+
+    response.aiter_bytes = aiter_bytes
+    archive = _stream_archive(_asset_stream([asset]))
+
+    with patch(
+        "routers.api.download.open_cdn_response",
+        new_callable=AsyncMock,
+        return_value=response,
+    ) as open_response:
+        for _ in range(50):
+            await anext(archive)
+            if open_response.await_count:
+                break
+        assert open_response.await_count == 1
+        await archive.aclose()
+
+    response.aclose.assert_awaited()
+    assert chunk_sizes == [64 * 1024]
+
+
+@pytest.mark.anyio
+async def test_archive_validates_all_metadata_before_returning_response() -> None:
+    asset_ids = [uuid4() for _ in range(GUMNUT_API_MAX_BULK_IDS + 1)]
+    assets = [_download_asset(asset_id) for asset_id in asset_ids]
+    client = Mock()
+    client.assets.list = Mock(
+        side_effect=[
+            MockSyncCursorPage(assets[:GUMNUT_API_MAX_BULK_IDS]),
+            MockSyncCursorPage(assets[GUMNUT_API_MAX_BULK_IDS:]),
+        ]
+    )
+
+    response = await download_archive(
+        DownloadArchiveDto(assetIds=asset_ids), client=client
+    )
+
+    assert client.assets.list.call_count == 2
+    body = cast(AsyncGenerator[bytes], response.body_iterator)
+    await body.aclose()
+
+
+@pytest.mark.anyio
+async def test_archive_rejects_missing_requested_asset_before_streaming() -> None:
+    asset_ids = [uuid4(), uuid4()]
+    client = Mock()
+    client.assets.list = Mock(
+        return_value=MockSyncCursorPage([_download_asset(asset_ids[0])])
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await download_archive(DownloadArchiveDto(assetIds=asset_ids), client=client)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Not found or no asset.download access"
+
+
+@pytest.mark.anyio
+async def test_archive_rejects_missing_asset_in_later_backend_chunk() -> None:
+    asset_ids = [uuid4() for _ in range(GUMNUT_API_MAX_BULK_IDS + 1)]
+    first_chunk_assets = [
+        _download_asset(asset_id) for asset_id in asset_ids[:GUMNUT_API_MAX_BULK_IDS]
+    ]
+    client = Mock()
+    client.assets.list = Mock(
+        side_effect=[
+            MockSyncCursorPage(first_chunk_assets),
+            MockSyncCursorPage([]),
+        ]
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await download_archive(DownloadArchiveDto(assetIds=asset_ids), client=client)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Not found or no asset.download access"
+    assert [len(call.kwargs["ids"]) for call in client.assets.list.call_args_list] == [
+        GUMNUT_API_MAX_BULK_IDS,
+        1,
+    ]
+
+
+@pytest.mark.anyio
+async def test_archive_rejects_unavailable_original_before_streaming() -> None:
+    missing_file_data = _download_asset(uuid4())
+    missing_file_data.file_data = None
+    missing_urls = _download_asset(uuid4())
+    missing_urls.asset_urls = None
+    missing_original = _download_asset(uuid4())
+    missing_original.asset_urls = {"thumbnail": Mock(url="https://cdn.example.com/x")}
+    for unavailable in (missing_file_data, missing_urls, missing_original):
+        client = Mock()
+        client.assets.list = Mock(return_value=MockSyncCursorPage([unavailable]))
+
+        with pytest.raises(HTTPException) as exc_info:
+            await download_archive(
+                DownloadArchiveDto(assetIds=[safe_uuid_from_asset_id(unavailable.id)]),
+                client=client,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Not found or no asset.download access"
+
+
+@pytest.mark.anyio
+async def test_archive_clamps_timestamps_to_zip_range() -> None:
+    early = _download_asset(uuid4(), filename="early.jpg")
+    future = _download_asset(uuid4(), filename="future.jpg")
+    too_late = _download_asset(uuid4(), filename="too-late.jpg")
+    assert early.file_data is not None
+    assert future.file_data is not None
+    assert too_late.file_data is not None
+    early.file_data.file_modified_at = datetime(1970, 1, 2, 3, 4, 6)
+    future.file_data.file_modified_at = datetime(2040, 2, 3, 4, 5, 6)
+    too_late.file_data.file_modified_at = datetime(2200, 1, 2, 3, 4, 6)
+    assets = [early, future, too_late]
+
+    async def fake_cdn_chunks(url: str, state: object) -> AsyncIterator[bytes]:
+        yield b"content"
+
+    with patch("routers.api.download._cdn_asset_chunks", side_effect=fake_cdn_chunks):
+        archive = b"".join(
+            [chunk async for chunk in _stream_archive(_asset_stream(assets))]
+        )
+
+    with ZipFile(BytesIO(archive)) as zip_file:
+        assert [entry.date_time for entry in zip_file.infolist()] == [
+            (1980, 1, 1, 0, 0, 0),
+            (2040, 2, 3, 4, 5, 6),
+            (2107, 12, 31, 23, 59, 58),
+        ]

--- a/tests/unit/api/test_download.py
+++ b/tests/unit/api/test_download.py
@@ -1,13 +1,15 @@
 """Tests for batch download planning and streamed ZIP archives."""
 
+import asyncio
 from collections.abc import AsyncGenerator, AsyncIterator
 from datetime import datetime
 from io import BytesIO
-from typing import cast
+from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 from uuid import UUID, uuid4
 from zipfile import ZipFile
 
+import httpx
 import pytest
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
@@ -15,6 +17,7 @@ from gumnut.types.asset_response import AssetResponse
 
 from routers.api.constants import GUMNUT_API_MAX_BULK_IDS
 from routers.api.download import (
+    _ArchiveAsset,
     _assets_by_ids,
     _assets_for_info,
     _build_download_info,
@@ -55,11 +58,6 @@ async def _collect_response_body(response: StreamingResponse) -> bytes:
     return b"".join([cast(bytes, chunk) async for chunk in response.body_iterator])
 
 
-async def _asset_stream(assets: list[AssetResponse]) -> AsyncIterator[AssetResponse]:
-    for asset in assets:
-        yield asset
-
-
 def _archive_names(filenames: list[str]) -> list[str]:
     next_suffix: dict[str, int] = {}
     emitted: set[str] = set()
@@ -67,6 +65,17 @@ def _archive_names(filenames: list[str]) -> list[str]:
         _deduplicated_archive_name(filename, next_suffix, emitted)
         for filename in filenames
     ]
+
+
+def _compact_archive_asset(asset: AssetResponse) -> _ArchiveAsset:
+    assert asset.file_data is not None
+    assert asset.asset_urls is not None
+    return _ArchiveAsset(
+        filename=asset.original_file_name,
+        modified_at=asset.file_data.file_modified_at,
+        size=asset.file_data.file_size_bytes,
+        url=asset.asset_urls["original"].url,
+    )
 
 
 @pytest.mark.anyio
@@ -259,6 +268,21 @@ def test_archive_names_avoid_collisions_with_generated_suffixes() -> None:
     ]
 
 
+def test_archive_names_avoid_case_insensitive_collisions() -> None:
+    assert _archive_names(["Photo.jpg", "photo.jpg", "PHOTO+1.JPG"]) == [
+        "Photo.jpg",
+        "photo+1.jpg",
+        "PHOTO+1+1.JPG",
+    ]
+
+
+def test_archive_names_avoid_windows_trailing_character_collisions() -> None:
+    assert _archive_names(["photo.jpg", "photo.jpg ."]) == [
+        "photo.jpg",
+        "photo+1.jpg",
+    ]
+
+
 @pytest.mark.anyio
 async def test_info_requests_only_file_data_without_signing_original_urls() -> None:
     current_user_id = uuid4()
@@ -307,6 +331,21 @@ async def test_get_download_info_composes_default_and_explicit_thresholds(
 
 
 @pytest.mark.anyio
+async def test_info_rejects_missing_requested_asset() -> None:
+    asset_ids = [uuid4(), uuid4()]
+    client = Mock()
+    client.assets.list = Mock(
+        return_value=MockSyncCursorPage([_download_asset(asset_ids[0])])
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_download_info(DownloadInfoDto(assetIds=asset_ids), client=client)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Not found or no asset.download access"
+
+
+@pytest.mark.anyio
 async def test_closing_partial_archive_immediately_closes_active_cdn_response() -> None:
     asset = _download_asset(uuid4(), size=1_000_004)
     response = Mock()
@@ -319,7 +358,7 @@ async def test_closing_partial_archive_immediately_closes_active_cdn_response() 
         yield b"rest"
 
     response.aiter_bytes = aiter_bytes
-    archive = _stream_archive(_asset_stream([asset]))
+    archive = _stream_archive([_compact_archive_asset(asset)])
 
     with patch(
         "routers.api.download.open_cdn_response",
@@ -335,6 +374,91 @@ async def test_closing_partial_archive_immediately_closes_active_cdn_response() 
 
     response.aclose.assert_awaited()
     assert chunk_sizes == [64 * 1024]
+
+
+@pytest.mark.anyio
+async def test_archive_emits_output_before_requesting_all_source_bytes() -> None:
+    asset = _download_asset(uuid4(), size=1_000_004)
+    response = Mock()
+    response.aclose = AsyncMock()
+    first_chunk_provided = asyncio.Event()
+    second_chunk_requested = asyncio.Event()
+    allow_second_chunk = asyncio.Event()
+
+    async def aiter_bytes(chunk_size: int | None = None) -> AsyncIterator[bytes]:
+        first_chunk_provided.set()
+        yield b"x" * 1_000_000
+        second_chunk_requested.set()
+        await allow_second_chunk.wait()
+        yield b"rest"
+
+    response.aiter_bytes = aiter_bytes
+    archive = _stream_archive([_compact_archive_asset(asset)])
+
+    with patch(
+        "routers.api.download.open_cdn_response",
+        new_callable=AsyncMock,
+        return_value=response,
+    ):
+        for _ in range(50):
+            output = await asyncio.wait_for(anext(archive), timeout=1)
+            if first_chunk_provided.is_set():
+                break
+        assert first_chunk_provided.is_set()
+        assert output
+        assert not second_chunk_requested.is_set()
+        allow_second_chunk.set()
+        await archive.aclose()
+
+    response.aclose.assert_awaited()
+
+
+@pytest.mark.anyio
+async def test_archive_propagates_cdn_read_failure_and_closes_response() -> None:
+    asset = _download_asset(uuid4(), size=10)
+    response = Mock()
+    response.aclose = AsyncMock()
+
+    async def aiter_bytes(chunk_size: int | None = None) -> AsyncIterator[bytes]:
+        yield b"partial"
+        raise httpx.ReadError("CDN connection lost")
+
+    response.aiter_bytes = aiter_bytes
+    archive = _stream_archive([_compact_archive_asset(asset)])
+
+    with patch(
+        "routers.api.download.open_cdn_response",
+        new_callable=AsyncMock,
+        return_value=response,
+    ):
+        with pytest.raises(httpx.ReadError, match="CDN connection lost"):
+            _ = [chunk async for chunk in archive]
+
+    response.aclose.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_archive_zip_generation_uses_a_dedicated_executor() -> None:
+    asset = _download_asset(uuid4(), size=1)
+    loop = asyncio.get_running_loop()
+    run_in_executor = loop.run_in_executor
+    executors: list[object | None] = []
+
+    def record_executor(executor: Any, function: Any, *args: Any):
+        executors.append(executor)
+        return run_in_executor(executor, function, *args)
+
+    async def fake_cdn_chunks(url: str, state: object) -> AsyncIterator[bytes]:
+        yield b"x"
+
+    with (
+        patch.object(loop, "run_in_executor", side_effect=record_executor),
+        patch("routers.api.download._cdn_asset_chunks", side_effect=fake_cdn_chunks),
+    ):
+        _ = [chunk async for chunk in _stream_archive([_compact_archive_asset(asset)])]
+
+    assert executors
+    assert all(executor is not None for executor in executors)
 
 
 @pytest.mark.anyio
@@ -438,7 +562,12 @@ async def test_archive_clamps_timestamps_to_zip_range() -> None:
 
     with patch("routers.api.download._cdn_asset_chunks", side_effect=fake_cdn_chunks):
         archive = b"".join(
-            [chunk async for chunk in _stream_archive(_asset_stream(assets))]
+            [
+                chunk
+                async for chunk in _stream_archive(
+                    [_compact_archive_asset(asset) for asset in assets]
+                )
+            ]
         )
 
     with ZipFile(BytesIO(archive)) as zip_file:

--- a/tests/unit/api/test_download.py
+++ b/tests/unit/api/test_download.py
@@ -1,0 +1,213 @@
+"""Tests for batch download planning and streamed ZIP archives."""
+
+from io import BytesIO
+from typing import cast
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import UUID, uuid4
+from zipfile import ZipFile
+
+import pytest
+from fastapi import HTTPException
+from gumnut.types.asset_response import AssetResponse
+
+from routers.api.constants import GUMNUT_API_MAX_BULK_IDS
+from routers.api.download import (
+    _assets_by_ids,
+    _assets_for_info,
+    _build_download_info,
+    _deduplicated_archive_names,
+    download_archive,
+)
+from routers.immich_models import DownloadArchiveDto, DownloadInfoDto
+from routers.utils.gumnut_id_conversion import (
+    safe_uuid_from_asset_id,
+    uuid_to_gumnut_album_id,
+    uuid_to_gumnut_asset_id,
+    uuid_to_gumnut_user_id,
+)
+from tests.conftest import MockSyncCursorPage, make_gumnut_asset
+
+
+def _download_asset(
+    asset_id: UUID,
+    *,
+    filename: str = "photo.jpg",
+    size: int = 10,
+    url: str | None = None,
+) -> AssetResponse:
+    asset = make_gumnut_asset(
+        asset_id=uuid_to_gumnut_asset_id(asset_id),
+        original_file_name=filename,
+    )
+    asset.file_data.file_size_bytes = size
+    asset.asset_urls = (
+        {"original": Mock(url=url or f"https://cdn.example.com/{asset_id}")}
+        if url is not None or filename
+        else {}
+    )
+    return cast(AssetResponse, asset)
+
+
+async def _collect_response_body(response) -> bytes:
+    return b"".join([chunk async for chunk in response.body_iterator])
+
+
+@pytest.mark.anyio
+async def test_archive_streams_valid_zip_in_request_order_with_safe_unique_names():
+    first_id = uuid4()
+    second_id = uuid4()
+    assets = [
+        _download_asset(
+            first_id,
+            filename="../trip/photo.jpg",
+            size=5,
+            url="https://cdn.example.com/first",
+        ),
+        _download_asset(
+            second_id,
+            filename="../trip/photo.jpg",
+            size=6,
+            url="https://cdn.example.com/second",
+        ),
+    ]
+    client = Mock()
+    # Deliberately reverse the backend result; the archive must follow request order.
+    client.assets.list = Mock(return_value=MockSyncCursorPage(list(reversed(assets))))
+
+    chunks = {
+        "https://cdn.example.com/first": (b"first",),
+        "https://cdn.example.com/second": (b"sec", b"ond"),
+    }
+
+    async def fake_cdn_chunks(url: str):
+        for chunk in chunks[url]:
+            yield chunk
+
+    with patch("routers.api.download._cdn_asset_chunks", side_effect=fake_cdn_chunks):
+        response = await download_archive(
+            DownloadArchiveDto(assetIds=[first_id, second_id]), client=client
+        )
+        archive = await _collect_response_body(response)
+
+    assert response.media_type == "application/zip"
+    assert response.headers["content-disposition"] == (
+        'attachment; filename="assets.zip"'
+    )
+    with ZipFile(BytesIO(archive)) as zip_file:
+        assert zip_file.namelist() == ["..tripphoto.jpg", "..tripphoto+1.jpg"]
+        assert zip_file.read("..tripphoto.jpg") == b"first"
+        assert zip_file.read("..tripphoto+1.jpg") == b"second"
+
+
+@pytest.mark.anyio
+async def test_assets_by_ids_chunks_backend_filter_and_preserves_duplicates():
+    asset_ids = [uuid4() for _ in range(GUMNUT_API_MAX_BULK_IDS + 1)]
+    selected = _download_asset(asset_ids[0])
+    client = Mock()
+    client.assets.list = Mock(
+        side_effect=[
+            MockSyncCursorPage([selected]),
+            MockSyncCursorPage([]),
+        ]
+    )
+
+    result = await _assets_by_ids(client, [*asset_ids, asset_ids[0]])
+
+    assert result == [selected, selected]
+    assert client.assets.list.call_count == 2
+    first_call, second_call = client.assets.list.call_args_list
+    assert len(first_call.kwargs["ids"]) == GUMNUT_API_MAX_BULK_IDS
+    assert len(second_call.kwargs["ids"]) == 2
+    assert first_call.kwargs["include"] == ["file_data", "variants"]
+
+
+def test_download_info_matches_immich_threshold_grouping():
+    assets = [
+        _download_asset(uuid4(), size=5_000),
+        _download_asset(uuid4(), size=100_000),
+        _download_asset(uuid4(), size=23_456),
+        _download_asset(uuid4(), size=123_000),
+    ]
+
+    result = _build_download_info(assets, 30_000)
+
+    assert result.totalSize == 251_456
+    assert [archive.size for archive in result.archives] == [105_000, 146_456]
+    assert result.archives[0].assetIds == [
+        safe_uuid_from_asset_id(assets[0].id),
+        safe_uuid_from_asset_id(assets[1].id),
+    ]
+
+
+@pytest.mark.anyio
+async def test_album_info_validates_album_then_pages_its_assets():
+    album_id = uuid4()
+    asset = _download_asset(uuid4())
+    client = Mock()
+    client.albums.retrieve = AsyncMock(return_value=Mock())
+    client.assets.list = Mock(return_value=MockSyncCursorPage([asset]))
+
+    result = await _assets_for_info(DownloadInfoDto(albumId=album_id), client)
+
+    assert result == [asset]
+    client.albums.retrieve.assert_awaited_once_with(uuid_to_gumnut_album_id(album_id))
+    assert client.assets.list.call_args.kwargs["album_id"] == (
+        uuid_to_gumnut_album_id(album_id)
+    )
+
+
+@pytest.mark.anyio
+async def test_user_info_only_allows_the_authenticated_user():
+    client = Mock()
+    client.assets.list = Mock()
+    current_user_id = uuid4()
+    client.users.me = AsyncMock(
+        return_value=Mock(id=uuid_to_gumnut_user_id(current_user_id))
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _assets_for_info(DownloadInfoDto(userId=uuid4()), client)
+
+    assert exc_info.value.status_code == 403
+    client.assets.list.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_info_requires_one_selector():
+    with pytest.raises(HTTPException) as exc_info:
+        await _assets_for_info(DownloadInfoDto(), Mock())
+
+    assert exc_info.value.status_code == 400
+
+
+def test_archive_names_sanitize_empty_and_deduplicate_extensions():
+    assets = [
+        _download_asset(uuid4(), filename=".."),
+        _download_asset(uuid4(), filename=".."),
+        _download_asset(uuid4(), filename=r"folder\photo.tar.gz"),
+        _download_asset(uuid4(), filename=r"folder\photo.tar.gz"),
+    ]
+
+    assert _deduplicated_archive_names(assets) == [
+        "unnamed",
+        "unnamed+1",
+        "folderphoto.tar.gz",
+        "folderphoto.tar+1.gz",
+    ]
+
+
+@pytest.mark.anyio
+async def test_info_omits_assets_without_an_original_variant():
+    current_user_id = uuid4()
+    available = _download_asset(uuid4())
+    unavailable = _download_asset(uuid4())
+    unavailable.asset_urls = {}
+    client = Mock()
+    client.assets.list = Mock(return_value=MockSyncCursorPage([available, unavailable]))
+    client.users.me = AsyncMock(
+        return_value=Mock(id=uuid_to_gumnut_user_id(current_user_id))
+    )
+
+    result = await _assets_for_info(DownloadInfoDto(userId=current_user_id), client)
+
+    assert result == [available]

--- a/tests/unit/api/test_download.py
+++ b/tests/unit/api/test_download.py
@@ -283,6 +283,14 @@ def test_archive_names_avoid_windows_trailing_character_collisions() -> None:
     ]
 
 
+def test_archive_names_avoid_canonically_equivalent_unicode_collisions() -> None:
+    assert _archive_names(["café.jpg", "café.jpg", "CAFÉ+1.JPG"]) == [
+        "café.jpg",
+        "café+1.jpg",
+        "CAFÉ+1+1.JPG",
+    ]
+
+
 @pytest.mark.anyio
 async def test_info_requests_only_file_data_without_signing_original_urls() -> None:
     current_user_id = uuid4()

--- a/tests/unit/api/test_download.py
+++ b/tests/unit/api/test_download.py
@@ -354,6 +354,28 @@ async def test_info_rejects_missing_requested_asset() -> None:
 
 
 @pytest.mark.anyio
+async def test_info_rejects_unavailable_file_size() -> None:
+    missing_file_data = _download_asset(uuid4())
+    missing_file_data.file_data = None
+    missing_size = _download_asset(uuid4())
+    assert missing_size.file_data is not None
+    cast(Any, missing_size.file_data).file_size_bytes = None
+
+    for unavailable in (missing_file_data, missing_size):
+        client = Mock()
+        client.assets.list = Mock(return_value=MockSyncCursorPage([unavailable]))
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_download_info(
+                DownloadInfoDto(assetIds=[safe_uuid_from_asset_id(unavailable.id)]),
+                client=client,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Not found or no asset.download access"
+
+
+@pytest.mark.anyio
 async def test_closing_partial_archive_immediately_closes_active_cdn_response() -> None:
     asset = _download_asset(uuid4(), size=1_000_004)
     response = Mock()
@@ -534,11 +556,19 @@ async def test_archive_rejects_missing_asset_in_later_backend_chunk() -> None:
 async def test_archive_rejects_unavailable_original_before_streaming() -> None:
     missing_file_data = _download_asset(uuid4())
     missing_file_data.file_data = None
+    missing_size = _download_asset(uuid4())
+    assert missing_size.file_data is not None
+    cast(Any, missing_size.file_data).file_size_bytes = None
     missing_urls = _download_asset(uuid4())
     missing_urls.asset_urls = None
     missing_original = _download_asset(uuid4())
     missing_original.asset_urls = {"thumbnail": Mock(url="https://cdn.example.com/x")}
-    for unavailable in (missing_file_data, missing_urls, missing_original):
+    for unavailable in (
+        missing_file_data,
+        missing_size,
+        missing_urls,
+        missing_original,
+    ):
         client = Mock()
         client.assets.list = Mock(return_value=MockSyncCursorPage([unavailable]))
 
@@ -550,6 +580,34 @@ async def test_archive_rejects_unavailable_original_before_streaming() -> None:
 
         assert exc_info.value.status_code == 400
         assert exc_info.value.detail == "Not found or no asset.download access"
+
+
+@pytest.mark.anyio
+async def test_archive_resolves_nullable_file_modified_at_before_streaming() -> None:
+    asset_id = uuid4()
+    asset = _download_asset(asset_id, size=7)
+    assert asset.file_data is not None
+    cast(Any, asset.file_data).file_modified_at = None
+    asset.metadata = Mock(modified_datetime=datetime(2024, 5, 6, 7, 8, 10))
+    client = Mock()
+    client.assets.list = Mock(return_value=MockSyncCursorPage([asset]))
+
+    async def fake_cdn_chunks(url: str, state: object) -> AsyncIterator[bytes]:
+        yield b"content"
+
+    with patch("routers.api.download._cdn_asset_chunks", side_effect=fake_cdn_chunks):
+        response = await download_archive(
+            DownloadArchiveDto(assetIds=[asset_id]), client=client
+        )
+        archive = await _collect_response_body(response)
+
+    assert client.assets.list.call_args.kwargs["include"] == [
+        "file_data",
+        "metadata",
+        "variants",
+    ]
+    with ZipFile(BytesIO(archive)) as zip_file:
+        assert zip_file.infolist()[0].date_time == (2024, 5, 6, 7, 8, 10)
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_download.py
+++ b/tests/unit/api/test_download.py
@@ -2,8 +2,10 @@
 
 import asyncio
 from collections.abc import AsyncGenerator, AsyncIterator
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from io import BytesIO
+from threading import Event
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 from uuid import UUID, uuid4
@@ -22,7 +24,9 @@ from routers.api.download import (
     _assets_for_info,
     _build_download_info,
     _deduplicated_archive_name,
+    _get_archive_zip_executor,
     _stream_archive,
+    close_archive_zip_executor,
     download_archive,
     get_download_info,
 )
@@ -130,21 +134,30 @@ async def test_assets_by_ids_chunks_backend_filter_and_preserves_duplicates() ->
     asset_ids = [uuid4() for _ in range(GUMNUT_API_MAX_BULK_IDS + 1)]
     selected = _download_asset(asset_ids[0])
     client = Mock()
-    client.assets.list = Mock(
-        side_effect=[MockSyncCursorPage([selected]), MockSyncCursorPage([selected])]
-    )
+    pages = iter([MockSyncCursorPage([selected]), MockSyncCursorPage([selected])])
+    conversion_counts: list[int] = []
 
-    result = [
-        asset
-        async for asset in _assets_by_ids(
-            client,
-            [*asset_ids, asset_ids[0]],
-            include=["file_data", "variants"],
-        )
-    ]
+    def list_assets(**kwargs: Any) -> MockSyncCursorPage:
+        conversion_counts.append(convert.call_count)
+        return next(pages)
+
+    with patch(
+        "routers.api.download.uuid_to_gumnut_asset_id",
+        wraps=uuid_to_gumnut_asset_id,
+    ) as convert:
+        client.assets.list = Mock(side_effect=list_assets)
+        result = [
+            asset
+            async for asset in _assets_by_ids(
+                client,
+                [*asset_ids, asset_ids[0]],
+                include=["file_data", "variants"],
+            )
+        ]
 
     assert result == [selected, selected]
     assert client.assets.list.call_count == 2
+    assert conversion_counts == [GUMNUT_API_MAX_BULK_IDS, len(asset_ids) + 1]
     first_call, second_call = client.assets.list.call_args_list
     assert len(first_call.kwargs["ids"]) == GUMNUT_API_MAX_BULK_IDS
     assert len(second_call.kwargs["ids"]) == 2
@@ -291,6 +304,52 @@ def test_archive_names_avoid_canonically_equivalent_unicode_collisions() -> None
     ]
 
 
+def test_archive_names_reserve_component_bytes_for_duplicate_suffixes() -> None:
+    filename = f"{'a' * 251}.jpg"
+
+    first, duplicate = _archive_names([filename, filename])
+
+    assert first == filename
+    assert duplicate.endswith("+1.jpg")
+    assert len(first.encode("utf-8")) == 255
+    assert len(duplicate.encode("utf-8")) == 255
+
+
+def test_archive_names_truncate_multibyte_components_on_codepoint_boundaries() -> None:
+    first, duplicate = _archive_names([f"{'é' * 200}.jpg"] * 2)
+
+    assert first.endswith(".jpg")
+    assert duplicate.endswith("+1.jpg")
+    assert len(first.encode("utf-8")) <= 255
+    assert len(duplicate.encode("utf-8")) <= 255
+
+
+def test_archive_names_revalidate_windows_devices_after_truncation() -> None:
+    filename = f"CONextra.{'a' * 251}"
+
+    assert _archive_names([filename]) == ["unnamed"]
+
+
+def test_distinct_truncated_names_share_suffix_progression() -> None:
+    next_suffix: dict[str, int] = {}
+    emitted: set[str] = set()
+    filenames = [f"{'a' * 255}{index}" for index in range(4)]
+
+    names = [
+        _deduplicated_archive_name(filename, next_suffix, emitted)
+        for filename in filenames
+    ]
+
+    assert names == [
+        f"{'a' * 255}",
+        f"{'a' * 253}+1",
+        f"{'a' * 253}+2",
+        f"{'a' * 253}+3",
+    ]
+    assert len(next_suffix) == 1
+    assert list(next_suffix.values()) == [4]
+
+
 @pytest.mark.anyio
 async def test_info_requests_only_file_data_without_signing_original_urls() -> None:
     current_user_id = uuid4()
@@ -407,6 +466,92 @@ async def test_closing_partial_archive_immediately_closes_active_cdn_response() 
 
 
 @pytest.mark.anyio
+async def test_cancelling_archive_read_unwinds_pending_cdn_open() -> None:
+    asset = _download_asset(uuid4(), size=10)
+    open_started = asyncio.Event()
+    open_cancelled = asyncio.Event()
+
+    async def blocked_open(url: str) -> httpx.Response:
+        open_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            open_cancelled.set()
+            raise
+        raise AssertionError("unreachable")
+
+    archive = _stream_archive([_compact_archive_asset(asset)])
+    pending_read: asyncio.Task[bytes] | None = None
+
+    with patch("routers.api.download.open_cdn_response", side_effect=blocked_open):
+        async with asyncio.timeout(2):
+            for _ in range(50):
+                next_chunk = asyncio.create_task(anext(archive))
+                open_wait = asyncio.create_task(open_started.wait())
+                completed, _ = await asyncio.wait(
+                    {next_chunk, open_wait},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if open_wait in completed:
+                    assert not next_chunk.done()
+                    pending_read = next_chunk
+                    break
+                await next_chunk
+                open_wait.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await open_wait
+
+        assert pending_read is not None
+        pending_read.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(pending_read, timeout=1)
+
+        assert open_cancelled.is_set()
+        await archive.aclose()
+
+
+@pytest.mark.anyio
+async def test_cancelling_queued_archive_read_does_not_wait_for_worker() -> None:
+    asset = _download_asset(uuid4(), size=10)
+    worker_started = Event()
+    release_worker = Event()
+    executor = ThreadPoolExecutor(max_workers=1)
+
+    def occupy_worker() -> None:
+        worker_started.set()
+        release_worker.wait()
+
+    blocker = executor.submit(occupy_worker)
+    assert await asyncio.to_thread(worker_started.wait, 1)
+    archive_submitted = asyncio.Event()
+    original_submit = executor.submit
+
+    def record_submit(function: Any, *args: Any, **kwargs: Any):
+        future = original_submit(function, *args, **kwargs)
+        archive_submitted.set()
+        return future
+
+    archive = _stream_archive([_compact_archive_asset(asset)])
+    try:
+        with (
+            patch(
+                "routers.api.download._get_archive_zip_executor", return_value=executor
+            ),
+            patch.object(executor, "submit", side_effect=record_submit),
+        ):
+            pending_read = asyncio.create_task(anext(archive))
+            await asyncio.wait_for(archive_submitted.wait(), timeout=1)
+            pending_read.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(pending_read, timeout=1)
+            await archive.aclose()
+    finally:
+        release_worker.set()
+        await asyncio.to_thread(blocker.result, 1)
+        executor.shutdown(wait=True)
+
+
+@pytest.mark.anyio
 async def test_archive_emits_output_before_requesting_all_source_bytes() -> None:
     asset = _download_asset(uuid4(), size=1_000_004)
     response = Mock()
@@ -470,25 +615,33 @@ async def test_archive_propagates_cdn_read_failure_and_closes_response() -> None
 @pytest.mark.anyio
 async def test_archive_zip_generation_uses_a_dedicated_executor() -> None:
     asset = _download_asset(uuid4(), size=1)
-    loop = asyncio.get_running_loop()
-    run_in_executor = loop.run_in_executor
-    executors: list[object | None] = []
-
-    def record_executor(executor: Any, function: Any, *args: Any):
-        executors.append(executor)
-        return run_in_executor(executor, function, *args)
+    executor = _get_archive_zip_executor()
 
     async def fake_cdn_chunks(url: str, state: object) -> AsyncIterator[bytes]:
         yield b"x"
 
     with (
-        patch.object(loop, "run_in_executor", side_effect=record_executor),
+        patch.object(executor, "submit", wraps=executor.submit) as submit,
         patch("routers.api.download._cdn_asset_chunks", side_effect=fake_cdn_chunks),
     ):
         _ = [chunk async for chunk in _stream_archive([_compact_archive_asset(asset)])]
 
-    assert executors
-    assert all(executor is not None for executor in executors)
+    assert submit.call_count > 0
+
+
+@pytest.mark.anyio
+async def test_archive_executor_shutdown_resets_and_is_idempotent() -> None:
+    executor = _get_archive_zip_executor()
+
+    await close_archive_zip_executor()
+
+    with pytest.raises(RuntimeError, match="cannot schedule new futures"):
+        executor.submit(lambda: None)
+    replacement = _get_archive_zip_executor()
+    assert replacement is not executor
+
+    await close_archive_zip_executor()
+    await close_archive_zip_executor()
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_users.py
+++ b/tests/unit/api/test_users.py
@@ -248,11 +248,11 @@ class TestMyPreferences:
         assert dumped["recentlyAdded"] == {"sidebarWeb": False}
 
     @pytest.mark.anyio
-    async def test_download_archive_size_is_positive_upstream_default(self):
-        """Immich Web forwards this value to a DTO whose minimum is one."""
+    async def test_download_archive_size_limits_typical_browser_blob(self):
         result = await get_my_preferences()
 
         assert result.download.archiveSize == DEFAULT_DOWNLOAD_ARCHIVE_SIZE
+        assert result.download.archiveSize == 512 * 1024**2
 
     @pytest.mark.anyio
     async def test_update_ignores_the_request(self):

--- a/tests/unit/api/test_users.py
+++ b/tests/unit/api/test_users.py
@@ -6,7 +6,7 @@ from uuid import UUID, uuid4
 import pytest
 import shortuuid
 
-from routers.api.constants import STUB_LICENSE_KEY
+from routers.api.constants import DEFAULT_DOWNLOAD_ARCHIVE_SIZE, STUB_LICENSE_KEY
 from routers.api.users import (
     get_my_calendar_heatmap,
     get_my_preferences,
@@ -246,6 +246,13 @@ class TestMyPreferences:
         dumped = (await get_my_preferences()).model_dump(by_alias=True)
 
         assert dumped["recentlyAdded"] == {"sidebarWeb": False}
+
+    @pytest.mark.anyio
+    async def test_download_archive_size_is_positive_upstream_default(self):
+        """Immich Web forwards this value to a DTO whose minimum is one."""
+        result = await get_my_preferences()
+
+        assert result.download.archiveSize == DEFAULT_DOWNLOAD_ARCHIVE_SIZE
 
     @pytest.mark.anyio
     async def test_update_ignores_the_request(self):

--- a/tests/unit/config/test_logging.py
+++ b/tests/unit/config/test_logging.py
@@ -1,0 +1,53 @@
+"""Tests for targeted HTTP client log redaction."""
+
+import io
+import logging
+
+import httpx
+import pytest
+
+from config.logging import LOGGING_CONFIG, RedactSensitiveHttpxQuery
+
+
+@pytest.mark.anyio
+async def test_httpx_logs_redact_only_signed_cdn_values() -> None:
+    output = io.StringIO()
+    handler = logging.StreamHandler(output)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    handler.addFilter(RedactSensitiveHttpxQuery())
+    httpx_logger = logging.getLogger("httpx")
+    prior_handlers = httpx_logger.handlers[:]
+    prior_level = httpx_logger.level
+    prior_propagate = httpx_logger.propagate
+    httpx_logger.handlers = [handler]
+    httpx_logger.setLevel(logging.INFO)
+    httpx_logger.propagate = False
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, request=request)
+
+    try:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+            await client.get(
+                "https://assets.gumnut.ai/asset.jpg"
+                "?w=720&verify=secret-token&dl=family-photo.jpg&f=webp"
+            )
+            await client.get(
+                "https://api.example.com/search?page=2&dl=report.csv&query=cats"
+            )
+    finally:
+        httpx_logger.handlers = prior_handlers
+        httpx_logger.setLevel(prior_level)
+        httpx_logger.propagate = prior_propagate
+
+    logs = output.getvalue()
+    assert "secret-token" not in logs
+    assert "family-photo.jpg" not in logs
+    assert "w=720&verify=REDACTED&dl=REDACTED&f=webp" in logs
+    assert "search?page=2&dl=report.csv&query=cats" in logs
+
+
+def test_default_handler_installs_httpx_redaction_filter() -> None:
+    assert LOGGING_CONFIG["handlers"]["default"]["filters"] == [
+        "redact_sensitive_httpx_query"
+    ]

--- a/tests/unit/config/test_sentry.py
+++ b/tests/unit/config/test_sentry.py
@@ -9,6 +9,64 @@ def _span_data(result: dict[str, Any], index: int) -> dict[str, Any]:
 
 
 class TestEnrichHttpSpans:
+    def test_redacts_only_sensitive_cdn_query_metadata(self):
+        event = {
+            "spans": [
+                {
+                    "op": "http.client",
+                    "description": (
+                        "GET https://assets.gumnut.ai/asset.jpg"
+                        "?w=720&verify=secret-token&dl=family-photo.jpg&f=webp"
+                    ),
+                    "data": {
+                        "url": (
+                            "https://assets.gumnut.ai/asset.jpg"
+                            "?w=720&verify=secret-token&dl=family-photo.jpg&f=webp"
+                        ),
+                        "http.query": (
+                            "w=720&verify=secret-token&dl=family-photo.jpg&f=webp"
+                        ),
+                    },
+                }
+            ]
+        }
+
+        result = _enrich_http_spans(event, {})
+        span = result["spans"][0]
+        assert span["description"].endswith("?w=720&verify=REDACTED&dl=REDACTED&f=webp")
+        assert _span_data(result, 0)["url"].endswith(
+            "?w=720&verify=REDACTED&dl=REDACTED&f=webp"
+        )
+        assert _span_data(result, 0)["http.query"] == (
+            "w=720&verify=REDACTED&dl=REDACTED&f=webp"
+        )
+
+    def test_preserves_unrelated_query_metadata(self):
+        event = {
+            "spans": [
+                {
+                    "op": "http.client",
+                    "description": (
+                        "GET https://api.example.com/search"
+                        "?page=2&dl=report.csv&query=cats"
+                    ),
+                    "data": {
+                        "url": (
+                            "https://api.example.com/search"
+                            "?page=2&dl=report.csv&query=cats"
+                        ),
+                        "http.query": "page=2&dl=report.csv&query=cats",
+                    },
+                }
+            ]
+        }
+
+        result = _enrich_http_spans(event, {})
+        assert _span_data(result, 0)["http.query"] == (
+            "page=2&dl=report.csv&query=cats"
+        )
+        assert _span_data(result, 0)["url"].endswith("?page=2&dl=report.csv&query=cats")
+
     def test_adds_server_address_from_url(self):
         event = {
             "spans": [

--- a/tests/unit/config/test_sentry.py
+++ b/tests/unit/config/test_sentry.py
@@ -26,6 +26,16 @@ def test_error_events_redact_signed_cdn_values_without_touching_other_queries():
                                         "'https://api.example.com/search"
                                         "?page=2&dl=report.csv&query=cats'"
                                     ),
+                                    "punctuated_url": (
+                                        "https://assets.gumnut.ai/asset.jpg"
+                                        "?verify=punctuation-secret"
+                                        "&dl=Sensitive,Family(One)'s.jpg"
+                                    ),
+                                    "filename_first_url": (
+                                        "https://assets.gumnut.ai/asset.jpg"
+                                        "?dl=Sensitive,Family.jpg"
+                                        "&verify=reordered-secret"
+                                    ),
                                 }
                             }
                         ]
@@ -50,6 +60,9 @@ def test_error_events_redact_signed_cdn_values_without_touching_other_queries():
     rendered = repr(result)
     assert "secret-token" not in rendered
     assert "family-photo.jpg" not in rendered
+    assert "punctuation-secret" not in rendered
+    assert "reordered-secret" not in rendered
+    assert "Sensitive,Family" not in rendered
     assert "verify=REDACTED&dl=REDACTED&w=720" in rendered
     assert "page=2&dl=report.csv&query=cats" in rendered
 

--- a/tests/unit/config/test_sentry.py
+++ b/tests/unit/config/test_sentry.py
@@ -1,11 +1,57 @@
 from typing import Any
 
-from config.sentry import _enrich_http_spans
+from config.sentry import _enrich_http_spans, _redact_error_event
 
 
 def _span_data(result: dict[str, Any], index: int) -> dict[str, Any]:
     """Extract span data dict with proper typing for test assertions."""
     return result["spans"][index]["data"]
+
+
+def test_error_events_redact_signed_cdn_values_without_touching_other_queries():
+    event: Any = {
+        "exception": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "vars": {
+                                    "url": (
+                                        "'https://assets.gumnut.ai/asset.jpg"
+                                        "?w=720&verify=secret-token"
+                                        "&dl=family-photo.jpg&f=webp'"
+                                    ),
+                                    "safe_url": (
+                                        "'https://api.example.com/search"
+                                        "?page=2&dl=report.csv&query=cats'"
+                                    ),
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "breadcrumbs": {
+            "values": [
+                {
+                    "message": (
+                        "GET https://assets.gumnut.ai/asset.jpg"
+                        "?verify=secret-token&dl=family-photo.jpg&w=720"
+                    )
+                }
+            ]
+        },
+        "request": {"query_string": "page=2&dl=report.csv&query=cats"},
+    }
+
+    result = _redact_error_event(event, {})
+    rendered = repr(result)
+    assert "secret-token" not in rendered
+    assert "family-photo.jpg" not in rendered
+    assert "verify=REDACTED&dl=REDACTED&w=720" in rendered
+    assert "page=2&dl=report.csv&query=cats" in rendered
 
 
 class TestEnrichHttpSpans:

--- a/tests/unit/utils/test_cdn_client.py
+++ b/tests/unit/utils/test_cdn_client.py
@@ -4,7 +4,7 @@ import pytest
 from unittest.mock import AsyncMock, Mock, patch
 from fastapi import HTTPException
 
-from routers.utils.cdn_client import stream_from_cdn
+from routers.utils.cdn_client import iter_cdn_response_bytes, stream_from_cdn
 
 
 @pytest.fixture
@@ -48,6 +48,16 @@ class TestStreamFromCdn:
 
         assert result.status_code == 200
         assert result.media_type == "image/jpeg"
+
+    @pytest.mark.anyio
+    async def test_shared_body_iterator_always_closes_response(self, mock_cdn_response):
+        """Archive members and individual downloads release the connection."""
+        cdn_response = mock_cdn_response(200)
+
+        chunks = [chunk async for chunk in iter_cdn_response_bytes(cdn_response)]
+
+        assert chunks == [b"fake cdn data"]
+        cdn_response.aclose.assert_awaited_once()
 
     @pytest.mark.anyio
     async def test_accept_ranges_on_200(self, mock_cdn_response):

--- a/tests/unit/utils/test_cdn_client.py
+++ b/tests/unit/utils/test_cdn_client.py
@@ -1,5 +1,8 @@
 """Tests for cdn_client.py CDN streaming helper."""
 
+import logging
+
+import httpx
 import pytest
 from unittest.mock import AsyncMock, Mock, patch
 from fastapi import HTTPException
@@ -57,6 +60,23 @@ class TestStreamFromCdn:
         chunks = [chunk async for chunk in iter_cdn_response_bytes(cdn_response)]
 
         assert chunks == [b"fake cdn data"]
+        cdn_response.aclose.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_shared_body_iterator_closes_response_after_read_error(
+        self, mock_cdn_response
+    ):
+        cdn_response = mock_cdn_response(200)
+
+        async def failing_body(chunk_size=None):
+            yield b"partial"
+            raise httpx.ReadError("connection interrupted")
+
+        cdn_response.aiter_bytes = failing_body
+
+        with pytest.raises(httpx.ReadError, match="connection interrupted"):
+            _ = [chunk async for chunk in iter_cdn_response_bytes(cdn_response)]
+
         cdn_response.aclose.assert_awaited_once()
 
     @pytest.mark.anyio
@@ -137,6 +157,31 @@ class TestStreamFromCdn:
 
         assert exc_info.value.status_code == 404
         cdn_response.aclose.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_signed_cdn_query_is_never_logged(self, mock_cdn_response, caplog):
+        """Signed query parameters are asset-access credentials."""
+        cdn_response = mock_cdn_response(403)
+        mock_client = AsyncMock()
+        mock_client.build_request = Mock(return_value=Mock())
+        mock_client.send = AsyncMock(return_value=cdn_response)
+        signed_url = "https://cdn.example.com/asset.jpg?verify=secret-token&dl=name"
+
+        with (
+            patch(
+                "routers.utils.cdn_client.get_cdn_http_client",
+                new_callable=AsyncMock,
+                return_value=mock_client,
+            ),
+            caplog.at_level(logging.WARNING),
+            pytest.raises(HTTPException),
+        ):
+            await stream_from_cdn(signed_url, "image/jpeg")
+
+        log_data = " ".join(str(record.__dict__) for record in caplog.records)
+        assert "secret-token" not in log_data
+        assert "verify=" not in log_data
+        assert caplog.records[-1].cdn_host == "cdn.example.com"
 
     @pytest.mark.anyio
     async def test_cdn_404_maps_to_404(self, mock_cdn_response):

--- a/tools/dump_openapi_json.py
+++ b/tools/dump_openapi_json.py
@@ -11,6 +11,7 @@
 #     "b64uuid>=0.1",
 #     "shortuuid>=1.0.13",
 #     "redis~=8.0",
+#     "stream-zip>=0.0.83",
 #     "user-agents>=2.2.0",
 # ]
 # ///

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-04T22:03:10.577091Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -409,6 +409,7 @@ dependencies = [
     { name = "redis" },
     { name = "sentry-sdk", extra = ["fastapi", "httpx"] },
     { name = "shortuuid" },
+    { name = "stream-zip" },
     { name = "user-agents" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -432,6 +433,7 @@ requires-dist = [
     { name = "redis", specifier = "~=8.0" },
     { name = "sentry-sdk", extras = ["fastapi", "httpx"], specifier = ">=2.37.1" },
     { name = "shortuuid", specifier = ">=1.0.13" },
+    { name = "stream-zip", specifier = ">=0.0.83" },
     { name = "user-agents", specifier = ">=2.2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.44.0" },
 ]
@@ -550,6 +552,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
+]
+
+[[package]]
+name = "pycryptodome"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/a6/8452177684d5e906854776276ddd34eca30d1b1e15aa1ee9cefc289a33f5/pycryptodome-3.23.0.tar.gz", hash = "sha256:447700a657182d60338bab09fdb27518f8856aecd80ae4c6bdddb67ff5da44ef", size = 4921276, upload-time = "2025-05-17T17:21:45.242Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/6c/a1f71542c969912bb0e106f64f60a56cc1f0fabecf9396f45accbe63fa68/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:187058ab80b3281b1de11c2e6842a357a1f71b42cb1e15bce373f3d238135c27", size = 2495627, upload-time = "2025-05-17T17:20:47.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/4e/a066527e079fc5002390c8acdd3aca431e6ea0a50ffd7201551175b47323/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:cfb5cd445280c5b0a4e6187a7ce8de5a07b5f3f897f235caa11f1f435f182843", size = 1640362, upload-time = "2025-05-17T17:20:50.392Z" },
+    { url = "https://files.pythonhosted.org/packages/50/52/adaf4c8c100a8c49d2bd058e5b551f73dfd8cb89eb4911e25a0c469b6b4e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67bd81fcbe34f43ad9422ee8fd4843c8e7198dd88dd3d40e6de42ee65fbe1490", size = 2182625, upload-time = "2025-05-17T17:20:52.866Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e9/a09476d436d0ff1402ac3867d933c61805ec2326c6ea557aeeac3825604e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8987bd3307a39bc03df5c8e0e3d8be0c4c3518b7f044b0f4c15d1aa78f52575", size = 2268954, upload-time = "2025-05-17T17:20:55.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c5/ffe6474e0c551d54cab931918127c46d70cab8f114e0c2b5a3c071c2f484/pycryptodome-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa0698f65e5b570426fc31b8162ed4603b0c2841cbb9088e2b01641e3065915b", size = 2308534, upload-time = "2025-05-17T17:20:57.279Z" },
+    { url = "https://files.pythonhosted.org/packages/18/28/e199677fc15ecf43010f2463fde4c1a53015d1fe95fb03bca2890836603a/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:53ecbafc2b55353edcebd64bf5da94a2a2cdf5090a6915bcca6eca6cc452585a", size = 2181853, upload-time = "2025-05-17T17:20:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ea/4fdb09f2165ce1365c9eaefef36625583371ee514db58dc9b65d3a255c4c/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:156df9667ad9f2ad26255926524e1c136d6664b741547deb0a86a9acf5ea631f", size = 2342465, upload-time = "2025-05-17T17:21:03.83Z" },
+    { url = "https://files.pythonhosted.org/packages/22/82/6edc3fc42fe9284aead511394bac167693fb2b0e0395b28b8bedaa07ef04/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:dea827b4d55ee390dc89b2afe5927d4308a8b538ae91d9c6f7a5090f397af1aa", size = 2267414, upload-time = "2025-05-17T17:21:06.72Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fe/aae679b64363eb78326c7fdc9d06ec3de18bac68be4b612fc1fe8902693c/pycryptodome-3.23.0-cp37-abi3-win32.whl", hash = "sha256:507dbead45474b62b2bbe318eb1c4c8ee641077532067fec9c1aa82c31f84886", size = 1768484, upload-time = "2025-05-17T17:21:08.535Z" },
+    { url = "https://files.pythonhosted.org/packages/54/2f/e97a1b8294db0daaa87012c24a7bb714147c7ade7656973fd6c736b484ff/pycryptodome-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:c75b52aacc6c0c260f204cbdd834f76edc9fb0d8e0da9fbf8352ef58202564e2", size = 1799636, upload-time = "2025-05-17T17:21:10.393Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3d/f9441a0d798bf2b1e645adc3265e55706aead1255ccdad3856dbdcffec14/pycryptodome-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:11eeeb6917903876f134b56ba11abe95c0b0fd5e3330def218083c7d98bbcb3c", size = 1703675, upload-time = "2025-05-17T17:21:13.146Z" },
 ]
 
 [[package]]
@@ -924,6 +945,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "stream-zip"
+version = "0.0.84"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycryptodome" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/f2/bc3d35c70735fa118eb3a49af8ce786863df87c910c14483daca5d056613/stream_zip-0.0.84.tar.gz", hash = "sha256:32ba07c3c7fe947c0224a9f8e4a228f14080e01b17d8ffc78c16a6043b1fba12", size = 10074, upload-time = "2026-02-04T08:37:41.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/8c/e11decad4ab23780503666170b09a8d0d07b15045b522b0ba94fc5df257f/stream_zip-0.0.84-py3-none-any.whl", hash = "sha256:4e3a68aba1aba643035c4b9e219a61de519752693ff727c3268581a1e70f1376", size = 9890, upload-time = "2026-02-04T08:37:39.862Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- implement Immich-compatible batch download planning and streamed ZIP archives
- preflight every requested asset and reject the complete archive and explicit-ID info request when any asset is missing, inaccessible, or lacks required metadata
- reject nullable file sizes before response construction and resolve ZIP mtimes through the documented metadata/file/capture-time fallback
- group browser downloads around a 512 MiB preference while streaming CDN bodies in 64 KiB chunks without buffering the archive, retaining only compact preflight descriptors and converting IDs in backend-sized batches
- isolate ZIP generation in a bounded archive executor, cancel queued work promptly, and unwind running CDN reads before response cleanup
- sanitize case-, Unicode-, and Windows-equivalent ZIP member names—including superscript device aliases—while keeping every deduplicated component within 255 UTF-8 bytes
- redact only signed-CDN `verify` and associated `dl` values from immich-adapter HTTPX logs, Sentry spans, and Sentry error-event metadata, including punctuation-bearing filenames embedded in text
- document the archive streaming architecture and cover request ordering, chunking, backpressure, filenames, timestamps, cleanup, strict validation, preferences, and telemetry

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pyright`
- `uv run python scripts/lint_docs.py`
- `uv run pytest` — 1,770 passed, 17 pre-existing warnings
- pinned Immich v3.1.0 OpenAPI validation — no download endpoint differences

Generated by an AI coding agent.
