### PR TITLE
Suppress Immich face geometry while an edited rendering is current

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ The sections below follow that order, with design docs split by their `status:` 
 |-------|----------|-----------------|
 | Project conventions | `docs/references/project-conventions.md` | Python style, repository organization, public-repository wording, and pull requests |
 | Routes and compatibility | `docs/references/routes-dtos-and-upstream-compatibility.md` | Route parameters, DTOs, errors, generated models, upstream behavior, and version bumps |
-| Asset and media handling | `docs/references/asset-and-media-handling.md` | Asset fields, media variants, checksums, edited-state and face-geometry suppression, and asset-operation WebSocket emission |
+| Asset and media handling | `docs/references/asset-and-media-handling.md` | Asset fields, media variants, checksums, face geometry, and asset-operation WebSocket emission |
 | Pagination, bulk, and concurrency | `docs/references/pagination-bulk-and-concurrency.md` | Cursor/offset translation, bounded enumeration, aggregates, fan-out, and bulk-ID operations |
 | Testing and logging | `docs/references/testing-and-logging.md` | Test fixtures, async test traps, structured logging, and upstream severity policy |
 | Documentation conventions | `docs/references/documentation-conventions.md` | Writing or maintaining docs — frontmatter, map rows, lifecycle, freshness, path citations |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ The sections below follow that order, with design docs split by their `status:` 
 |-------|----------|-----------------|
 | Project conventions | `docs/references/project-conventions.md` | Python style, repository organization, public-repository wording, and pull requests |
 | Routes and compatibility | `docs/references/routes-dtos-and-upstream-compatibility.md` | Route parameters, DTOs, errors, generated models, upstream behavior, and version bumps |
-| Asset and media handling | `docs/references/asset-and-media-handling.md` | Asset fields, media variants, checksums, and asset-operation WebSocket emission |
+| Asset and media handling | `docs/references/asset-and-media-handling.md` | Asset fields, media variants, checksums, edited-state and face-geometry suppression, and asset-operation WebSocket emission |
 | Pagination, bulk, and concurrency | `docs/references/pagination-bulk-and-concurrency.md` | Cursor/offset translation, bounded enumeration, aggregates, fan-out, and bulk-ID operations |
 | Testing and logging | `docs/references/testing-and-logging.md` | Test fixtures, async test traps, structured logging, and upstream severity policy |
 | Documentation conventions | `docs/references/documentation-conventions.md` | Writing or maintaining docs — frontmatter, map rows, lifecycle, freshness, path citations |

--- a/docs/architecture/sync-stream-architecture.md
+++ b/docs/architecture/sync-stream-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Sync Stream Architecture"
-last-updated: 2026-08-12
+last-updated: 2026-08-19
 ---
 
 # Sync Stream Architecture
@@ -25,6 +25,15 @@ Event types are classified into `_DELETE_EVENT_TYPES` (construct delete sync eve
 ## Deletion Events
 
 `_make_delete_sync_event()` maps `entity_id` to a UUID. For junction table deletions (e.g., `album_asset_removed`), the event's `payload` field carries the foreign keys since the record is hard-deleted.
+
+## Gating Rows Is a State Transition, Never an Omission
+
+A pass that must hide rows from clients (e.g., the face-geometry gate — see
+`docs/references/asset-and-media-handling.md`) cannot just skip the upsert: a
+client that synced the row before the condition arose keeps its stale copy
+forever, and the cursor advances past the discarded event. Emit the hidden
+state instead — a visibility flag where the sync type has one, a retraction
+delete where it doesn't.
 
 ## Face person_id Handling
 

--- a/docs/references/asset-and-media-handling.md
+++ b/docs/references/asset-and-media-handling.md
@@ -62,6 +62,22 @@ archive route currently streams the current rendering regardless of `edited`.
 Mock assets must set `kind` explicitly; `make_gumnut_asset` defaults it to
 `"original"`.
 
+**Face geometry is suppressed while an edited rendering is current.** Gumnut
+stores face bounding boxes in the *original* upload's pixel space and keeps
+them there across edits, so emitting them alongside derived pixels would draw
+boxes in the wrong frame. `should_expose_face_geometry`
+(`routers/utils/asset_conversion.py`) is the single home for the rule — gate
+any new face-geometry emit or write site on it instead of re-deriving from
+`kind`. Today that gates three sites: `GET /api/faces` returns `[]` for edited
+assets (before spending face/person calls), `POST /api/faces` rejects with 409
+before any coordinate math, and the face sync pass skips
+`SyncAssetFaceV1/V2` rows via `fetch_suppressed_face_ids` — one lean bulk
+asset read per event page, never one retrieve per face, suppressing
+fail-safe when the owning asset can't be fetched. Suppression hides rows; it
+never mutates stored faces, and people associations, person thumbnails, and
+`AssetResponseDto.people` stay intact. Reverting to the original restores the
+same geometry with no reconstruction.
+
 ## Thumbnail variant selection by aspect ratio
 
 `GET /api/assets/{id}/thumbnail?size=thumbnail` normally streams the 360px `thumbnail` variant, but `_retrieve_and_stream_variant` (`routers/api/assets.py`) upgrades it to the 720px `small` variant for **wide-landscape** assets — `width > height` AND aspect ratio above `_LANDSCAPE_SMALL_ASPECT_THRESHOLD` (see the constant for the value). The Immich web timeline is a justified-rows grid that renders every row at a fixed height; a 360px-longest-edge thumbnail of a landscape asset has a height of only `360/aspect`, so the wider the asset the shorter the tile and the more visibly it softens when upscaled to fill the row. Only assets past the threshold — where the upscale is visible — get bumped. The 720px `small` keeps those panorama/ultrawide cells crisp at roughly a quarter of the pixels of the 1440px `preview`, which is far more resolution than a timeline tile needs. Portrait assets are deliberately excluded — 360px lands on their height, which already meets the row height, so they stay crisp without the extra bandwidth. `small`/`preview`/`fullsize`/`original` requests and missing/zero dims pass through unchanged (the `width`/`height` `0`-means-unknown guard from *Asset dimensions and orientation* applies here too). Video upgrades resolve to `small_image` via the existing `_image`-suffix logic — so any variant the bump can target must be a member of both the `AssetVariant` type and `_VIDEO_IMAGE_VARIANTS`, or a video upgrade resolves to a bare (non-`_image`) key that isn't in `asset_urls` and 404s. The threshold is tunable.

--- a/docs/references/asset-and-media-handling.md
+++ b/docs/references/asset-and-media-handling.md
@@ -62,25 +62,16 @@ archive route currently streams the current rendering regardless of `edited`.
 Mock assets must set `kind` explicitly; `make_gumnut_asset` defaults it to
 `"original"`.
 
-**Face geometry is suppressed while an edited rendering is current.** Gumnut
-stores face bounding boxes in the *original* upload's pixel space and keeps
-them there across edits, so emitting them alongside derived pixels would draw
-boxes in the wrong frame. `should_expose_face_geometry`
-(`routers/utils/asset_conversion.py`) is the single home for the rule — gate
-every face-geometry emit or write site on it instead of re-deriving from
-`kind` (search its callers for the gated surfaces). REST reads return no
-geometry and writes are rejected while gated. The sync stream represents the
-gate as a **state transition, never an omission**, because a client may
-already hold a face row synced before the edit: a gated face event re-emits
-the row with `isVisible=false` on `AssetFaceV2` and retracts it
-(`AssetFaceDeleteV1`) on `AssetFaceV1`, and the next face event after the
-original is restored re-emits the visible row. An edit or restore with no
-subsequent face event reaches checkpointed clients only on the next face
-event or full resync — closing that gap needs upstream face events emitted
-on rendering changes. Suppression never mutates stored state — faces, people
-associations, person thumbnails, and `AssetResponseDto.people` stay intact,
-and reverting to the original restores the same geometry with no
-reconstruction.
+**Suppress face geometry while an edited rendering is current.** Gumnut stores
+face boxes in the original upload's pixel space, so they are invalid over
+derived pixels. Gate every REST and sync emit or write site through
+`should_expose_face_geometry`: REST reads return no geometry and writes return
+409. Sync must transition existing rows rather than omit them — `AssetFaceV2`
+emits `isVisible=false`, while `AssetFaceV1` emits `AssetFaceDeleteV1`; a later
+face event after restoration re-emits the visible row. Edits and restores do
+not themselves emit face events, so checkpointed clients converge only after
+the next face event or full resync. Suppression does not mutate faces, people
+associations, person thumbnails, or `AssetResponseDto.people`.
 
 ## Thumbnail variant selection by aspect ratio
 

--- a/docs/references/asset-and-media-handling.md
+++ b/docs/references/asset-and-media-handling.md
@@ -68,15 +68,12 @@ them there across edits, so emitting them alongside derived pixels would draw
 boxes in the wrong frame. `should_expose_face_geometry`
 (`routers/utils/asset_conversion.py`) is the single home for the rule — gate
 any new face-geometry emit or write site on it instead of re-deriving from
-`kind`. Today that gates three sites: `GET /api/faces` returns `[]` for edited
-assets (before spending face/person calls), `POST /api/faces` rejects with 409
-before any coordinate math, and the face sync pass skips
-`SyncAssetFaceV1/V2` rows via `fetch_suppressed_face_ids` — one lean bulk
-asset read per event page, never one retrieve per face, suppressing
-fail-safe when the owning asset can't be fetched. Suppression hides rows; it
-never mutates stored faces, and people associations, person thumbnails, and
-`AssetResponseDto.people` stay intact. Reverting to the original restores the
-same geometry with no reconstruction.
+`kind`. Today that gates three sites: `GET /api/faces` (empty list),
+`POST /api/faces` (409), and the face sync pass
+(`fetch_suppressed_face_ids`, which owns the bulk-read and fail-safe
+mechanics). Suppression hides rows only — stored faces, people associations,
+person thumbnails, and `AssetResponseDto.people` stay intact, and reverting
+to the original restores the same geometry with no reconstruction.
 
 ## Thumbnail variant selection by aspect ratio
 

--- a/docs/references/asset-and-media-handling.md
+++ b/docs/references/asset-and-media-handling.md
@@ -67,13 +67,20 @@ stores face bounding boxes in the *original* upload's pixel space and keeps
 them there across edits, so emitting them alongside derived pixels would draw
 boxes in the wrong frame. `should_expose_face_geometry`
 (`routers/utils/asset_conversion.py`) is the single home for the rule — gate
-any new face-geometry emit or write site on it instead of re-deriving from
-`kind`. Today that gates three sites: `GET /api/faces` (empty list),
-`POST /api/faces` (409), and the face sync pass
-(`fetch_suppressed_face_ids`, which owns the bulk-read and fail-safe
-mechanics). Suppression hides rows only — stored faces, people associations,
-person thumbnails, and `AssetResponseDto.people` stay intact, and reverting
-to the original restores the same geometry with no reconstruction.
+every face-geometry emit or write site on it instead of re-deriving from
+`kind` (search its callers for the gated surfaces). REST reads return no
+geometry and writes are rejected while gated. The sync stream represents the
+gate as a **state transition, never an omission**, because a client may
+already hold a face row synced before the edit: a gated face event re-emits
+the row with `isVisible=false` on `AssetFaceV2` and retracts it
+(`AssetFaceDeleteV1`) on `AssetFaceV1`, and the next face event after the
+original is restored re-emits the visible row. An edit or restore with no
+subsequent face event reaches checkpointed clients only on the next face
+event or full resync — closing that gap needs upstream face events emitted
+on rendering changes. Suppression never mutates stored state — faces, people
+associations, person thumbnails, and `AssetResponseDto.people` stay intact,
+and reverting to the original restores the same geometry with no
+reconstruction.
 
 ## Thumbnail variant selection by aspect ratio
 

--- a/routers/api/faces.py
+++ b/routers/api/faces.py
@@ -83,10 +83,9 @@ async def get_faces(
     """Get all faces detected in an asset."""
     gumnut_asset_id = uuid_to_gumnut_asset_id(id)
 
-    # Resolve the owning asset before touching faces: while an edited rendering
-    # is current, stored boxes live in the original's pixel space and must not
-    # be paired with derived pixels (see should_expose_face_geometry). Checking
-    # first also keeps the suppression path from spending face/person calls.
+    # Gate on the owning asset before touching faces (see
+    # should_expose_face_geometry); checking first also keeps the suppression
+    # path from spending face/person calls.
     asset = await client.assets.retrieve(gumnut_asset_id)
     if not should_expose_face_geometry(asset):
         return []
@@ -158,11 +157,9 @@ async def create_face(
     # to the asset's real dimensions before storing.
     asset = await client.assets.retrieve(gumnut_asset_id)
 
-    # A box drawn while an edited rendering is current would be captured in the
-    # derived image's pixel space, but Gumnut stores boxes in the original's
-    # space — reject before any coordinate math rather than store geometry in
-    # the wrong frame. The backend enforces the same invariant; failing here
-    # gives Immich a stable client error instead of a doomed upstream call.
+    # Reject before any coordinate math (see should_expose_face_geometry).
+    # The backend enforces the same invariant; failing here gives Immich a
+    # stable client error instead of a doomed upstream call.
     if not should_expose_face_geometry(asset):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/routers/api/faces.py
+++ b/routers/api/faces.py
@@ -2,7 +2,7 @@ import logging
 from typing import List
 from uuid import UUID
 
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Body, Depends, HTTPException, status
 from gumnut import AsyncGumnut
 
 from routers.immich_models import (
@@ -20,6 +20,7 @@ from routers.utils.gumnut_id_conversion import (
     uuid_to_gumnut_face_id,
     uuid_to_gumnut_person_id,
 )
+from routers.utils.asset_conversion import should_expose_face_geometry
 from routers.utils.person_conversion import convert_gumnut_person_to_immich
 
 
@@ -82,11 +83,17 @@ async def get_faces(
     """Get all faces detected in an asset."""
     gumnut_asset_id = uuid_to_gumnut_asset_id(id)
 
+    # Resolve the owning asset before touching faces: while an edited rendering
+    # is current, stored boxes live in the original's pixel space and must not
+    # be paired with derived pixels (see should_expose_face_geometry). Checking
+    # first also keeps the suppression path from spending face/person calls.
+    asset = await client.assets.retrieve(gumnut_asset_id)
+    if not should_expose_face_geometry(asset):
+        return []
+
     faces = [f async for f in client.faces.list(asset_id=gumnut_asset_id)]
     if not faces:
         return []
-
-    asset = await client.assets.retrieve(gumnut_asset_id)
 
     image_width = asset.width or 0
     image_height = asset.height or 0
@@ -150,6 +157,21 @@ async def create_face(
     # 3024-wide asset, landing shrunk in the top-left corner. Scale the box up
     # to the asset's real dimensions before storing.
     asset = await client.assets.retrieve(gumnut_asset_id)
+
+    # A box drawn while an edited rendering is current would be captured in the
+    # derived image's pixel space, but Gumnut stores boxes in the original's
+    # space — reject before any coordinate math rather than store geometry in
+    # the wrong frame. The backend enforces the same invariant; failing here
+    # gives Immich a stable client error instead of a doomed upstream call.
+    if not should_expose_face_geometry(asset):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "This asset currently shows an edited version. Restore the "
+                "original before drawing a face."
+            ),
+        )
+
     scale_x = (
         asset.width / request.imageWidth if asset.width and request.imageWidth else 1.0
     )

--- a/routers/api/faces.py
+++ b/routers/api/faces.py
@@ -83,9 +83,7 @@ async def get_faces(
     """Get all faces detected in an asset."""
     gumnut_asset_id = uuid_to_gumnut_asset_id(id)
 
-    # Gate on the owning asset before touching faces (see
-    # should_expose_face_geometry); checking first also keeps the suppression
-    # path from spending face/person calls.
+    # Fetch the owner first to avoid face/person reads when geometry is gated.
     asset = await client.assets.retrieve(gumnut_asset_id)
     if not should_expose_face_geometry(asset):
         return []
@@ -157,9 +155,7 @@ async def create_face(
     # to the asset's real dimensions before storing.
     asset = await client.assets.retrieve(gumnut_asset_id)
 
-    # Reject before any coordinate math (see should_expose_face_geometry).
-    # The backend enforces the same invariant; failing here gives Immich a
-    # stable client error instead of a doomed upstream call.
+    # Reject before scaling so Immich receives a stable 409.
     if not should_expose_face_geometry(asset):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/routers/api/sync/converters.py
+++ b/routers/api/sync/converters.py
@@ -402,10 +402,8 @@ def gumnut_face_to_sync_face_v2(
 ) -> SyncAssetFaceV2:
     """Convert Gumnut FaceResponse to Immich SyncAssetFaceV2 format.
 
-    Delegates to V1 and adds deletedAt (always None — Gumnut has no soft-delete
-    on faces) and isVisible. ``visible=False`` marks a geometry-gated row
-    (see ``should_expose_face_geometry``) so a pre-edit client copy
-    reconciles hidden.
+    Delegates to V1 and adds ``deletedAt`` (always ``None``) and ``isVisible``.
+    A false ``visible`` value hides geometry already held by a client.
     """
     v1 = gumnut_face_to_sync_face_v1(face)
     return SyncAssetFaceV2(**v1.model_dump(), deletedAt=None, isVisible=visible)

--- a/routers/api/sync/converters.py
+++ b/routers/api/sync/converters.py
@@ -397,14 +397,18 @@ def gumnut_face_to_sync_face_v1(face: FaceResponse) -> SyncAssetFaceV1:
     )
 
 
-def gumnut_face_to_sync_face_v2(face: FaceResponse) -> SyncAssetFaceV2:
+def gumnut_face_to_sync_face_v2(
+    face: FaceResponse, *, visible: bool = True
+) -> SyncAssetFaceV2:
     """Convert Gumnut FaceResponse to Immich SyncAssetFaceV2 format.
 
     Delegates to V1 and adds deletedAt (always None — Gumnut has no soft-delete
-    on faces) and isVisible (always True — Gumnut has no face visibility control).
+    on faces) and isVisible. ``visible=False`` marks a geometry-gated row
+    (see ``should_expose_face_geometry``) so a pre-edit client copy
+    reconciles hidden.
     """
     v1 = gumnut_face_to_sync_face_v1(face)
-    return SyncAssetFaceV2(**v1.model_dump(), deletedAt=None, isVisible=True)
+    return SyncAssetFaceV2(**v1.model_dump(), deletedAt=None, isVisible=visible)
 
 
 def gumnut_album_asset_to_sync_album_to_asset_v1(

--- a/routers/api/sync/entity_fetch.py
+++ b/routers/api/sync/entity_fetch.py
@@ -6,11 +6,15 @@ from uuid import UUID
 
 from gumnut import AsyncGumnut
 from gumnut.types.asset_response import AssetResponse
+from gumnut.types.face_response import FaceResponse
 from gumnut.types.stack_list_stacks_response import StackListStacksResponse
 
 from routers.api.constants import GUMNUT_API_MAX_BULK_IDS
 from routers.api.sync.types import EntityType, FetchedStack
-from routers.utils.asset_conversion import ASSET_INCLUDE_NO_PEOPLE
+from routers.utils.asset_conversion import (
+    ASSET_INCLUDE_NO_PEOPLE,
+    should_expose_face_geometry,
+)
 from routers.utils.concurrency import gather_with_concurrency
 from routers.utils.gumnut_id_conversion import (
     safe_uuid_from_asset_id,
@@ -199,3 +203,37 @@ async def fetch_entities_map(
                     )
 
     return result, missing_ids
+
+
+async def fetch_suppressed_face_ids(
+    gumnut_client: AsyncGumnut,
+    faces: list[FaceResponse],
+) -> set[str]:
+    """Return the ids of faces whose geometry rows must not be synced.
+
+    Face rows carry original-space bounding boxes, so they are suppressed while
+    the owning asset's current rendering is edited (see
+    ``should_expose_face_geometry``). The face hydration read returns no asset
+    context, so this resolves the owning assets in one lean bulk read per
+    ``GUMNUT_API_MAX_BULK_IDS`` chunk of unique asset ids — never one retrieve
+    per face. No ``include`` is needed: the gate reads only ``kind``, a
+    lean-core field. ``state="all"`` matches the hydration read so a trashed
+    asset's faces are gated by its kind rather than by its absence.
+
+    Fail safe: a face whose owning asset the bulk read does not return is also
+    suppressed — geometry is only emitted once the original is confirmed
+    current. Suppression hides rows from the stream; it never mutates stored
+    faces, and the same rows emit again once the original is current.
+    """
+    asset_ids = list(dict.fromkeys(face.asset_id for face in faces))
+    if not asset_ids:
+        return set()
+
+    exposable_asset_ids: set[str] = set()
+    for chunk in _batched(asset_ids, GUMNUT_API_MAX_BULK_IDS):
+        page = await gumnut_client.assets.list(state="all", ids=chunk, limit=len(chunk))
+        exposable_asset_ids.update(
+            asset.id for asset in page.data if should_expose_face_geometry(asset)
+        )
+
+    return {face.id for face in faces if face.asset_id not in exposable_asset_ids}

--- a/routers/api/sync/entity_fetch.py
+++ b/routers/api/sync/entity_fetch.py
@@ -209,24 +209,23 @@ async def fetch_suppressed_face_ids(
     gumnut_client: AsyncGumnut,
     faces: list[FaceResponse],
 ) -> set[str]:
-    """Return the ids of faces whose geometry rows must not be synced.
+    """Return the ids of faces whose geometry must not be exposed when synced.
 
-    Face rows carry original-space bounding boxes, so they are suppressed while
-    the owning asset's current rendering is edited (see
-    ``should_expose_face_geometry``). The face hydration read returns no asset
-    context, so this resolves the owning assets in one lean bulk read per
-    ``GUMNUT_API_MAX_BULK_IDS`` chunk of unique asset ids — never one retrieve
-    per face. No ``include`` is needed: the gate reads only ``kind``, a
-    lean-core field. ``state="all"`` matches the hydration read so a trashed
-    asset's faces are gated by its kind rather than by its absence.
+    The gate is ``should_expose_face_geometry`` (see its docstring for the
+    pixel-space rationale); the stream turns membership in this set into a
+    visibility state transition rather than an omission. The face hydration
+    read returns no asset context, so this resolves the owning assets in one
+    bulk read per ``GUMNUT_API_MAX_BULK_IDS`` chunk of unique asset ids —
+    never one retrieve per face. No ``include`` is requested: the gate reads
+    only ``kind``, a lean-core field, so the read becomes lean once the API's
+    lean-include default lands (see the ``ASSET_INCLUDE`` comment in
+    ``routers/utils/asset_conversion.py``). ``state="all"`` matches the
+    hydration read so a trashed asset's faces are gated by its kind rather
+    than by its absence.
 
     Fail safe: a face whose owning asset the bulk read does not return is also
-    suppressed (with a warning — usually the asset was deleted between event
-    and fetch, and its face_deleted events follow) — geometry is only emitted
-    once the original is confirmed current. Suppression hides rows from the
-    stream and never mutates stored faces; the cursor advances past a
-    suppressed event, so the row reaches the client again via a later face
-    event or a full resync once the original is current.
+    gated (with a warning — usually the asset was deleted between event and
+    fetch, and its face_deleted events follow).
     """
     asset_ids = list(dict.fromkeys(face.asset_id for face in faces))
     if not asset_ids:

--- a/routers/api/sync/entity_fetch.py
+++ b/routers/api/sync/entity_fetch.py
@@ -221,19 +221,33 @@ async def fetch_suppressed_face_ids(
     asset's faces are gated by its kind rather than by its absence.
 
     Fail safe: a face whose owning asset the bulk read does not return is also
-    suppressed — geometry is only emitted once the original is confirmed
-    current. Suppression hides rows from the stream; it never mutates stored
-    faces, and the same rows emit again once the original is current.
+    suppressed (with a warning — usually the asset was deleted between event
+    and fetch, and its face_deleted events follow) — geometry is only emitted
+    once the original is confirmed current. Suppression hides rows from the
+    stream and never mutates stored faces; the cursor advances past a
+    suppressed event, so the row reaches the client again via a later face
+    event or a full resync once the original is current.
     """
     asset_ids = list(dict.fromkeys(face.asset_id for face in faces))
     if not asset_ids:
         return set()
 
-    exposable_asset_ids: set[str] = set()
+    fetched_assets: dict[str, AssetResponse] = {}
     for chunk in _batched(asset_ids, GUMNUT_API_MAX_BULK_IDS):
         page = await gumnut_client.assets.list(state="all", ids=chunk, limit=len(chunk))
-        exposable_asset_ids.update(
-            asset.id for asset in page.data if should_expose_face_geometry(asset)
+        fetched_assets.update({asset.id: asset for asset in page.data})
+
+    unfetched = set(asset_ids) - fetched_assets.keys()
+    if unfetched:
+        logger.warning(
+            "Owning assets missing during face-geometry gating; suppressing "
+            "their face rows fail-safe",
+            extra={"asset_ids": sorted(unfetched)},
         )
 
+    exposable_asset_ids = {
+        asset.id
+        for asset in fetched_assets.values()
+        if should_expose_face_geometry(asset)
+    }
     return {face.id for face in faces if face.asset_id not in exposable_asset_ids}

--- a/routers/api/sync/entity_fetch.py
+++ b/routers/api/sync/entity_fetch.py
@@ -209,23 +209,11 @@ async def fetch_suppressed_face_ids(
     gumnut_client: AsyncGumnut,
     faces: list[FaceResponse],
 ) -> set[str]:
-    """Return the ids of faces whose geometry must not be exposed when synced.
+    """Return face ids whose owning assets do not expose geometry.
 
-    The gate is ``should_expose_face_geometry`` (see its docstring for the
-    pixel-space rationale); the stream turns membership in this set into a
-    visibility state transition rather than an omission. The face hydration
-    read returns no asset context, so this resolves the owning assets in one
-    bulk read per ``GUMNUT_API_MAX_BULK_IDS`` chunk of unique asset ids —
-    never one retrieve per face. No ``include`` is requested: the gate reads
-    only ``kind``, a lean-core field, so the read becomes lean once the API's
-    lean-include default lands (see the ``ASSET_INCLUDE`` comment in
-    ``routers/utils/asset_conversion.py``). ``state="all"`` matches the
-    hydration read so a trashed asset's faces are gated by its kind rather
-    than by its absence.
-
-    Fail safe: a face whose owning asset the bulk read does not return is also
-    gated (with a warning — usually the asset was deleted between event and
-    fetch, and its face_deleted events follow).
+    Owners are deduplicated and fetched with ``state="all"``, chunked at
+    ``GUMNUT_API_MAX_BULK_IDS``. Missing owners are suppressed fail-safe. No
+    ``include`` is needed because the predicate reads lean-core ``kind``.
     """
     asset_ids = list(dict.fromkeys(face.asset_id for face in faces))
     if not asset_ids:

--- a/routers/api/sync/events.py
+++ b/routers/api/sync/events.py
@@ -300,9 +300,7 @@ def convert_entity_to_sync_event(
         owner_id: UUID of the owner
         cursor: The event cursor for the ack string
         sync_entity_type: The Immich sync entity type
-        face_visible: For AssetFaceV2 rows only — False emits the row with
-            ``isVisible=False`` (geometry gated while the owning asset's
-            rendering is edited)
+        face_visible: Whether an AssetFaceV2 row is visible
 
     Returns:
         JSON line string with newline

--- a/routers/api/sync/events.py
+++ b/routers/api/sync/events.py
@@ -288,6 +288,8 @@ def convert_entity_to_sync_event(
     owner_id: UUID,
     cursor: str,
     sync_entity_type: SyncEntityType,
+    *,
+    face_visible: bool = True,
 ) -> str:
     """
     Convert a fetched entity to an Immich sync event JSON line.
@@ -298,6 +300,9 @@ def convert_entity_to_sync_event(
         owner_id: UUID of the owner
         cursor: The event cursor for the ack string
         sync_entity_type: The Immich sync entity type
+        face_visible: For AssetFaceV2 rows only — False emits the row with
+            ``isVisible=False`` (geometry gated while the owning asset's
+            rendering is edited)
 
     Returns:
         JSON line string with newline
@@ -339,7 +344,9 @@ def convert_entity_to_sync_event(
         )
     elif gumnut_entity_type == "face":
         if sync_entity_type == SyncEntityType.AssetFaceV2:
-            sync_model = gumnut_face_to_sync_face_v2(cast(FaceResponse, entity))
+            sync_model = gumnut_face_to_sync_face_v2(
+                cast(FaceResponse, entity), visible=face_visible
+            )
         else:
             sync_model = gumnut_face_to_sync_face_v1(cast(FaceResponse, entity))
     elif gumnut_entity_type == "metadata":

--- a/routers/api/sync/fk_integrity.py
+++ b/routers/api/sync/fk_integrity.py
@@ -122,6 +122,7 @@ class SyncStreamStats:
     delete_event_skips: int = 0
     buffered_deletes: int = 0
     fk_warnings: int = 0
+    suppressed_face_geometry: int = 0
 
 
 def check_fk_references(

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -21,11 +21,15 @@ from gumnut.types.face_response import FaceResponse
 from gumnut.types.user_response import UserResponse
 
 from routers.immich_models import (
+    SyncAssetFaceDeleteV1,
     SyncEntityType,
     SyncRequestType,
     SyncStreamDto,
 )
-from routers.utils.gumnut_id_conversion import safe_uuid_from_user_id
+from routers.utils.gumnut_id_conversion import (
+    safe_uuid_from_face_id,
+    safe_uuid_from_user_id,
+)
 from services.checkpoint_store import Checkpoint
 
 from routers.api.constants import GUMNUT_API_MAX_PAGE_SIZE
@@ -440,11 +444,34 @@ async def _stream_entity_type(
                 else:
                     stats.delete_event_skips += 1
             else:
-                # Geometry-gated face row — advance the cursor without
-                # emitting or mutating anything.
-                if event.entity_id in suppressed_face_ids:
+                # Geometry-gated face row — emit a state transition, never an
+                # omission (see "Face geometry is suppressed while an edited
+                # rendering is current" in
+                # docs/references/asset-and-media-handling.md): V2 re-emits
+                # the row hidden below, V1 has no visibility flag and
+                # retracts it here.
+                suppress_geometry = event.entity_id in suppressed_face_ids
+                if suppress_geometry:
                     stats.suppressed_face_geometry += 1
-                    continue
+                    if sync_entity_type == SyncEntityType.AssetFaceV1:
+                        # Emitted inline, not via delete_buffer: a face
+                        # delete is FK-safe anywhere before the buffered
+                        # parent deletes flush, and buffering could reorder
+                        # this retraction after a same-stream restore upsert
+                        # of the same face id.
+                        delete_data = SyncAssetFaceDeleteV1(
+                            assetFaceId=safe_uuid_from_face_id(event.entity_id)
+                        )
+                        yield (
+                            make_sync_event(
+                                SyncEntityType.AssetFaceDeleteV1,
+                                delete_data.model_dump(mode="json"),
+                                event.cursor,
+                            ),
+                            1,
+                        )
+                        count += 1
+                        continue
 
                 # Upsert event — look up fetched entity
                 entity = entities_map.get(event.entity_id)
@@ -573,7 +600,12 @@ async def _stream_entity_type(
                 )
 
                 json_line = convert_entity_to_sync_event(
-                    gumnut_entity_type, entity, owner_id, event.cursor, sync_entity_type
+                    gumnut_entity_type,
+                    entity,
+                    owner_id,
+                    event.cursor,
+                    sync_entity_type,
+                    face_visible=not suppress_geometry,
                 )
                 yield json_line, 1
                 count += 1

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -350,8 +350,7 @@ async def _stream_entity_type(
             gumnut_client, gumnut_entity_type, upsert_ids
         )
 
-        # Gate face rows on the owning asset's current kind (resolved in bulk,
-        # never per face) — see fetch_suppressed_face_ids for the rules.
+        # Resolve face gates in bulk from their owning assets.
         suppressed_face_ids: set[str] = set()
         if gumnut_entity_type == "face" and entities_map:
             suppressed_face_ids = await fetch_suppressed_face_ids(
@@ -444,21 +443,14 @@ async def _stream_entity_type(
                 else:
                     stats.delete_event_skips += 1
             else:
-                # Geometry-gated face row — emit a state transition, never an
-                # omission (see "Face geometry is suppressed while an edited
-                # rendering is current" in
-                # docs/references/asset-and-media-handling.md): V2 re-emits
-                # the row hidden below, V1 has no visibility flag and
-                # retracts it here.
+                # Do not omit gated rows: existing clients need V2 hidden
+                # upserts or V1 retractions.
                 suppress_geometry = event.entity_id in suppressed_face_ids
                 if suppress_geometry:
                     stats.suppressed_face_geometry += 1
                     if sync_entity_type == SyncEntityType.AssetFaceV1:
-                        # Emitted inline, not via delete_buffer: a face
-                        # delete is FK-safe anywhere before the buffered
-                        # parent deletes flush, and buffering could reorder
-                        # this retraction after a same-stream restore upsert
-                        # of the same face id.
+                        # Emit inline so a later-page restore upsert wins;
+                        # buffering would reverse them.
                         delete_data = SyncAssetFaceDeleteV1(
                             assetFaceId=safe_uuid_from_face_id(event.entity_id)
                         )

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -34,7 +34,10 @@ from routers.api.sync.converters import (
     gumnut_user_to_sync_user_metadata_v1,
     gumnut_user_to_sync_user_v1,
 )
-from routers.api.sync.entity_fetch import fetch_entities_map
+from routers.api.sync.entity_fetch import (
+    fetch_entities_map,
+    fetch_suppressed_face_ids,
+)
 from routers.api.sync.events import (
     convert_entity_to_sync_event,
     make_delete_sync_event,
@@ -343,6 +346,17 @@ async def _stream_entity_type(
             gumnut_client, gumnut_entity_type, upsert_ids
         )
 
+        # Face rows carry original-space bounding boxes, which must not sync
+        # while the owning asset's current rendering is edited. Resolve the
+        # owning assets' kinds in bulk (never per face) and skip the gated
+        # rows below — see fetch_suppressed_face_ids for the fail-safe rules.
+        suppressed_face_ids: set[str] = set()
+        if gumnut_entity_type == "face" and entities_map:
+            suppressed_face_ids = await fetch_suppressed_face_ids(
+                gumnut_client,
+                [e for e in entities_map.values() if isinstance(e, FaceResponse)],
+            )
+
         # Track entity IDs that were requested but not returned (deleted/404)
         not_returned = set(upsert_ids) - entities_map.keys()
         if not_returned:
@@ -428,6 +442,14 @@ async def _stream_entity_type(
                 else:
                     stats.delete_event_skips += 1
             else:
+                # Geometry-gated face row — advance the cursor without
+                # emitting. Nothing is deleted or mutated: once the original
+                # rendering is current again, the row syncs normally from its
+                # next face event.
+                if event.entity_id in suppressed_face_ids:
+                    stats.suppressed_face_geometry += 1
+                    continue
+
                 # Upsert event — look up fetched entity
                 entity = entities_map.get(event.entity_id)
                 if entity is None:
@@ -815,6 +837,8 @@ async def generate_sync_stream(
             summary_extra["buffered_deletes"] = stats.buffered_deletes
         if stats.fk_warnings > 0:
             summary_extra["fk_reference_warnings"] = stats.fk_warnings
+        if stats.suppressed_face_geometry > 0:
+            summary_extra["suppressed_face_geometry"] = stats.suppressed_face_geometry
 
         logger.info("Sync stream summary", extra=summary_extra)
 

--- a/routers/api/sync/stream.py
+++ b/routers/api/sync/stream.py
@@ -346,10 +346,8 @@ async def _stream_entity_type(
             gumnut_client, gumnut_entity_type, upsert_ids
         )
 
-        # Face rows carry original-space bounding boxes, which must not sync
-        # while the owning asset's current rendering is edited. Resolve the
-        # owning assets' kinds in bulk (never per face) and skip the gated
-        # rows below — see fetch_suppressed_face_ids for the fail-safe rules.
+        # Gate face rows on the owning asset's current kind (resolved in bulk,
+        # never per face) — see fetch_suppressed_face_ids for the rules.
         suppressed_face_ids: set[str] = set()
         if gumnut_entity_type == "face" and entities_map:
             suppressed_face_ids = await fetch_suppressed_face_ids(
@@ -443,9 +441,7 @@ async def _stream_entity_type(
                     stats.delete_event_skips += 1
             else:
                 # Geometry-gated face row — advance the cursor without
-                # emitting. Nothing is deleted or mutated: once the original
-                # rendering is current again, the row syncs normally from its
-                # next face event.
+                # emitting or mutating anything.
                 if event.entity_id in suppressed_face_ids:
                     stats.suppressed_face_geometry += 1
                     continue

--- a/routers/utils/asset_conversion.py
+++ b/routers/utils/asset_conversion.py
@@ -74,11 +74,8 @@ def is_asset_edited(gumnut_asset: AssetResponse) -> bool:
 def should_expose_face_geometry(gumnut_asset: AssetResponse) -> bool:
     """Return whether Immich face bounding boxes may be emitted for this asset.
 
-    Gate any new face-geometry emit or write site on this predicate rather
-    than re-deriving from ``kind``. For the pixel-space rationale and the
-    per-surface suppression behavior, see "Face geometry is suppressed while
-    an edited rendering is current" in
-    ``docs/references/asset-and-media-handling.md``.
+    Use this predicate at every face-geometry emit or write site. The rationale
+    and surface behavior live in ``docs/references/asset-and-media-handling.md``.
     """
     return not is_asset_edited(gumnut_asset)
 

--- a/routers/utils/asset_conversion.py
+++ b/routers/utils/asset_conversion.py
@@ -71,6 +71,23 @@ def is_asset_edited(gumnut_asset: AssetResponse) -> bool:
     return gumnut_asset.kind != "original"
 
 
+def should_expose_face_geometry(gumnut_asset: AssetResponse) -> bool:
+    """Return whether Immich face bounding boxes may be emitted for this asset.
+
+    Gumnut stores face boxes in the *original* upload's pixel space and keeps
+    them there across edits. While a derived rendering is current, those
+    coordinates no longer correspond to the pixels clients display, so every
+    geometry emit/write path (REST ``/faces``, face sync rows) must suppress
+    boxes rather than pair original-space coordinates with derived pixels.
+    People associations and person thumbnails stay untouched — only geometry
+    is hidden, and it reappears once the original is current again.
+
+    This is the single home for the rule; gate any new face-geometry emit site
+    on it rather than re-deriving from ``kind``.
+    """
+    return not is_asset_edited(gumnut_asset)
+
+
 class AssetLocationFields(NamedTuple):
     """Immich-facing location fields shared by every asset response path."""
 

--- a/routers/utils/asset_conversion.py
+++ b/routers/utils/asset_conversion.py
@@ -74,16 +74,11 @@ def is_asset_edited(gumnut_asset: AssetResponse) -> bool:
 def should_expose_face_geometry(gumnut_asset: AssetResponse) -> bool:
     """Return whether Immich face bounding boxes may be emitted for this asset.
 
-    Gumnut stores face boxes in the *original* upload's pixel space and keeps
-    them there across edits. While a derived rendering is current, those
-    coordinates no longer correspond to the pixels clients display, so every
-    geometry emit/write path (REST ``/faces``, face sync rows) must suppress
-    boxes rather than pair original-space coordinates with derived pixels.
-    People associations and person thumbnails stay untouched — only geometry
-    is hidden, and it reappears once the original is current again.
-
-    This is the single home for the rule; gate any new face-geometry emit site
-    on it rather than re-deriving from ``kind``.
+    Gate any new face-geometry emit or write site on this predicate rather
+    than re-deriving from ``kind``. For the pixel-space rationale and the
+    per-surface suppression behavior, see "Face geometry is suppressed while
+    an edited rendering is current" in
+    ``docs/references/asset-and-media-handling.md``.
     """
     return not is_asset_edited(gumnut_asset)
 

--- a/tests/unit/api/sync/conftest.py
+++ b/tests/unit/api/sync/conftest.py
@@ -248,13 +248,7 @@ def create_mock_face_data(updated_at: datetime) -> FaceResponse:
 
 
 def create_mock_face_owning_asset_page(kind: str = "original"):
-    """Owning-asset page for the face-geometry gate.
-
-    The face sync pass gates face rows whose owning asset is edited **or
-    absent** (``fetch_suppressed_face_ids``) — so any test that expects
-    visible face rows must return the owning asset (original kind) from
-    ``mock_client.assets.list``.
-    """
+    """Return the owner page required by visible-face sync tests."""
     asset = Mock()
     asset.id = uuid_to_gumnut_asset_id(TEST_UUID)
     asset.kind = kind

--- a/tests/unit/api/sync/conftest.py
+++ b/tests/unit/api/sync/conftest.py
@@ -250,10 +250,9 @@ def create_mock_face_data(updated_at: datetime) -> FaceResponse:
 def create_mock_face_owning_asset_page(kind: str = "original"):
     """Owning-asset page for the face-geometry gate.
 
-    The face sync pass resolves each event page's owning assets in one bulk
-    ``assets.list`` read (``fetch_suppressed_face_ids``) and suppresses face
-    rows whose asset is edited **or absent** — so any test that expects face
-    rows to emit must return the owning asset (original kind) from
+    The face sync pass gates face rows whose owning asset is edited **or
+    absent** (``fetch_suppressed_face_ids``) — so any test that expects
+    visible face rows must return the owning asset (original kind) from
     ``mock_client.assets.list``.
     """
     asset = Mock()

--- a/tests/unit/api/sync/conftest.py
+++ b/tests/unit/api/sync/conftest.py
@@ -247,6 +247,21 @@ def create_mock_face_data(updated_at: datetime) -> FaceResponse:
     )
 
 
+def create_mock_face_owning_asset_page(kind: str = "original"):
+    """Owning-asset page for the face-geometry gate.
+
+    The face sync pass resolves each event page's owning assets in one bulk
+    ``assets.list`` read (``fetch_suppressed_face_ids``) and suppresses face
+    rows whose asset is edited **or absent** — so any test that expects face
+    rows to emit must return the owning asset (original kind) from
+    ``mock_client.assets.list``.
+    """
+    asset = Mock()
+    asset.id = uuid_to_gumnut_asset_id(TEST_UUID)
+    asset.kind = kind
+    return create_mock_entity_page([asset])
+
+
 def create_mock_album_asset_data(updated_at: datetime) -> Mock:
     """Create mock album_asset data for entity fetch."""
     album_asset = Mock()
@@ -282,5 +297,6 @@ __all__ = [
     "create_mock_metadata_data",
     "create_mock_person_data",
     "create_mock_face_data",
+    "create_mock_face_owning_asset_page",
     "create_mock_entity_page",
 ]

--- a/tests/unit/api/sync/test_entity_fetch.py
+++ b/tests/unit/api/sync/test_entity_fetch.py
@@ -75,8 +75,6 @@ async def test_suppressed_face_ids_empty_input_skips_the_read():
 
 @pytest.mark.anyio
 async def test_suppressed_face_ids_partitions_per_asset_and_fails_safe():
-    """One deduplicated bulk read; only edited-owned and unfetchable-owned
-    faces are suppressed."""
     faces = [
         _face("face_original", "asset_original"),
         _face("face_original_2", "asset_original"),
@@ -102,8 +100,6 @@ async def test_suppressed_face_ids_partitions_per_asset_and_fails_safe():
 
 @pytest.mark.anyio
 async def test_suppressed_face_ids_chunk_at_bulk_id_limit():
-    """Owning-asset resolution chunks like the sibling hydration read, and
-    assets returned by every chunk count as exposable."""
     total = GUMNUT_API_MAX_BULK_IDS + 1
     faces = [_face(f"face_{index}", f"asset_{index}") for index in range(total)]
     client = Mock()

--- a/tests/unit/api/sync/test_entity_fetch.py
+++ b/tests/unit/api/sync/test_entity_fetch.py
@@ -1,11 +1,17 @@
 """Tests for batched sync entity hydration."""
 
+from datetime import datetime, timezone
 from unittest.mock import Mock
 
 import pytest
 
+from gumnut.types.face_response import FaceResponse
+
 from routers.api.constants import GUMNUT_API_MAX_BULK_IDS
-from routers.api.sync.entity_fetch import fetch_entities_map
+from routers.api.sync.entity_fetch import (
+    fetch_entities_map,
+    fetch_suppressed_face_ids,
+)
 from tests.conftest import MockSyncCursorPage
 
 
@@ -39,3 +45,80 @@ async def test_asset_hydration_chunks_at_bulk_id_limit(
     assert [
         entity_id for call in calls for entity_id in call.kwargs["ids"]
     ] == entity_ids
+
+
+def _face(face_id: str, asset_id: str) -> FaceResponse:
+    return FaceResponse(
+        id=face_id,
+        asset_id=asset_id,
+        bounding_box={"x": 1, "y": 1, "w": 2, "h": 2},
+        source="automatic",
+        created_at=datetime(2025, 1, 15, tzinfo=timezone.utc),
+        updated_at=datetime(2025, 1, 15, tzinfo=timezone.utc),
+    )
+
+
+def _asset(asset_id: str, kind: str = "original") -> Mock:
+    asset = Mock()
+    asset.id = asset_id
+    asset.kind = kind
+    return asset
+
+
+@pytest.mark.anyio
+async def test_suppressed_face_ids_empty_input_skips_the_read():
+    client = Mock()
+
+    assert await fetch_suppressed_face_ids(client, []) == set()
+    client.assets.list.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_suppressed_face_ids_partitions_per_asset_and_fails_safe():
+    """One deduplicated bulk read; only edited-owned and unfetchable-owned
+    faces are suppressed."""
+    faces = [
+        _face("face_original", "asset_original"),
+        _face("face_original_2", "asset_original"),
+        _face("face_edited", "asset_edited"),
+        _face("face_missing", "asset_missing"),
+    ]
+    client = Mock()
+    client.assets.list = Mock(
+        return_value=MockSyncCursorPage(
+            [_asset("asset_original"), _asset("asset_edited", kind="edit")]
+        )
+    )
+
+    suppressed = await fetch_suppressed_face_ids(client, faces)
+
+    assert suppressed == {"face_edited", "face_missing"}
+    client.assets.list.assert_called_once()
+    kwargs = client.assets.list.call_args.kwargs
+    assert kwargs["ids"] == ["asset_original", "asset_edited", "asset_missing"]
+    assert kwargs["state"] == "all"
+    assert "include" not in kwargs
+
+
+@pytest.mark.anyio
+async def test_suppressed_face_ids_chunk_at_bulk_id_limit():
+    """Owning-asset resolution chunks like the sibling hydration read, and
+    assets returned by every chunk count as exposable."""
+    total = GUMNUT_API_MAX_BULK_IDS + 1
+    faces = [_face(f"face_{index}", f"asset_{index}") for index in range(total)]
+    client = Mock()
+    client.assets.list = Mock(
+        side_effect=lambda **kwargs: MockSyncCursorPage(
+            [_asset(asset_id) for asset_id in kwargs["ids"]]
+        )
+    )
+
+    suppressed = await fetch_suppressed_face_ids(client, faces)
+
+    assert suppressed == set()
+    calls = client.assets.list.call_args_list
+    assert [len(call.kwargs["ids"]) for call in calls] == [
+        GUMNUT_API_MAX_BULK_IDS,
+        1,
+    ]
+    assert [call.kwargs["limit"] for call in calls] == [GUMNUT_API_MAX_BULK_IDS, 1]

--- a/tests/unit/api/sync/test_sync_stream.py
+++ b/tests/unit/api/sync/test_sync_stream.py
@@ -25,6 +25,7 @@ from routers.immich_models import (
     SyncStreamDto,
 )
 from routers.utils.gumnut_id_conversion import (
+    safe_uuid_from_asset_id,
     uuid_to_gumnut_album_id,
     uuid_to_gumnut_asset_id,
     uuid_to_gumnut_face_id,
@@ -616,6 +617,64 @@ class TestGenerateSyncStream:
         assert kwargs["ids"] == [face1.asset_id]
         assert kwargs["state"] == "all"
         assert "include" not in kwargs
+
+    @pytest.mark.anyio
+    async def test_mixed_page_suppresses_only_edited_assets_faces(self):
+        """Suppression partitions per owning asset within one event page: the
+        edited asset's face is skipped while the original asset's face on the
+        same page still emits — the gate must key on set membership, never on
+        "the page contains an edited asset"."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        mock_user = create_mock_user(updated_at)
+        mock_client = create_mock_gumnut_client(mock_user)
+
+        original_asset = Mock()
+        original_asset.id = uuid_to_gumnut_asset_id(TEST_UUID)
+        original_asset.kind = "original"
+        edited_asset = Mock()
+        edited_asset.id = uuid_to_gumnut_asset_id(uuid4())
+        edited_asset.kind = "edit"
+
+        face_on_original = create_mock_face_data(updated_at)
+        face_on_edited = face_on_original.model_copy(
+            update={
+                "id": uuid_to_gumnut_face_id(uuid4()),
+                "asset_id": edited_asset.id,
+            }
+        )
+        events_in = [
+            create_mock_event(
+                entity_type="face",
+                entity_id=face.id,
+                event_type="face_created",
+                created_at=updated_at,
+                cursor=f"cursor_face_{i}",
+            )
+            for i, face in enumerate([face_on_original, face_on_edited])
+        ]
+        mock_client.events.get.return_value = create_mock_events_response(events_in)
+        mock_client.faces.list.return_value = create_mock_entity_page(
+            [face_on_original, face_on_edited]
+        )
+        mock_client.assets.list.return_value = create_mock_entity_page(
+            [original_asset, edited_asset]
+        )
+
+        request = SyncStreamDto(types=[SyncRequestType.AssetFacesV1])
+
+        events = await collect_stream(
+            generate_sync_stream(mock_client, request, {}, mock_user)
+        )
+
+        assert [e["type"] for e in events] == ["AssetFaceV1", "SyncCompleteV1"]
+        assert events[0]["data"]["assetId"] == str(
+            safe_uuid_from_asset_id(original_asset.id)
+        )
+        # One bulk read carrying both deduplicated owning-asset ids.
+        mock_client.assets.list.assert_called_once()
+        assert sorted(mock_client.assets.list.call_args.kwargs["ids"]) == sorted(
+            [original_asset.id, edited_asset.id]
+        )
 
     @pytest.mark.anyio
     async def test_unknown_non_original_kind_suppresses_face_rows(self):

--- a/tests/unit/api/sync/test_sync_stream.py
+++ b/tests/unit/api/sync/test_sync_stream.py
@@ -577,11 +577,6 @@ class TestGenerateSyncStream:
 
     @pytest.mark.anyio
     async def test_edited_asset_suppresses_face_rows_without_n_plus_one(self, caplog):
-        """While the owning asset's current rendering is edited, V1 face rows
-        are retracted (AssetFaceDeleteV1) instead of upserted, so a client
-        that synced the row before the edit doesn't keep stale geometry. The
-        gate resolves owning assets in ONE bulk read per event page, never
-        one retrieve per face, and reports gated rows in the summary log."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)
@@ -621,15 +616,11 @@ class TestGenerateSyncStream:
             str(safe_uuid_from_face_id(face1.id)),
             str(safe_uuid_from_face_id(face2.id)),
         }
-        # Both faces share one owning asset: exactly one lean bulk read, with
-        # the deduplicated id, all-state, and no include (kind is lean-core).
         mock_client.assets.list.assert_called_once()
         kwargs = mock_client.assets.list.call_args.kwargs
         assert kwargs["ids"] == [face1.asset_id]
         assert kwargs["state"] == "all"
         assert "include" not in kwargs
-        # The summary counter is the operator-visible evidence that rows were
-        # intentionally gated.
         summary = next(
             r for r in caplog.records if r.getMessage() == "Sync stream summary"
         )
@@ -637,10 +628,6 @@ class TestGenerateSyncStream:
 
     @pytest.mark.anyio
     async def test_mixed_page_suppresses_only_edited_assets_faces(self):
-        """Suppression partitions per owning asset within one event page: the
-        edited asset's face is retracted while the original asset's face on
-        the same page still upserts — the gate must key on set membership,
-        never on "the page contains an edited asset"."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)
@@ -694,7 +681,6 @@ class TestGenerateSyncStream:
         assert events[1]["data"]["assetFaceId"] == str(
             safe_uuid_from_face_id(face_on_edited.id)
         )
-        # One bulk read carrying both deduplicated owning-asset ids.
         mock_client.assets.list.assert_called_once()
         assert sorted(mock_client.assets.list.call_args.kwargs["ids"]) == sorted(
             [original_asset.id, edited_asset.id]
@@ -702,8 +688,6 @@ class TestGenerateSyncStream:
 
     @pytest.mark.anyio
     async def test_unknown_non_original_kind_suppresses_face_rows(self):
-        """The kind namespace is open: any non-original kind gates (retracts
-        the V1 row) exactly like an edit."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)
@@ -732,9 +716,6 @@ class TestGenerateSyncStream:
 
     @pytest.mark.anyio
     async def test_missing_owning_asset_suppresses_face_rows(self):
-        """Fail safe: a face whose owning asset the bulk read does not return
-        is gated (retracted on V1) — geometry only syncs once the original is
-        confirmed current."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)
@@ -749,8 +730,6 @@ class TestGenerateSyncStream:
         )
         mock_client.events.get.return_value = create_mock_events_response([mock_event])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
-        # Default assets.list mock returns an empty page — asset unfetchable.
-
         request = SyncStreamDto(types=[SyncRequestType.AssetFacesV1])
 
         events = await collect_stream(
@@ -761,8 +740,6 @@ class TestGenerateSyncStream:
 
     @pytest.mark.anyio
     async def test_face_v2_rows_suppressed_for_edited_assets(self):
-        """The V2 gate is a visibility transition: the row still syncs (so a
-        client holding a pre-edit copy reconciles) but with isVisible false."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)
@@ -792,12 +769,6 @@ class TestGenerateSyncStream:
 
     @pytest.mark.anyio
     async def test_face_v2_edit_then_restore_transitions_checkpointed(self):
-        """Both directions of the gate are observable, checkpointed state
-        transitions: a face event while the rendering is edited re-emits the
-        row hidden (isVisible false), and the next face event after the
-        original is restored re-emits it visible — each under its own acked
-        cursor, so a checkpointed client resumes past the transition instead
-        of replaying it."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)
@@ -805,7 +776,6 @@ class TestGenerateSyncStream:
         face_data = create_mock_face_data(updated_at)
         request = SyncStreamDto(types=[SyncRequestType.AssetFacesV2])
 
-        # Round 1: the owning asset's current rendering is edited.
         edit_event = create_mock_event(
             entity_type="face",
             entity_id=face_data.id,
@@ -827,8 +797,6 @@ class TestGenerateSyncStream:
         assert events[0]["data"]["isVisible"] is False
         assert events[0]["ack"] == "AssetFaceV2|cursor_edit|"
 
-        # Round 2: the client acked round 1's cursor; the original is restored
-        # and a later face event re-emits the visible row.
         restore_event = create_mock_event(
             entity_type="face",
             entity_id=face_data.id,
@@ -858,15 +826,11 @@ class TestGenerateSyncStream:
         assert [e["type"] for e in events] == ["AssetFaceV2", "SyncCompleteV1"]
         assert events[0]["data"]["isVisible"] is True
         assert events[0]["ack"] == "AssetFaceV2|cursor_restore|"
-        # The checkpointed cursor bounds round 2's event read.
         assert mock_client.events.get.call_args.kwargs["after_cursor"] == "cursor_edit"
 
     @pytest.mark.anyio
     async def test_v1_retraction_emits_inline_before_same_stream_restore_upsert(self):
-        """The V1 retraction must yield inline, not via the end-of-stream
-        delete buffer: when a later page of the SAME stream carries a restore
-        upsert for the same face id, a buffered retraction would flush after
-        it and leave the client with the face deleted post-restore."""
+        """Keep retractions inline so a later-page restore upsert wins."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)
@@ -891,7 +855,6 @@ class TestGenerateSyncStream:
             create_mock_events_response([page2_event]),
         ]
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
-        # Page 1 resolves the owning asset as edited; page 2 as restored.
         mock_client.assets.list.side_effect = [
             create_mock_face_owning_asset_page(kind="edit"),
             create_mock_face_owning_asset_page(kind="original"),
@@ -914,9 +877,6 @@ class TestGenerateSyncStream:
 
     @pytest.mark.anyio
     async def test_people_still_stream_for_edited_assets(self):
-        """The gate touches face rows only: person rows still sync while the
-        owning asset is edited (the V1 face row is retracted alongside), so
-        the person and its thumbnail survive edits server-side."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)
@@ -969,9 +929,6 @@ class TestGenerateSyncStream:
 
     @pytest.mark.anyio
     async def test_face_delete_events_still_emitted_for_edited_assets(self):
-        """Deletes bypass the geometry gate: a face_deleted event must reach
-        the client even while the owning asset is edited, or stored rows go
-        stale. Deletes carry no geometry, so nothing leaks."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)

--- a/tests/unit/api/sync/test_sync_stream.py
+++ b/tests/unit/api/sync/test_sync_stream.py
@@ -5,7 +5,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock, Mock, call
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -43,6 +43,7 @@ from tests.unit.api.sync.conftest import (
     create_mock_event,
     create_mock_events_response,
     create_mock_face_data,
+    create_mock_face_owning_asset_page,
     create_mock_metadata_data,
     create_mock_gumnut_client,
     create_mock_person_data,
@@ -558,6 +559,7 @@ class TestGenerateSyncStream:
         )
         mock_client.events.get.return_value = create_mock_events_response([mock_event])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
 
         request = SyncStreamDto(types=[SyncRequestType.AssetFacesV1])
         checkpoint_map: dict[SyncEntityType, Checkpoint] = {}
@@ -570,6 +572,220 @@ class TestGenerateSyncStream:
         assert events[0]["type"] == "AssetFaceV1"
         assert "boundingBoxX1" in events[0]["data"]
         assert events[1]["type"] == "SyncCompleteV1"
+
+    @pytest.mark.anyio
+    async def test_edited_asset_suppresses_face_rows_without_n_plus_one(self):
+        """No face rows sync while the owning asset's current rendering is
+        edited — the stored boxes are original-space and must not pair with
+        derived pixels. The gate resolves owning assets in ONE bulk read per
+        event page, never one retrieve per face."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        mock_user = create_mock_user(updated_at)
+        mock_client = create_mock_gumnut_client(mock_user)
+
+        face1 = create_mock_face_data(updated_at)
+        face2 = face1.model_copy(update={"id": uuid_to_gumnut_face_id(uuid4())})
+        events_in = [
+            create_mock_event(
+                entity_type="face",
+                entity_id=face.id,
+                event_type="face_created",
+                created_at=updated_at,
+                cursor=f"cursor_face_{i}",
+            )
+            for i, face in enumerate([face1, face2])
+        ]
+        mock_client.events.get.return_value = create_mock_events_response(events_in)
+        mock_client.faces.list.return_value = create_mock_entity_page([face1, face2])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page(
+            kind="edit"
+        )
+
+        request = SyncStreamDto(types=[SyncRequestType.AssetFacesV1])
+        checkpoint_map: dict[SyncEntityType, Checkpoint] = {}
+
+        events = await collect_stream(
+            generate_sync_stream(mock_client, request, checkpoint_map, mock_user)
+        )
+
+        assert [e["type"] for e in events] == ["SyncCompleteV1"]
+        # Both faces share one owning asset: exactly one lean bulk read, with
+        # the deduplicated id, all-state, and no include (kind is lean-core).
+        mock_client.assets.list.assert_called_once()
+        kwargs = mock_client.assets.list.call_args.kwargs
+        assert kwargs["ids"] == [face1.asset_id]
+        assert kwargs["state"] == "all"
+        assert "include" not in kwargs
+
+    @pytest.mark.anyio
+    async def test_unknown_non_original_kind_suppresses_face_rows(self):
+        """The kind namespace is open: any non-original kind gates exactly
+        like an edit."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        mock_user = create_mock_user(updated_at)
+        mock_client = create_mock_gumnut_client(mock_user)
+
+        face_data = create_mock_face_data(updated_at)
+        mock_event = create_mock_event(
+            entity_type="face",
+            entity_id=face_data.id,
+            event_type="face_created",
+            created_at=updated_at,
+            cursor="cursor_face_1",
+        )
+        mock_client.events.get.return_value = create_mock_events_response([mock_event])
+        mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page(
+            kind="restyle"
+        )
+
+        request = SyncStreamDto(types=[SyncRequestType.AssetFacesV1])
+
+        events = await collect_stream(
+            generate_sync_stream(mock_client, request, {}, mock_user)
+        )
+
+        assert [e["type"] for e in events] == ["SyncCompleteV1"]
+
+    @pytest.mark.anyio
+    async def test_missing_owning_asset_suppresses_face_rows(self):
+        """Fail safe: a face whose owning asset the bulk read does not return
+        is suppressed — geometry only syncs once the original is confirmed
+        current."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        mock_user = create_mock_user(updated_at)
+        mock_client = create_mock_gumnut_client(mock_user)
+
+        face_data = create_mock_face_data(updated_at)
+        mock_event = create_mock_event(
+            entity_type="face",
+            entity_id=face_data.id,
+            event_type="face_created",
+            created_at=updated_at,
+            cursor="cursor_face_1",
+        )
+        mock_client.events.get.return_value = create_mock_events_response([mock_event])
+        mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        # Default assets.list mock returns an empty page — asset unfetchable.
+
+        request = SyncStreamDto(types=[SyncRequestType.AssetFacesV1])
+
+        events = await collect_stream(
+            generate_sync_stream(mock_client, request, {}, mock_user)
+        )
+
+        assert [e["type"] for e in events] == ["SyncCompleteV1"]
+
+    @pytest.mark.anyio
+    async def test_face_v2_rows_suppressed_for_edited_assets(self):
+        """The gate covers AssetFaceV2 rows identically to V1."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        mock_user = create_mock_user(updated_at)
+        mock_client = create_mock_gumnut_client(mock_user)
+
+        face_data = create_mock_face_data(updated_at)
+        mock_event = create_mock_event(
+            entity_type="face",
+            entity_id=face_data.id,
+            event_type="face_created",
+            created_at=updated_at,
+            cursor="cursor_face_1",
+        )
+        mock_client.events.get.return_value = create_mock_events_response([mock_event])
+        mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page(
+            kind="edit"
+        )
+
+        request = SyncStreamDto(types=[SyncRequestType.AssetFacesV2])
+
+        events = await collect_stream(
+            generate_sync_stream(mock_client, request, {}, mock_user)
+        )
+
+        assert [e["type"] for e in events] == ["SyncCompleteV1"]
+
+    @pytest.mark.anyio
+    async def test_people_still_stream_for_edited_assets(self):
+        """Suppression hides geometry only: person rows still sync while the
+        owning asset is edited, so people associations survive edits."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        mock_user = create_mock_user(updated_at)
+        mock_client = create_mock_gumnut_client(mock_user)
+
+        face_data = create_mock_face_data(updated_at)
+        person_data = create_mock_person_data(updated_at)
+        face_event = create_mock_event(
+            entity_type="face",
+            entity_id=face_data.id,
+            event_type="face_created",
+            created_at=updated_at,
+            cursor="cursor_face_1",
+        )
+        person_event = create_mock_event(
+            entity_type="person",
+            entity_id=person_data.id,
+            event_type="person_created",
+            created_at=updated_at,
+            cursor="cursor_person_1",
+        )
+
+        def mock_events_get(**kwargs: Any) -> Any:
+            entity_types = kwargs.get("entity_types", "")
+            if entity_types == "person":
+                return create_mock_events_response([person_event])
+            if entity_types == "face":
+                return create_mock_events_response([face_event])
+            return create_mock_events_response([])
+
+        mock_client.events.get.side_effect = mock_events_get
+        mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.people.list.return_value = create_mock_entity_page([person_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page(
+            kind="edit"
+        )
+
+        request = SyncStreamDto(
+            types=[SyncRequestType.PeopleV1, SyncRequestType.AssetFacesV1]
+        )
+
+        events = await collect_stream(
+            generate_sync_stream(mock_client, request, {}, mock_user)
+        )
+
+        assert [e["type"] for e in events] == ["PersonV1", "SyncCompleteV1"]
+
+    @pytest.mark.anyio
+    async def test_face_delete_events_still_emitted_for_edited_assets(self):
+        """Deletes bypass the geometry gate: a face_deleted event must reach
+        the client even while the owning asset is edited, or stored rows go
+        stale. Deletes carry no geometry, so nothing leaks."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        mock_user = create_mock_user(updated_at)
+        mock_client = create_mock_gumnut_client(mock_user)
+
+        mock_event = create_mock_event(
+            entity_type="face",
+            entity_id=uuid_to_gumnut_face_id(TEST_UUID),
+            event_type="face_deleted",
+            created_at=updated_at,
+            cursor="cursor_face_1",
+        )
+        mock_client.events.get.return_value = create_mock_events_response([mock_event])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page(
+            kind="edit"
+        )
+
+        request = SyncStreamDto(types=[SyncRequestType.AssetFacesV1])
+
+        events = await collect_stream(
+            generate_sync_stream(mock_client, request, {}, mock_user)
+        )
+
+        assert [e["type"] for e in events] == [
+            "AssetFaceDeleteV1",
+            "SyncCompleteV1",
+        ]
 
     @pytest.mark.anyio
     async def test_streams_user_metadata_preferences_with_min_faces(self):

--- a/tests/unit/api/sync/test_sync_stream.py
+++ b/tests/unit/api/sync/test_sync_stream.py
@@ -26,6 +26,7 @@ from routers.immich_models import (
 )
 from routers.utils.gumnut_id_conversion import (
     safe_uuid_from_asset_id,
+    safe_uuid_from_face_id,
     uuid_to_gumnut_album_id,
     uuid_to_gumnut_asset_id,
     uuid_to_gumnut_face_id,
@@ -575,11 +576,12 @@ class TestGenerateSyncStream:
         assert events[1]["type"] == "SyncCompleteV1"
 
     @pytest.mark.anyio
-    async def test_edited_asset_suppresses_face_rows_without_n_plus_one(self):
-        """No face rows sync while the owning asset's current rendering is
-        edited — the stored boxes are original-space and must not pair with
-        derived pixels. The gate resolves owning assets in ONE bulk read per
-        event page, never one retrieve per face."""
+    async def test_edited_asset_suppresses_face_rows_without_n_plus_one(self, caplog):
+        """While the owning asset's current rendering is edited, V1 face rows
+        are retracted (AssetFaceDeleteV1) instead of upserted, so a client
+        that synced the row before the edit doesn't keep stale geometry. The
+        gate resolves owning assets in ONE bulk read per event page, never
+        one retrieve per face, and reports gated rows in the summary log."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)
@@ -605,11 +607,20 @@ class TestGenerateSyncStream:
         request = SyncStreamDto(types=[SyncRequestType.AssetFacesV1])
         checkpoint_map: dict[SyncEntityType, Checkpoint] = {}
 
-        events = await collect_stream(
-            generate_sync_stream(mock_client, request, checkpoint_map, mock_user)
-        )
+        with caplog.at_level(logging.INFO, logger="routers.api.sync.stream"):
+            events = await collect_stream(
+                generate_sync_stream(mock_client, request, checkpoint_map, mock_user)
+            )
 
-        assert [e["type"] for e in events] == ["SyncCompleteV1"]
+        assert [e["type"] for e in events] == [
+            "AssetFaceDeleteV1",
+            "AssetFaceDeleteV1",
+            "SyncCompleteV1",
+        ]
+        assert {e["data"]["assetFaceId"] for e in events[:2]} == {
+            str(safe_uuid_from_face_id(face1.id)),
+            str(safe_uuid_from_face_id(face2.id)),
+        }
         # Both faces share one owning asset: exactly one lean bulk read, with
         # the deduplicated id, all-state, and no include (kind is lean-core).
         mock_client.assets.list.assert_called_once()
@@ -617,13 +628,19 @@ class TestGenerateSyncStream:
         assert kwargs["ids"] == [face1.asset_id]
         assert kwargs["state"] == "all"
         assert "include" not in kwargs
+        # The summary counter is the operator-visible evidence that rows were
+        # intentionally gated.
+        summary = next(
+            r for r in caplog.records if r.getMessage() == "Sync stream summary"
+        )
+        assert summary.suppressed_face_geometry == 2
 
     @pytest.mark.anyio
     async def test_mixed_page_suppresses_only_edited_assets_faces(self):
         """Suppression partitions per owning asset within one event page: the
-        edited asset's face is skipped while the original asset's face on the
-        same page still emits — the gate must key on set membership, never on
-        "the page contains an edited asset"."""
+        edited asset's face is retracted while the original asset's face on
+        the same page still upserts — the gate must key on set membership,
+        never on "the page contains an edited asset"."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)
@@ -666,9 +683,16 @@ class TestGenerateSyncStream:
             generate_sync_stream(mock_client, request, {}, mock_user)
         )
 
-        assert [e["type"] for e in events] == ["AssetFaceV1", "SyncCompleteV1"]
+        assert [e["type"] for e in events] == [
+            "AssetFaceV1",
+            "AssetFaceDeleteV1",
+            "SyncCompleteV1",
+        ]
         assert events[0]["data"]["assetId"] == str(
             safe_uuid_from_asset_id(original_asset.id)
+        )
+        assert events[1]["data"]["assetFaceId"] == str(
+            safe_uuid_from_face_id(face_on_edited.id)
         )
         # One bulk read carrying both deduplicated owning-asset ids.
         mock_client.assets.list.assert_called_once()
@@ -678,8 +702,8 @@ class TestGenerateSyncStream:
 
     @pytest.mark.anyio
     async def test_unknown_non_original_kind_suppresses_face_rows(self):
-        """The kind namespace is open: any non-original kind gates exactly
-        like an edit."""
+        """The kind namespace is open: any non-original kind gates (retracts
+        the V1 row) exactly like an edit."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)
@@ -704,13 +728,13 @@ class TestGenerateSyncStream:
             generate_sync_stream(mock_client, request, {}, mock_user)
         )
 
-        assert [e["type"] for e in events] == ["SyncCompleteV1"]
+        assert [e["type"] for e in events] == ["AssetFaceDeleteV1", "SyncCompleteV1"]
 
     @pytest.mark.anyio
     async def test_missing_owning_asset_suppresses_face_rows(self):
         """Fail safe: a face whose owning asset the bulk read does not return
-        is suppressed — geometry only syncs once the original is confirmed
-        current."""
+        is gated (retracted on V1) — geometry only syncs once the original is
+        confirmed current."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)
@@ -733,11 +757,12 @@ class TestGenerateSyncStream:
             generate_sync_stream(mock_client, request, {}, mock_user)
         )
 
-        assert [e["type"] for e in events] == ["SyncCompleteV1"]
+        assert [e["type"] for e in events] == ["AssetFaceDeleteV1", "SyncCompleteV1"]
 
     @pytest.mark.anyio
     async def test_face_v2_rows_suppressed_for_edited_assets(self):
-        """The gate covers AssetFaceV2 rows identically to V1."""
+        """The V2 gate is a visibility transition: the row still syncs (so a
+        client holding a pre-edit copy reconciles) but with isVisible false."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)
@@ -762,12 +787,136 @@ class TestGenerateSyncStream:
             generate_sync_stream(mock_client, request, {}, mock_user)
         )
 
-        assert [e["type"] for e in events] == ["SyncCompleteV1"]
+        assert [e["type"] for e in events] == ["AssetFaceV2", "SyncCompleteV1"]
+        assert events[0]["data"]["isVisible"] is False
+
+    @pytest.mark.anyio
+    async def test_face_v2_edit_then_restore_transitions_checkpointed(self):
+        """Both directions of the gate are observable, checkpointed state
+        transitions: a face event while the rendering is edited re-emits the
+        row hidden (isVisible false), and the next face event after the
+        original is restored re-emits it visible — each under its own acked
+        cursor, so a checkpointed client resumes past the transition instead
+        of replaying it."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        mock_user = create_mock_user(updated_at)
+        mock_client = create_mock_gumnut_client(mock_user)
+
+        face_data = create_mock_face_data(updated_at)
+        request = SyncStreamDto(types=[SyncRequestType.AssetFacesV2])
+
+        # Round 1: the owning asset's current rendering is edited.
+        edit_event = create_mock_event(
+            entity_type="face",
+            entity_id=face_data.id,
+            event_type="face_updated",
+            created_at=updated_at,
+            cursor="cursor_edit",
+        )
+        mock_client.events.get.return_value = create_mock_events_response([edit_event])
+        mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page(
+            kind="edit"
+        )
+
+        events = await collect_stream(
+            generate_sync_stream(mock_client, request, {}, mock_user)
+        )
+
+        assert [e["type"] for e in events] == ["AssetFaceV2", "SyncCompleteV1"]
+        assert events[0]["data"]["isVisible"] is False
+        assert events[0]["ack"] == "AssetFaceV2|cursor_edit|"
+
+        # Round 2: the client acked round 1's cursor; the original is restored
+        # and a later face event re-emits the visible row.
+        restore_event = create_mock_event(
+            entity_type="face",
+            entity_id=face_data.id,
+            event_type="face_updated",
+            created_at=updated_at,
+            cursor="cursor_restore",
+        )
+        mock_client.events.get.return_value = create_mock_events_response(
+            [restore_event]
+        )
+        mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page(
+            kind="original"
+        )
+        checkpoint_map = {
+            SyncEntityType.AssetFaceV2: Checkpoint(
+                entity_type=SyncEntityType.AssetFaceV2,
+                updated_at=updated_at,
+                cursor="cursor_edit",
+            )
+        }
+
+        events = await collect_stream(
+            generate_sync_stream(mock_client, request, checkpoint_map, mock_user)
+        )
+
+        assert [e["type"] for e in events] == ["AssetFaceV2", "SyncCompleteV1"]
+        assert events[0]["data"]["isVisible"] is True
+        assert events[0]["ack"] == "AssetFaceV2|cursor_restore|"
+        # The checkpointed cursor bounds round 2's event read.
+        assert mock_client.events.get.call_args.kwargs["after_cursor"] == "cursor_edit"
+
+    @pytest.mark.anyio
+    async def test_v1_retraction_emits_inline_before_same_stream_restore_upsert(self):
+        """The V1 retraction must yield inline, not via the end-of-stream
+        delete buffer: when a later page of the SAME stream carries a restore
+        upsert for the same face id, a buffered retraction would flush after
+        it and leave the client with the face deleted post-restore."""
+        updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        mock_user = create_mock_user(updated_at)
+        mock_client = create_mock_gumnut_client(mock_user)
+
+        face_data = create_mock_face_data(updated_at)
+        page1_event = create_mock_event(
+            entity_type="face",
+            entity_id=face_data.id,
+            event_type="face_updated",
+            created_at=updated_at,
+            cursor="cursor_edit",
+        )
+        page2_event = create_mock_event(
+            entity_type="face",
+            entity_id=face_data.id,
+            event_type="face_updated",
+            created_at=updated_at,
+            cursor="cursor_restore",
+        )
+        mock_client.events.get.side_effect = [
+            create_mock_events_response([page1_event], has_more=True),
+            create_mock_events_response([page2_event]),
+        ]
+        mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        # Page 1 resolves the owning asset as edited; page 2 as restored.
+        mock_client.assets.list.side_effect = [
+            create_mock_face_owning_asset_page(kind="edit"),
+            create_mock_face_owning_asset_page(kind="original"),
+        ]
+
+        request = SyncStreamDto(types=[SyncRequestType.AssetFacesV1])
+
+        events = await collect_stream(
+            generate_sync_stream(mock_client, request, {}, mock_user)
+        )
+
+        assert [e["type"] for e in events] == [
+            "AssetFaceDeleteV1",
+            "AssetFaceV1",
+            "SyncCompleteV1",
+        ]
+        assert events[0]["data"]["assetFaceId"] == str(
+            safe_uuid_from_face_id(face_data.id)
+        )
 
     @pytest.mark.anyio
     async def test_people_still_stream_for_edited_assets(self):
-        """Suppression hides geometry only: person rows still sync while the
-        owning asset is edited, so people associations survive edits."""
+        """The gate touches face rows only: person rows still sync while the
+        owning asset is edited (the V1 face row is retracted alongside), so
+        the person and its thumbnail survive edits server-side."""
         updated_at = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         mock_user = create_mock_user(updated_at)
         mock_client = create_mock_gumnut_client(mock_user)
@@ -812,7 +961,11 @@ class TestGenerateSyncStream:
             generate_sync_stream(mock_client, request, {}, mock_user)
         )
 
-        assert [e["type"] for e in events] == ["PersonV1", "SyncCompleteV1"]
+        assert [e["type"] for e in events] == [
+            "PersonV1",
+            "AssetFaceDeleteV1",
+            "SyncCompleteV1",
+        ]
 
     @pytest.mark.anyio
     async def test_face_delete_events_still_emitted_for_edited_assets(self):

--- a/tests/unit/api/sync/test_sync_stream_ordering.py
+++ b/tests/unit/api/sync/test_sync_stream_ordering.py
@@ -28,6 +28,7 @@ from tests.unit.api.sync.conftest import (
     create_mock_event,
     create_mock_events_response,
     create_mock_face_data,
+    create_mock_face_owning_asset_page,
     create_mock_gumnut_client,
     create_mock_person_data,
     create_mock_user,
@@ -104,6 +105,7 @@ class TestUpsertsBeforeDeletes:
         mock_client.events.get.side_effect = mock_events_get
         mock_client.people.list.return_value = create_mock_entity_page([person_data])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
 
         request = SyncStreamDto(
             types=[SyncRequestType.PeopleV1, SyncRequestType.AssetFacesV1]
@@ -512,6 +514,7 @@ class TestFaceV1V2DedupGuard:
 
         mock_client.events.get.return_value = create_mock_events_response([face_event])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
 
         request = SyncStreamDto(
             types=[SyncRequestType.AssetFacesV1, SyncRequestType.AssetFacesV2]
@@ -544,6 +547,7 @@ class TestFaceV1V2DedupGuard:
 
         mock_client.events.get.return_value = create_mock_events_response([face_event])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
 
         request = SyncStreamDto(types=[SyncRequestType.AssetFacesV1])
         events = await collect_stream(
@@ -572,6 +576,7 @@ class TestFaceV1V2DedupGuard:
 
         mock_client.events.get.return_value = create_mock_events_response([face_event])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
 
         request = SyncStreamDto(types=[SyncRequestType.AssetFacesV2])
         events = await collect_stream(

--- a/tests/unit/api/sync/test_sync_stream_payload.py
+++ b/tests/unit/api/sync/test_sync_stream_payload.py
@@ -30,6 +30,7 @@ from tests.unit.api.sync.conftest import (
     create_mock_event,
     create_mock_events_response,
     create_mock_face_data,
+    create_mock_face_owning_asset_page,
     create_mock_gumnut_client,
     create_mock_person_data,
     create_mock_user,
@@ -85,6 +86,7 @@ class TestFacePersonIdOverride:
 
         mock_client.events.get.return_value = create_mock_events_response([face_event])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
 
         sync_started_at = datetime(2025, 1, 20, 10, 0, 0, tzinfo=timezone.utc)
 
@@ -161,6 +163,7 @@ class TestFacePersonIdOverride:
 
         mock_client.events.get.side_effect = mock_events_get
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
 
         request = SyncStreamDto(
             types=[SyncRequestType.PeopleV1, SyncRequestType.AssetFacesV1]
@@ -230,6 +233,7 @@ class TestFacePersonIdOverride:
         mock_client.events.get.side_effect = mock_events_get
         mock_client.people.list.return_value = create_mock_entity_page([person_data])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
 
         request = SyncStreamDto(
             types=[SyncRequestType.PeopleV1, SyncRequestType.AssetFacesV1]
@@ -293,6 +297,7 @@ class TestFacePersonIdOverride:
 
         mock_client.events.get.return_value = create_mock_events_response([face_event])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
         mock_client.people.list.return_value = create_mock_entity_page(
             [payload_person_data]
         )
@@ -355,6 +360,7 @@ class TestFacePersonIdOverride:
 
         mock_client.events.get.return_value = create_mock_events_response([face_event])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
 
         sync_started_at = datetime(2025, 1, 20, 10, 0, 0, tzinfo=timezone.utc)
 
@@ -405,6 +411,7 @@ class TestFacePersonIdOverride:
 
         mock_client.events.get.return_value = create_mock_events_response([face_event])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
 
         sync_started_at = datetime(2025, 1, 20, 10, 0, 0, tzinfo=timezone.utc)
 
@@ -454,6 +461,7 @@ class TestFacePersonIdOverride:
 
         mock_client.events.get.return_value = create_mock_events_response([face_event])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
 
         sync_started_at = datetime(2025, 1, 20, 10, 0, 0, tzinfo=timezone.utc)
 
@@ -712,6 +720,7 @@ class TestFacePayloadOverrideDeletedPerson:
         # Person fetch returns empty -- person was deleted
         mock_client.people.list.return_value = create_mock_entity_page([])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
 
         request = SyncStreamDto(
             types=[SyncRequestType.PeopleV1, SyncRequestType.AssetFacesV1]
@@ -772,6 +781,7 @@ class TestFacePayloadOverrideDeletedPerson:
 
         mock_client.events.get.return_value = create_mock_events_response([face_event])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
         mock_client.people.list.return_value = create_mock_entity_page(
             [payload_person_data]
         )
@@ -924,6 +934,7 @@ class TestFacePayloadOverrideDeletedPerson:
         # Person P1 is deleted (404), P2 exists
         mock_client.people.list.return_value = create_mock_entity_page([p2_data])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
 
         request = SyncStreamDto(
             types=[SyncRequestType.PeopleV1, SyncRequestType.AssetFacesV1]
@@ -1041,6 +1052,7 @@ class TestFacePayloadOverrideDeletedPerson:
         mock_client.faces.list.return_value = create_mock_entity_page(
             [face1_data, face2_data]
         )
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
 
         request = SyncStreamDto(
             types=[SyncRequestType.PeopleV1, SyncRequestType.AssetFacesV1]
@@ -1108,6 +1120,7 @@ class TestFacePayloadOverrideDeletedPerson:
 
         mock_client.events.get.return_value = create_mock_events_response([face_event])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
         # Verification fetch returns empty — person is deleted in prod
         mock_client.people.list.return_value = create_mock_entity_page([])
 
@@ -1330,6 +1343,7 @@ class TestAssetFaceV2Converter:
 
         mock_client.events.get.return_value = create_mock_events_response([face_event])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
 
         sync_started_at = datetime(2025, 1, 20, 10, 0, 0, tzinfo=timezone.utc)
 
@@ -1384,6 +1398,7 @@ class TestAssetFaceV2Converter:
 
         mock_client.events.get.return_value = create_mock_events_response([face_event])
         mock_client.faces.list.return_value = create_mock_entity_page([face_data])
+        mock_client.assets.list.return_value = create_mock_face_owning_asset_page()
         mock_client.people.list.return_value = create_mock_entity_page(
             [payload_person_data]
         )

--- a/tests/unit/api/test_faces.py
+++ b/tests/unit/api/test_faces.py
@@ -54,9 +54,8 @@ def _make_asset(
 ) -> Mock:
     """Create a mock Gumnut AssetResponse with dimensions.
 
-    ``width``/``height`` are ``Optional[int]`` in the SDK; pass ``None`` to model
-    an asset whose dimensions have not been extracted yet. ``kind`` must be set
-    explicitly — an auto-created Mock attribute would read as edited.
+    ``width``/``height`` may be ``None`` before extraction. Set ``kind``
+    explicitly because an auto-created Mock attribute would read as edited.
     """
     asset = Mock()
     asset.id = asset_id
@@ -265,8 +264,6 @@ class TestGetFaces:
 
     @pytest.mark.anyio
     async def test_edited_asset_returns_empty_without_face_or_person_calls(self):
-        """An edited-current asset returns no geometry, and the suppression path
-        spends no face or person calls."""
         asset_uuid = uuid4()
         gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
 
@@ -283,8 +280,6 @@ class TestGetFaces:
 
     @pytest.mark.anyio
     async def test_unknown_non_original_kind_suppresses_like_edit(self):
-        """The kind namespace is open: any non-original current kind suppresses
-        geometry exactly like an edit — never branch on ``kind == "edit"``."""
         asset_uuid = uuid4()
         gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
 
@@ -476,9 +471,6 @@ class TestCreateFace:
 
     @pytest.mark.anyio
     async def test_edited_asset_rejected_with_409_before_coordinate_math(self):
-        """Drawing a face while an edited rendering is current is rejected with
-        a 409 before any scaling, and the doomed upstream create is never
-        sent."""
         asset_uuid = uuid4()
         person_uuid = uuid4()
         gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
@@ -499,7 +491,6 @@ class TestCreateFace:
 
     @pytest.mark.anyio
     async def test_unknown_non_original_kind_rejected_like_edit(self):
-        """Any non-original current kind rejects creation, not just ``edit``."""
         asset_uuid = uuid4()
         person_uuid = uuid4()
         gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)

--- a/tests/unit/api/test_faces.py
+++ b/tests/unit/api/test_faces.py
@@ -1,6 +1,7 @@
 """Tests for faces.py endpoints."""
 
 import pytest
+from fastapi import HTTPException
 from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 from datetime import datetime, timezone
@@ -265,8 +266,7 @@ class TestGetFaces:
     @pytest.mark.anyio
     async def test_edited_asset_returns_empty_without_face_or_person_calls(self):
         """An edited-current asset returns no geometry, and the suppression path
-        spends no face or person calls — stored boxes live in the original's
-        pixel space and must not pair with derived pixels."""
+        spends no face or person calls."""
         asset_uuid = uuid4()
         gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
 
@@ -477,11 +477,8 @@ class TestCreateFace:
     @pytest.mark.anyio
     async def test_edited_asset_rejected_with_409_before_coordinate_math(self):
         """Drawing a face while an edited rendering is current is rejected with
-        a 409 before any scaling, and the doomed upstream create is never sent
-        — the box would be captured in the derived image's pixel space while
-        Gumnut stores boxes in the original's."""
-        from fastapi import HTTPException
-
+        a 409 before any scaling, and the doomed upstream create is never
+        sent."""
         asset_uuid = uuid4()
         person_uuid = uuid4()
         gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
@@ -503,8 +500,6 @@ class TestCreateFace:
     @pytest.mark.anyio
     async def test_unknown_non_original_kind_rejected_like_edit(self):
         """Any non-original current kind rejects creation, not just ``edit``."""
-        from fastapi import HTTPException
-
         asset_uuid = uuid4()
         person_uuid = uuid4()
         gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)

--- a/tests/unit/api/test_faces.py
+++ b/tests/unit/api/test_faces.py
@@ -46,17 +46,22 @@ def _make_face(
 
 
 def _make_asset(
-    asset_id: str, width: int | None = 1920, height: int | None = 1080
+    asset_id: str,
+    width: int | None = 1920,
+    height: int | None = 1080,
+    kind: str = "original",
 ) -> Mock:
     """Create a mock Gumnut AssetResponse with dimensions.
 
     ``width``/``height`` are ``Optional[int]`` in the SDK; pass ``None`` to model
-    an asset whose dimensions have not been extracted yet.
+    an asset whose dimensions have not been extracted yet. ``kind`` must be set
+    explicitly — an auto-created Mock attribute would read as edited.
     """
     asset = Mock()
     asset.id = asset_id
     asset.width = width
     asset.height = height
+    asset.kind = kind
     return asset
 
 
@@ -249,10 +254,49 @@ class TestGetFaces:
 
         asset_uuid = uuid4()
         mock_client = Mock()
+        mock_client.assets.retrieve = AsyncMock(
+            return_value=_make_asset(uuid_to_gumnut_asset_id(asset_uuid))
+        )
         mock_client.faces.list = Mock(side_effect=make_sdk_status_error(500, "boom"))
 
         with pytest.raises(APIStatusError):
             await get_faces(id=asset_uuid, client=mock_client)
+
+    @pytest.mark.anyio
+    async def test_edited_asset_returns_empty_without_face_or_person_calls(self):
+        """An edited-current asset returns no geometry, and the suppression path
+        spends no face or person calls — stored boxes live in the original's
+        pixel space and must not pair with derived pixels."""
+        asset_uuid = uuid4()
+        gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
+
+        mock_client = Mock()
+        mock_client.assets.retrieve = AsyncMock(
+            return_value=_make_asset(gumnut_asset_id, kind="edit")
+        )
+
+        result = await get_faces(id=asset_uuid, client=mock_client)
+
+        assert result == []
+        mock_client.faces.list.assert_not_called()
+        mock_client.people.retrieve.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_unknown_non_original_kind_suppresses_like_edit(self):
+        """The kind namespace is open: any non-original current kind suppresses
+        geometry exactly like an edit — never branch on ``kind == "edit"``."""
+        asset_uuid = uuid4()
+        gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
+
+        mock_client = Mock()
+        mock_client.assets.retrieve = AsyncMock(
+            return_value=_make_asset(gumnut_asset_id, kind="restyle")
+        )
+
+        result = await get_faces(id=asset_uuid, client=mock_client)
+
+        assert result == []
+        mock_client.faces.list.assert_not_called()
 
 
 class TestDeleteFace:
@@ -429,6 +473,53 @@ class TestCreateFace:
         assert result.person is not None
         assert result.person.name == "Calvin"
         assert result.person.id == safe_uuid_from_person_id(gumnut_person_id)
+
+    @pytest.mark.anyio
+    async def test_edited_asset_rejected_with_409_before_coordinate_math(self):
+        """Drawing a face while an edited rendering is current is rejected with
+        a 409 before any scaling, and the doomed upstream create is never sent
+        — the box would be captured in the derived image's pixel space while
+        Gumnut stores boxes in the original's."""
+        from fastapi import HTTPException
+
+        asset_uuid = uuid4()
+        person_uuid = uuid4()
+        gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
+
+        mock_client = Mock()
+        mock_client.assets.retrieve = AsyncMock(
+            return_value=_make_asset(gumnut_asset_id, kind="edit")
+        )
+
+        request = self._make_request(asset_uuid, person_uuid)
+        with pytest.raises(HTTPException) as exc_info:
+            await create_face(request=request, client=mock_client)
+
+        assert exc_info.value.status_code == 409
+        assert "original" in exc_info.value.detail
+        mock_client.faces.create.assert_not_called()
+        mock_client.people.retrieve.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_unknown_non_original_kind_rejected_like_edit(self):
+        """Any non-original current kind rejects creation, not just ``edit``."""
+        from fastapi import HTTPException
+
+        asset_uuid = uuid4()
+        person_uuid = uuid4()
+        gumnut_asset_id = uuid_to_gumnut_asset_id(asset_uuid)
+
+        mock_client = Mock()
+        mock_client.assets.retrieve = AsyncMock(
+            return_value=_make_asset(gumnut_asset_id, kind="restyle")
+        )
+
+        request = self._make_request(asset_uuid, person_uuid)
+        with pytest.raises(HTTPException) as exc_info:
+            await create_face(request=request, client=mock_client)
+
+        assert exc_info.value.status_code == 409
+        mock_client.faces.create.assert_not_called()
 
     @pytest.mark.anyio
     async def test_box_passes_through_when_preview_matches_asset(self):

--- a/tests/unit/utils/test_asset_conversion.py
+++ b/tests/unit/utils/test_asset_conversion.py
@@ -1001,9 +1001,6 @@ class TestIsEditedMapping:
 
 
 class TestShouldExposeFaceGeometry:
-    """Pin the single-home face-geometry predicate directly, so a call site
-    quietly re-deriving from ``kind`` locally still leaves the rule tested."""
-
     def test_original_current_exposes_geometry(self):
         assert should_expose_face_geometry(make_gumnut_asset(kind="original"))
 

--- a/tests/unit/utils/test_asset_conversion.py
+++ b/tests/unit/utils/test_asset_conversion.py
@@ -45,6 +45,7 @@ from routers.utils.asset_conversion import (
     resolve_asset_location,
     resolve_file_modified_at,
     resolve_immich_checksum,
+    should_expose_face_geometry,
 )
 from routers.utils.datetime_utils import to_actual_utc
 from tests.conftest import make_gumnut_asset, make_gumnut_stack
@@ -997,3 +998,19 @@ class TestIsEditedMapping:
 
     def test_unknown_non_original_kind_maps_edited(self):
         assert self._is_edited_everywhere("external:future-service") == {True}
+
+
+class TestShouldExposeFaceGeometry:
+    """Pin the single-home face-geometry predicate directly, so a call site
+    quietly re-deriving from ``kind`` locally still leaves the rule tested."""
+
+    def test_original_current_exposes_geometry(self):
+        assert should_expose_face_geometry(make_gumnut_asset(kind="original"))
+
+    def test_edit_current_suppresses_geometry(self):
+        assert not should_expose_face_geometry(make_gumnut_asset(kind="edit"))
+
+    def test_unknown_non_original_kind_suppresses_geometry(self):
+        assert not should_expose_face_geometry(
+            make_gumnut_asset(kind="external:future-service")
+        )


### PR DESCRIPTION
## What

- Add `should_expose_face_geometry` (any non-original `kind` gates, fail-safe) as the single home for the face-geometry rule, and gate every emit/write site on it: `GET /api/faces` returns `[]` for edited assets before spending face/person calls, `POST /api/faces` rejects with 409 before coordinate math, and the face sync pass gates `SyncAssetFaceV1/V2` rows.
- Sync gating is a **state transition, never an omission**: a gated face event re-emits the row with `isVisible=false` on `AssetFaceV2` and retracts it inline via `AssetFaceDeleteV1` on `AssetFaceV1` (inline rather than buffered, so a same-stream restore upsert cannot be reordered behind the retraction), and the next face event after the original is restored re-emits the visible row — each under its own acked cursor, so checkpointed clients resume past the transition. A `suppressed_face_geometry` counter surfaces gated rows in the sync summary log.
- Owning assets are resolved via `fetch_suppressed_face_ids`: one bulk `assets.list` per face event page (deduplicated ids, chunked at the bulk-id limit, `state="all"`, no `include` requested — the gate reads only lean-core `kind`), never one retrieve per face. A face whose owning asset can't be fetched is gated fail-safe with a warning.
- Document the rule canonically in `docs/references/asset-and-media-handling.md` (code docstrings point there), and record the general gating-is-a-state-transition principle in `docs/architecture/sync-stream-architecture.md`.

## Why

Gumnut stores face bounding boxes in the original upload's pixel space and keeps them there across edits. While an edited rendering is current, emitting those boxes would draw them in the wrong frame over derived pixels. A client may also already hold a face row synced before the edit, so the sync gate must actively transition that row to a hidden/retracted state rather than silently skipping events — otherwise the stale original-space geometry stays cached against the edited rendering. Suppression hides geometry only: stored faces, people associations, person thumbnails, `AssetResponseDto.people`, and face delete events are untouched, and reverting to the original restores the same geometry with no reconstruction. The backend enforces the same invariant on writes; the adapter guard gives Immich clients a stable 409 instead of a doomed upstream call.

Accepted interim-contract limitations: an edit or restore with **no subsequent face event** reaches checkpointed clients only on the next face event or full resync — closing that gap needs upstream face events emitted on rendering changes. `GET /api/faces` for a nonexistent asset now surfaces the upstream 404 rather than `[]` because the owning asset is resolved first by design.

## Test plan

- `uv run pytest` — 1945 passed; `uv run ruff check`, `uv run pyright`, and `uv run scripts/lint_docs.py` clean.
- New coverage: edited/unknown-kind gating on both REST routes (409 before any coordinate math, no `faces.create` call, no wasted face/person calls); V1 retraction and V2 hidden re-emission for edited assets, including the mixed-page partition (edited asset's face retracted while the original asset's face on the same page upserts); a checkpointed edit→restore transition test (hidden then visible, each under its own acked cursor); an ordering guard proving the V1 retraction emits inline before a same-stream restore upsert; the `suppressed_face_geometry` summary counter asserted via caplog; direct `fetch_suppressed_face_ids` tests for empty input, per-asset partitioning + fail-safe, and chunking at the bulk-id boundary; people/person sync and face delete events unaffected for edited assets; direct `should_expose_face_geometry` unit tests pinning the open kind namespace.

Generated by an AI coding agent.